### PR TITLE
Boyankostov/bignumber reveal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "ethers": "^6.15.0",
         "express": "^5.2.1",
         "marked": "^17.0.0",
+        "motion-plus-vue": "^1.5.1",
         "pinia": "^3.0.4",
         "qrcode": "^1.5.4",
         "sirv": "^3.0.2",
@@ -7218,12 +7219,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.26.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.26.2.tgz",
-      "integrity": "sha512-lflOQEdjquUi9sCg5Y1LrsZDlsjrHw7m0T9Yedvnk7Bnhqfkc89/Uha10J3CFhkL+TCZVCRw9eUGyM/lyYhXQA==",
+      "version": "12.27.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.27.1.tgz",
+      "integrity": "sha512-cEAqO69kcZt3gL0TGua8WTgRQfv4J57nqt1zxHtLKwYhAwA0x9kDS/JbMa1hJbwkGY74AGJKvZ9pX/IqWZtZWQ==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.26.2",
+        "motion-dom": "^12.27.1",
         "motion-utils": "^12.24.10",
         "tslib": "^2.4.0"
       },
@@ -8604,13 +8605,63 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
     },
+    "node_modules/motion": {
+      "version": "12.27.1",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.27.1.tgz",
+      "integrity": "sha512-FAZTPDm1LccBdWSL46WLnEdTSHmdVx+fdWK8f61qBQn67MmFefXLXlrwy94rK2DDsd9A50Gj8H+LYCgQ/cQlFg==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.27.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/motion-dom": {
-      "version": "12.26.2",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.26.2.tgz",
-      "integrity": "sha512-KLMT1BroY8oKNeliA3JMNJ+nbCIsTKg6hJpDb4jtRAJ7nCKnnpg/LTq/NGqG90Limitz3kdAnAVXecdFVGlWTw==",
+      "version": "12.27.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.27.1.tgz",
+      "integrity": "sha512-V/53DA2nBqKl9O2PMJleSUb/G0dsMMeZplZwgIQf5+X0bxIu7Q1cTv6DrjvTTGYRm3+7Y5wMlRZ1wT61boU/bQ==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.24.10"
+      }
+    },
+    "node_modules/motion-plus-dom": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/motion-plus-dom/-/motion-plus-dom-2.3.0.tgz",
+      "integrity": "sha512-Ph43zyV2nKeGqRpdY2AQYachusA10/NPggpoJQhajOH9Ab33UbkrTGGDaT7o8Vld78+3L/9brmQfJGe6goZLSg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion": "^12.25.0",
+        "motion-dom": "^12.24.11",
+        "motion-utils": "^12.24.10"
+      }
+    },
+    "node_modules/motion-plus-vue": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/motion-plus-vue/-/motion-plus-vue-1.5.1.tgz",
+      "integrity": "sha512-aRJT2+btwOBY6cE1BZya2bFBSB4pnA39RcZ9vsDhxcEsr5pxKU5oLM18NL8VgFNbltee2gKZT7PSWKno2qTDag==",
+      "license": "ISC",
+      "dependencies": {
+        "motion-plus-dom": "^2.0.2"
+      },
+      "peerDependencies": {
+        "motion-v": "^1.7.4",
+        "vue": ">=3.0.0"
       }
     },
     "node_modules/motion-utils": {
@@ -8624,6 +8675,7 @@
       "resolved": "https://registry.npmjs.org/motion-v/-/motion-v-1.9.0.tgz",
       "integrity": "sha512-B5VeO69gO416yIqCyNL9EAD7v6n/h/9ktv7gGSRKzTCQhAhnC/N1VWLOTYvOiH90f/tZivbgN/V0MzSU5nsJLA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "framer-motion": "^12.25.0",
         "hey-listen": "^1.0.8",
@@ -8633,6 +8685,12 @@
         "@vueuse/core": ">=10.0.0",
         "vue": ">=3.0.0"
       }
+    },
+    "node_modules/motion/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ethers": "^6.15.0",
     "express": "^5.2.1",
     "marked": "^17.0.0",
+    "motion-plus-vue": "^1.5.1",
     "pinia": "^3.0.4",
     "qrcode": "^1.5.4",
     "sirv": "^3.0.2",

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -4,6 +4,7 @@
 html,
 body {
   @apply h-full w-full bg-neutral-bg-1;
+  -webkit-font-smoothing: antialiased;
 }
 
 ::-webkit-scrollbar {

--- a/src/common/components/BigNumber.vue
+++ b/src/common/components/BigNumber.vue
@@ -16,6 +16,7 @@
       /></Tooltip>
     </div>
     <div class="flex items-center gap-2">
+      
       <template v-if="!loading">
         <Tooltip
           v-if="amount?.tooltip"
@@ -23,8 +24,8 @@
         >
           <CurrencyComponent
             v-if="amount"
-            :font-size="32"
-            :font-size-small="32"
+            :font-size="40"
+            :font-size-small="40"
             v-bind="amount"
             class="flex break-keep font-semibold text-typography-default"
           />
@@ -32,8 +33,8 @@
         <template v-else>
           <CurrencyComponent
             v-if="amount"
-            :font-size="32"
-            :font-size-small="32"
+            :font-size="40"
+            :font-size-small="40"
             v-bind="amount"
             class="flex break-keep font-semibold text-typography-default"
           />
@@ -52,6 +53,7 @@
         :style="[{ width: loadingWidth ?? '100%', height: `${amount?.fontSize || 32 * 1.2}px` }]"
       ></div>
     </div>
+
     <template v-if="pnlStatus">
       <template v-if="!loading">
         <div

--- a/src/common/components/CurrencyComponent.vue
+++ b/src/common/components/CurrencyComponent.vue
@@ -30,7 +30,6 @@ export interface CurrencyComponentProps {
   decimals?: number;
   maxDecimals?: number;
   fontSize?: number;
-  fontSizeSmall?: number;
   hasSpace?: boolean;
   isDenomInfront?: boolean;
   defaultZeroValue?: string;
@@ -49,20 +48,12 @@ const props = withDefaults(defineProps<CurrencyComponentProps>(), {
   maxDecimals: 2,
   decimals: 2,
   fontSize: 16,
-  SmallFontSize: 16,
   hasSpace: false,
   isDenomInfront: true,
   prettyZeros: false
 });
 
 const isMounted = ref(false);
-
-const smallFontSize = computed(() => {
-  if (props.fontSizeSmall) {
-    return props.fontSizeSmall;
-  }
-  return props.fontSize - 2;
-});
 
 const amount = computed(() => {
   switch (props.type) {

--- a/src/common/components/CurrencyComponent.vue
+++ b/src/common/components/CurrencyComponent.vue
@@ -1,32 +1,26 @@
 <template>
   <div>
     <template v-if="type == CURRENCY_VIEW_TYPES.CURRENCY">
-      <span :class="[`text-${fontSize}`, $attrs.class]">
+      <span :class="[`text-${fontSize}`, $attrs.class]" class="items-center">
         {{ amount.symbol
         }}<template v-if="isDenomInfront">{{ amount.denom }}<template v-if="hasSpace">&nbsp;</template></template
-        ><template v-if="around">~</template>{{ amount.beforeDecimal }}
-      </span>
-      <span :class="[`text-${smallFontSize}`, $attrs.class]"
-        >{{ amount.afterDecimal
-        }}<template v-if="!isDenomInfront"><template v-if="hasSpace">&nbsp;</template>{{ amount.denom }}</template>
+        ><template v-if="around">~</template><template v-if="!hide"><AnimateNumber :value="isMounted ? Number((amount.beforeDecimal+amount.afterDecimal).replace(/,/g, '')) : 0"/></template><template v-else>{{ amount.beforeDecimal+amount.afterDecimal }}</template><template v-if="!isDenomInfront"><template v-if="hasSpace">&nbsp;</template>{{ amount.denom }}</template>
       </span>
     </template>
     <template v-if="type == CURRENCY_VIEW_TYPES.TOKEN">
-      <span :class="[`text-${fontSize}`, $attrs.class]"
-        ><template v-if="around">~</template>{{ amount.beforeDecimal }}</span
-      >
-      <span :class="[`text-${smallFontSize}`, $attrs.class]"
-        >{{ amount.afterDecimal }}<template v-if="hasSpace">&nbsp;</template>{{ amount.denom }}</span
+      <span :class="[`text-${fontSize}`, $attrs.class]" class="items-center"><template v-if="around">~</template><template v-if="!hide"><AnimateNumber :value="isMounted ? Number((amount.beforeDecimal+amount.afterDecimal).replace(/,/g, '')) : 0" :format="{ minimumFractionDigits: maxDecimals, maximumFractionDigits: maxDecimals }" /></template><template v-else>{{ amount.beforeDecimal+amount.afterDecimal }}</template><template v-if="hasSpace">&nbsp;</template>{{ amount.denom }}</span
       >
     </template>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { computed } from "vue";
+import { computed, ref, onMounted } from "vue";
 import { CurrencyUtils } from "@nolus/nolusjs";
 import { NATIVE_CURRENCY } from "@/config/global";
 import { CURRENCY_VIEW_TYPES } from "@/common/types";
+import { AnimateNumber } from "motion-plus-vue";
+
 
 export interface CurrencyComponentProps {
   type: string;
@@ -60,6 +54,8 @@ const props = withDefaults(defineProps<CurrencyComponentProps>(), {
   isDenomInfront: true,
   prettyZeros: false
 });
+
+const isMounted = ref(false);
 
 const smallFontSize = computed(() => {
   if (props.fontSizeSmall) {
@@ -176,5 +172,13 @@ const amount = computed(() => {
     afterDecimal: ""
   };
 });
+
+onMounted(() => {
+  isMounted.value = true;
+});
 </script>
-<style lang="scss" scoped></style>
+<style>
+.number-section-fraction, .number-section-integer {
+  align-items: flex-end!important;
+}
+</style>

--- a/src/common/components/activities/TransactionDetails.vue
+++ b/src/common/components/activities/TransactionDetails.vue
@@ -3,7 +3,7 @@
     ref="dialog"
     :title="$t('message.transaction-details')"
     showClose
-    class-list="md:h-auto"
+    class-list="md:h-fit"
   >
     <template v-slot:content>
       <div class="flex flex-col gap-5 px-6 pb-6 text-typography-default">

--- a/src/common/components/auth/Disconnect.vue
+++ b/src/common/components/auth/Disconnect.vue
@@ -3,7 +3,7 @@
     ref="dialog"
     show-close
     :title="$t('message.disconnect-title')"
-    class-list="md:h-auto"
+    class-list="md:h-fit"
   >
     <template v-slot:content>
       <div class="px-6 pb-6">

--- a/src/modules/assets/components/AssetsTable.vue
+++ b/src/modules/assets/components/AssetsTable.vue
@@ -19,8 +19,7 @@
         hide: hide,
         type: CURRENCY_VIEW_TYPES.CURRENCY,
         denom: NATIVE_CURRENCY.symbol,
-        fontSize: isMobile() ? 20 : 40,
-        fontSizeSmall: isMobile() ? 20 : 40
+        fontSize: isMobile() ? 20 : 40
       }"
     />
 

--- a/src/modules/assets/components/AssetsTable.vue
+++ b/src/modules/assets/components/AssetsTable.vue
@@ -19,8 +19,8 @@
         hide: hide,
         type: CURRENCY_VIEW_TYPES.CURRENCY,
         denom: NATIVE_CURRENCY.symbol,
-        fontSize: isMobile() ? 20 : 32,
-        fontSizeSmall: isMobile() ? 20 : 32
+        fontSize: isMobile() ? 20 : 40,
+        fontSizeSmall: isMobile() ? 20 : 40
       }"
     />
 

--- a/src/modules/dashboard/components/DashboardAssets.vue
+++ b/src/modules/dashboard/components/DashboardAssets.vue
@@ -36,8 +36,7 @@
         amount: total.toString(2),
         type: CURRENCY_VIEW_TYPES.CURRENCY,
         denom: NATIVE_CURRENCY.symbol,
-        fontSize: isMobile() ? 20 : 32,
-        fontSizeSmall: isMobile() ? 20 : 32
+        fontSize: isMobile() ? 20 : 32
       }"
     />
     <Table

--- a/src/modules/dashboard/components/DashboardLeases.vue
+++ b/src/modules/dashboard/components/DashboardLeases.vue
@@ -25,8 +25,7 @@
               amount: pnl.toString(),
               type: CURRENCY_VIEW_TYPES.CURRENCY,
               denom: NATIVE_CURRENCY.symbol,
-              fontSize: isMobile() ? 20 : 32,
-              fontSizeSmall: isMobile() ? 20 : 32
+              fontSize: isMobile() ? 20 : 32
             }"
             :pnl-status="{
               positive: pnl_percent.isPositive() || pnl_percent.isZero(),

--- a/src/modules/dashboard/components/DashboardRewards.vue
+++ b/src/modules/dashboard/components/DashboardRewards.vue
@@ -13,8 +13,7 @@
           amount: earningsAmount,
           type: CURRENCY_VIEW_TYPES.CURRENCY,
           denom: NATIVE_CURRENCY.symbol,
-          fontSize: isMobile() ? 20 : 32,
-          fontSizeSmall: isMobile() ? 20 : 32
+          fontSize: isMobile() ? 20 : 32
         }"
       />
 
@@ -25,8 +24,7 @@
           amount: stableRewards,
           type: CURRENCY_VIEW_TYPES.CURRENCY,
           denom: NATIVE_CURRENCY.symbol,
-          fontSize: isMobile() ? 20 : 32,
-          fontSizeSmall: isMobile() ? 20 : 32
+          fontSize: isMobile() ? 20 : 32
         }"
       />
 

--- a/src/modules/earn/components/EarnAssets.vue
+++ b/src/modules/earn/components/EarnAssets.vue
@@ -15,8 +15,7 @@
             amount: stableAmount,
             type: CURRENCY_VIEW_TYPES.CURRENCY,
             denom: NATIVE_CURRENCY.symbol,
-            fontSize: isMobile() ? 20 : 32,
-            fontSizeSmall: isMobile() ? 20 : 32
+            fontSize: isMobile() ? 20 : 32
           }"
         />
 
@@ -30,8 +29,7 @@
             amount: earningsAmount,
             type: CURRENCY_VIEW_TYPES.CURRENCY,
             denom: NATIVE_CURRENCY.symbol,
-            fontSize: 20,
-            fontSizeSmall: 20
+            fontSize: 20
           }"
         />
 
@@ -45,8 +43,7 @@
             amount: anualYield,
             type: CURRENCY_VIEW_TYPES.CURRENCY,
             denom: NATIVE_CURRENCY.symbol,
-            fontSize: 20,
-            fontSizeSmall: 20
+            fontSize: 20
           }"
         />
       </div>

--- a/src/modules/history/components/RealisedPnl.vue
+++ b/src/modules/history/components/RealisedPnl.vue
@@ -9,8 +9,7 @@
             type: CURRENCY_VIEW_TYPES.CURRENCY,
             denom: NATIVE_CURRENCY.symbol,
             decimals: NORMAL_DECIMALS,
-            fontSize: isMobile() ? 20 : 32,
-            fontSizeSmall: isMobile() ? 20 : 32
+            fontSize: isMobile() ? 20 : 32
           }"
           :loading="loading"
         />
@@ -24,7 +23,6 @@
             type: CURRENCY_VIEW_TYPES.CURRENCY,
             denom: NATIVE_CURRENCY.symbol,
             fontSize: 20,
-            fontSizeSmall: 20,
             decimals: NORMAL_DECIMALS
           }"
           :loading="loading"
@@ -39,7 +37,6 @@
             type: CURRENCY_VIEW_TYPES.CURRENCY,
             denom: '%',
             fontSize: 20,
-            fontSizeSmall: 20,
             decimals: NORMAL_DECIMALS,
             isDenomInfront: false
           }"

--- a/src/modules/leases/components/Leases.vue
+++ b/src/modules/leases/components/Leases.vue
@@ -48,7 +48,6 @@
               type: CURRENCY_VIEW_TYPES.CURRENCY,
               denom: NATIVE_CURRENCY.symbol,
               fontSize: isMobile() ? 20 : 32,
-              fontSizeSmall: isMobile() ? 20 : 32,
               class:
                 pnl_percent.isPositive() || pnl_percent.isZero() ? 'text-typography-success' : 'text-typography-error'
             }"
@@ -68,7 +67,6 @@
               type: CURRENCY_VIEW_TYPES.CURRENCY,
               denom: NATIVE_CURRENCY.symbol,
               fontSize: 20,
-              fontSizeSmall: 20,
               hide: hide
             }"
           />
@@ -79,7 +77,6 @@
               type: CURRENCY_VIEW_TYPES.CURRENCY,
               denom: NATIVE_CURRENCY.symbol,
               fontSize: 20,
-              fontSizeSmall: 20,
               hide: hide
             }"
           />

--- a/src/modules/leases/components/PnlLog.vue
+++ b/src/modules/leases/components/PnlLog.vue
@@ -39,8 +39,7 @@
             amount: pnl.toString(),
             type: CURRENCY_VIEW_TYPES.CURRENCY,
             denom: NATIVE_CURRENCY.symbol,
-            fontSize: isMobile() ? 20 : 32,
-            fontSizeSmall: isMobile() ? 20 : 32
+            fontSize: isMobile() ? 20 : 32
           }"
         />
         <Button

--- a/src/modules/leases/components/new-lease/LongLeaseDetails.vue
+++ b/src/modules/leases/components/new-lease/LongLeaseDetails.vue
@@ -52,8 +52,7 @@
               type: CURRENCY_VIEW_TYPES.TOKEN,
               denom: downPaymentAsset.shortName,
               hasSpace: true,
-              fontSize: 16,
-              fontSizeSmall: 16
+              fontSize: 16
             }"
             :secondary="{
               amount: downPaymentStable.toString(),
@@ -74,8 +73,7 @@
                 hasSpace: true,
                 denom: lpn.shortName,
                 decimals: lpn.decimal_digits,
-                fontSize: 16,
-                fontSizeSmall: 16
+                fontSize: 16
               }"
               :secondary="{
                 amount: borrowAmount,
@@ -93,8 +91,7 @@
                 type: CURRENCY_VIEW_TYPES.TOKEN,
                 denom: asset.shortName,
                 hasSpace: true,
-                fontSize: 16,
-                fontSizeSmall: 16
+                fontSize: 16
               }"
               :secondary="{
                 amount: swapStableFee.toString(),
@@ -147,7 +144,6 @@
           minimalDenom: '',
           decimals: 2,
           fontSize: 16,
-          fontSizeSmall: 16,
           class: { 'line-through': isFreeLease },
           additional: isFreeLease
             ? {
@@ -165,8 +161,7 @@
           type: CURRENCY_VIEW_TYPES.CURRENCY,
           denom: NATIVE_CURRENCY.symbol,
           decimals: 3,
-          fontSize: 16,
-          fontSizeSmall: 16
+          fontSize: 16
         }"
       />
       <BigNumber
@@ -179,8 +174,7 @@
           maxDecimals: 0,
           minimalDenom: '',
           decimals: 0,
-          fontSize: 16,
-          fontSizeSmall: 16
+          fontSize: 16
         }"
       />
     </div>

--- a/src/modules/leases/components/new-lease/ShortLeaseDetails.vue
+++ b/src/modules/leases/components/new-lease/ShortLeaseDetails.vue
@@ -53,8 +53,7 @@
               type: CURRENCY_VIEW_TYPES.TOKEN,
               denom: downPaymentAsset.shortName,
               hasSpace: true,
-              fontSize: 16,
-              fontSizeSmall: 16
+              fontSize: 16
             }"
             :secondary="{
               amount: downPaymentStable.toString(),
@@ -75,8 +74,7 @@
                 type: CURRENCY_VIEW_TYPES.TOKEN,
                 denom: asset.shortName,
                 hasSpace: true,
-                fontSize: 16,
-                fontSizeSmall: 16
+                fontSize: 16
               }"
               :secondary="{
                 amount: borrowStable.toString(),
@@ -95,8 +93,7 @@
                 type: CURRENCY_VIEW_TYPES.TOKEN,
                 denom: asset.shortName,
                 hasSpace: true,
-                fontSize: 16,
-                fontSizeSmall: 16
+                fontSize: 16
               }"
               :secondary="{
                 amount: swapStableFee.toString(),
@@ -138,7 +135,6 @@
           minimalDenom: '',
           decimals: 2,
           fontSize: 16,
-          fontSizeSmall: 16,
           class: { 'line-through': isFreeLease },
           additional: isFreeLease
             ? {
@@ -156,8 +152,7 @@
           type: CURRENCY_VIEW_TYPES.CURRENCY,
           denom: NATIVE_CURRENCY.symbol,
           decimals: 3,
-          fontSize: 16,
-          fontSizeSmall: 16
+          fontSize: 16
         }"
       />
       <BigNumber
@@ -170,8 +165,7 @@
           maxDecimals: 0,
           minimalDenom: '',
           decimals: 0,
-          fontSize: 16,
-          fontSizeSmall: 16
+          fontSize: 16
         }"
       />
     </div>

--- a/src/modules/leases/components/single-lease/PositionHealthWidget.vue
+++ b/src/modules/leases/components/single-lease/PositionHealthWidget.vue
@@ -68,7 +68,7 @@
         ></div>
         <div
           v-else
-          class="text-32 font-semibold"
+          class="text-40 font-semibold"
         >
           {{ health }}%
         </div>

--- a/src/modules/leases/components/single-lease/PositionSummaryWidget.vue
+++ b/src/modules/leases/components/single-lease/PositionSummaryWidget.vue
@@ -37,8 +37,7 @@
               decimals: assetLoan?.decimal_digits ?? 0,
               hasSpace: true,
               maxDecimals: MAX_DECIMALS,
-              fontSize: isMobile() ? 20 : 32,
-              fontSizeSmall: isMobile() ? 20 : 32
+              fontSize: isMobile() ? 20 : 32
             }"
             :secondary="stable"
           />
@@ -55,8 +54,7 @@
                 denom: lpn?.shortName ?? '',
                 decimals: lpn?.decimal_digits ?? 0,
                 hasSpace: true,
-                fontSize: 16,
-                fontSizeSmall: 16
+                fontSize: 16
               }"
             />
 
@@ -68,8 +66,7 @@
                 type: CURRENCY_VIEW_TYPES.CURRENCY,
                 denom: NATIVE_CURRENCY.symbol,
                 decimals: MID_DECIMALS,
-                fontSize: 16,
-                fontSizeSmall: 16
+                fontSize: 16
               }"
             />
 
@@ -82,8 +79,7 @@
                 type: CURRENCY_VIEW_TYPES.CURRENCY,
                 denom: `${NATIVE_CURRENCY.symbol}`,
                 decimals: 4,
-                fontSize: 16,
-                fontSizeSmall: 16
+                fontSize: 16
               }"
             />
             <BigNumber
@@ -97,7 +93,6 @@
                 decimals: lpn?.decimal_digits ?? 0,
                 hasSpace: true,
                 fontSize: 16,
-                fontSizeSmall: 16,
                 class: interestDueStatus ? 'text-warning-100' : ''
               }"
             />
@@ -112,8 +107,7 @@
                 type: CURRENCY_VIEW_TYPES.CURRENCY,
                 denom: NATIVE_CURRENCY.symbol,
                 hasSpace: false,
-                fontSize: 16,
-                fontSizeSmall: 16
+                fontSize: 16
               }"
             />
 
@@ -125,8 +119,7 @@
                 amount: fee,
                 type: CURRENCY_VIEW_TYPES.CURRENCY,
                 denom: NATIVE_CURRENCY.symbol,
-                fontSize: 16,
-                fontSizeSmall: 16
+                fontSize: 16
               }"
             />
 
@@ -140,7 +133,6 @@
                 denom: '%',
                 isDenomInfront: false,
                 fontSize: 16,
-                fontSizeSmall: 16,
                 class: { 'line-through': isFreeLease },
                 additional: isFreeLease
                   ? {
@@ -164,8 +156,7 @@
             type: CURRENCY_VIEW_TYPES.CURRENCY,
             denom: '$',
             class: pnl.status ? 'text-typography-success' : 'text-typography-error',
-            fontSize: isMobile() ? 20 : 32,
-            fontSizeSmall: isMobile() ? 20 : 32
+            fontSize: isMobile() ? 20 : 32
           }"
           :pnl-status="{
             positive: pnl.status,
@@ -499,8 +490,7 @@ const stable = computed<CurrencyComponentProps>(() => {
     amount: "0",
     type: CURRENCY_VIEW_TYPES.CURRENCY,
     denom: NATIVE_CURRENCY.symbol,
-    fontSize: 16,
-    fontSizeSmall: 16
+    fontSize: 16
   } as CurrencyComponentProps;
 
   if (!lease) {
@@ -529,8 +519,7 @@ const stable = computed<CurrencyComponentProps>(() => {
         amount: value.toString(NATIVE_CURRENCY.maximumFractionDigits),
         type: CURRENCY_VIEW_TYPES.CURRENCY,
         denom: NATIVE_CURRENCY.symbol,
-        fontSize: 16,
-        fontSizeSmall: 16
+        fontSize: 16
       } as CurrencyComponentProps;
     }
     case PositionTypes.short: {
@@ -543,7 +532,6 @@ const stable = computed<CurrencyComponentProps>(() => {
         denom: ast?.shortName,
         decimals: asset.value?.decimal_digits,
         fontSize: 16,
-        fontSizeSmall: 16,
         hasSpace: true
       } as CurrencyComponentProps;
     }

--- a/src/modules/leases/components/single-lease/SharePnLDialog.vue
+++ b/src/modules/leases/components/single-lease/SharePnLDialog.vue
@@ -3,7 +3,7 @@
     ref="dialog"
     :title="$t(`message.share-position`)"
     showClose
-    class-list="md:h-auto"
+    class-list="md:h-fit"
   >
     <template v-slot:content>
       <div class="custom-scroll max-h-full flex-1 overflow-auto">

--- a/src/modules/stake/components/DelegationOverview.vue
+++ b/src/modules/stake/components/DelegationOverview.vue
@@ -17,8 +17,7 @@
           decimals: NATIVE_ASSET.decimal_digits,
           hasSpace: true,
           class: 'leading-[36px]',
-          fontSize: isMobile() ? 20 : 32,
-          fontSizeSmall: isMobile() ? 20 : 32
+          fontSize: isMobile() ? 20 : 32
         }"
         :secondary="{
           amount: stableDelegated,
@@ -38,8 +37,7 @@
           decimals: 2,
           hasSpace: false,
           class: 'leading-[36px]',
-          fontSize: isMobile() ? 20 : 32,
-          fontSizeSmall: isMobile() ? 20 : 32
+          fontSize: isMobile() ? 20 : 32
         }"
       />
       <template v-if="!showEmpty">
@@ -55,8 +53,7 @@
             class: 'leading-[36px]',
             denom: '%',
             isDenomInfront: false,
-            fontSize: isMobile() ? 20 : 32,
-            fontSizeSmall: isMobile() ? 20 : 32
+            fontSize: isMobile() ? 20 : 32
           }"
         />
       </template>

--- a/src/modules/stake/components/StakingRewards.vue
+++ b/src/modules/stake/components/StakingRewards.vue
@@ -24,8 +24,7 @@
           amount: stableRewards,
           type: CURRENCY_VIEW_TYPES.CURRENCY,
           denom: NATIVE_CURRENCY.symbol,
-          fontSize: isMobile() ? 20 : 32,
-          fontSizeSmall: isMobile() ? 20 : 32
+          fontSize: isMobile() ? 20 : 32
         }"
       />
     </div>

--- a/src/modules/stats/components/LoansProvided.vue
+++ b/src/modules/stats/components/LoansProvided.vue
@@ -9,8 +9,7 @@
           type: CURRENCY_VIEW_TYPES.CURRENCY,
           denom: NATIVE_CURRENCY.symbol,
           decimals: 0,
-          fontSize: isMobile() ? 20 : 32,
-          fontSizeSmall: isMobile() ? 20 : 32
+          fontSize: isMobile() ? 20 : 32
         }"
         :loading="loading"
       />
@@ -24,7 +23,6 @@
           type: CURRENCY_VIEW_TYPES.CURRENCY,
           denom: NATIVE_CURRENCY.symbol,
           fontSize: 20,
-          fontSizeSmall: 20,
           decimals: 0
         }"
         :loading="loading"

--- a/src/modules/stats/components/Overview.vue
+++ b/src/modules/stats/components/Overview.vue
@@ -9,8 +9,7 @@
           type: CURRENCY_VIEW_TYPES.CURRENCY,
           denom: NATIVE_CURRENCY.symbol,
           decimals: 0,
-          fontSize: isMobile() ? 20 : 32,
-          fontSizeSmall: isMobile() ? 20 : 32
+          fontSize: isMobile() ? 20 : 32
         }"
         :loading="loading"
       />
@@ -21,8 +20,7 @@
           type: CURRENCY_VIEW_TYPES.CURRENCY,
           denom: NATIVE_CURRENCY.symbol,
           decimals: 0,
-          fontSize: 20,
-          fontSizeSmall: 20
+          fontSize: 20
         }"
         :loading="loading"
       />
@@ -33,8 +31,7 @@
           type: CURRENCY_VIEW_TYPES.CURRENCY,
           denom: NATIVE_CURRENCY.symbol,
           decimals: 0,
-          fontSize: 20,
-          fontSizeSmall: 20
+          fontSize: 20
         }"
         :loading="loading"
       />
@@ -45,7 +42,6 @@
           type: CURRENCY_VIEW_TYPES.CURRENCY,
           denom: NATIVE_CURRENCY.symbol,
           fontSize: 20,
-          fontSizeSmall: 20,
           decimals: 0
         }"
         :loading="loading"
@@ -59,8 +55,7 @@
           decimals: 0,
           hasSpace: true,
           isDenomInfront: false,
-          fontSize: 20,
-          fontSizeSmall: 20
+          fontSize: 20
         }"
         :loading="loading"
       />

--- a/src/modules/stats/components/ProtocolUtilization.vue
+++ b/src/modules/stats/components/ProtocolUtilization.vue
@@ -8,8 +8,7 @@
         type: CURRENCY_VIEW_TYPES.CURRENCY,
         denom: NATIVE_CURRENCY.symbol,
         decimals: 0,
-        fontSize: isMobile() ? 20 : 32,
-        fontSizeSmall: isMobile() ? 20 : 32
+        fontSize: isMobile() ? 20 : 32
       }"
     />
     <Table


### PR DESCRIPTION
## Summary
- Integrate `AnimateNumber` component from `motion-plus-vue` for animated number transitions in `CurrencyComponent`
- Add animate-from-zero effect when component mounts (numbers animate from 0 to their actual value)
- Remove unused `fontSizeSmall` prop and related code from `CurrencyComponent`
- Bump default font size from 32 to 40 in `BigNumber` component
- Minor UI tweaks: dialog height class changes (`h-auto` → `h-fit`), font smoothing
