### PR TITLE
feat(static): agent-readiness metadata at /.well-known/*

### DIFF
--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,142 @@
+{
+  "name": "Nolus Webapp — Agent Skills",
+  "description": "Machine-readable index of agent-callable skills on app.nolus.io. The REST API is the primary surface; 85 documented endpoints live in the OpenAPI spec. The Nolus.js MCP server wraps these as tools for AI assistants.",
+  "version": "1.0.0",
+  "provider": {
+    "organization": "Nolus Protocol",
+    "url": "https://nolus.io/"
+  },
+  "sources": [
+    {
+      "type": "openapi",
+      "url": "https://app.nolus.io/api/openapi.json",
+      "description": "OpenAPI 3.1 spec — the authoritative machine-readable contract for all public endpoints"
+    },
+    {
+      "type": "mcp",
+      "transport": "stdio",
+      "package": "@nolus/nolusjs",
+      "card": "https://app.nolus.io/.well-known/mcp.json",
+      "description": "Nolus.js MCP server — 20+ query tools and 8 transaction builders"
+    },
+    {
+      "type": "websocket",
+      "url": "wss://app.nolus.io/ws",
+      "description": "Real-time price and position updates"
+    }
+  ],
+  "skills": [
+    {
+      "id": "fetch-prices",
+      "name": "Fetch oracle prices",
+      "description": "Get current USD prices for supported assets from Oracle contracts",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/prices" },
+      "tags": ["read", "prices"]
+    },
+    {
+      "id": "fetch-currencies",
+      "name": "List currencies",
+      "description": "Supported currencies with metadata (tickers, denoms, decimals, icons)",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/currencies" },
+      "tags": ["read", "currencies"]
+    },
+    {
+      "id": "fetch-protocols",
+      "name": "List DeFi sub-protocols",
+      "description": "Available Nolus sub-protocols and their contract addresses",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/protocols" },
+      "tags": ["read", "protocols"]
+    },
+    {
+      "id": "fetch-leases",
+      "name": "Get leverage leases for a wallet",
+      "description": "Fetch active leverage leases and aggregated collateral/debt for a Nolus address",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/leases?address={bech32_address}" },
+      "tags": ["read", "leases", "wallet-scoped"]
+    },
+    {
+      "id": "fetch-lease-quote",
+      "name": "Quote a lease opening",
+      "description": "Preview what a new leverage position would look like given a downpayment and target currency",
+      "endpoint": { "method": "POST", "url": "https://app.nolus.io/api/leases/quote" },
+      "tags": ["read", "leases", "quote"]
+    },
+    {
+      "id": "open-lease",
+      "name": "Build lease-open transaction",
+      "description": "Generate unsigned transaction messages to open a leveraged lease. The caller signs with their own wallet.",
+      "endpoint": { "method": "POST", "url": "https://app.nolus.io/api/leases/open" },
+      "tags": ["write", "leases", "unsigned-tx"]
+    },
+    {
+      "id": "fetch-earn-pools",
+      "name": "List liquidity pools",
+      "description": "LP pool metadata and yields",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/earn/pools" },
+      "tags": ["read", "earn"]
+    },
+    {
+      "id": "fetch-earn-positions",
+      "name": "Get LP positions for a wallet",
+      "description": "Active liquidity-pool deposits for a Nolus address",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/earn/positions?address={bech32_address}" },
+      "tags": ["read", "earn", "wallet-scoped"]
+    },
+    {
+      "id": "fetch-earn-stats",
+      "name": "Get earn statistics",
+      "description": "Aggregated earn/LP statistics across the protocol",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/earn/stats" },
+      "tags": ["read", "earn", "stats"]
+    },
+    {
+      "id": "fetch-staking-apr",
+      "name": "Get staking APR",
+      "description": "Current NLS staking annual percentage rate",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/governance/apr" },
+      "tags": ["read", "staking", "governance"]
+    },
+    {
+      "id": "fetch-validators",
+      "name": "List validators",
+      "description": "Nolus chain validators with voting power, commission, status",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/staking/validators" },
+      "tags": ["read", "staking", "validators"]
+    },
+    {
+      "id": "fetch-staking-positions",
+      "name": "Get staking delegations for a wallet",
+      "description": "Active delegations, unbonding entries, and rewards for an address",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/staking/positions?address={bech32_address}" },
+      "tags": ["read", "staking", "wallet-scoped"]
+    },
+    {
+      "id": "fetch-proposals",
+      "name": "List governance proposals",
+      "description": "On-chain governance proposals with status and vote tallies",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/governance/proposals" },
+      "tags": ["read", "governance"]
+    },
+    {
+      "id": "fetch-balances",
+      "name": "Get wallet balances",
+      "description": "Token balances for a Nolus wallet address, filtered against the gated currency catalog, with USD value aggregation",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/balances?address={bech32_address}" },
+      "tags": ["read", "balances", "wallet-scoped"]
+    },
+    {
+      "id": "fetch-fees",
+      "name": "Get gas fee configuration",
+      "description": "Accepted fee denoms, minimum gas prices, and the gas estimate multiplier",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/fees/gas-config" },
+      "tags": ["read", "fees"]
+    },
+    {
+      "id": "fetch-networks",
+      "name": "List supported networks",
+      "description": "Cosmos and EVM networks supported by the app with RPC/REST endpoints",
+      "endpoint": { "method": "GET", "url": "https://app.nolus.io/api/config/networks" },
+      "tags": ["read", "networks"]
+    }
+  ]
+}

--- a/public/.well-known/agent.json
+++ b/public/.well-known/agent.json
@@ -1,0 +1,49 @@
+{
+  "name": "Nolus Webapp Backend",
+  "description": "Public REST API for the Nolus Protocol webapp (app.nolus.io). Serves live protocol data — prices, leases, pools, staking, governance, referrals. Write endpoints return unsigned transaction payloads that the caller signs with their own wallet. For programmatic invocation, see the OpenAPI document at /api/openapi.json.",
+  "url": "https://app.nolus.io/",
+  "provider": {
+    "organization": "Nolus Protocol",
+    "url": "https://nolus.io/"
+  },
+  "version": "1.0.0",
+  "documentationUrl": "https://app.nolus.io/api/openapi.json",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes": ["application/json"],
+  "defaultOutputModes": ["application/json"],
+  "skills": [
+    {
+      "id": "read-protocol-data",
+      "name": "Read live protocol data",
+      "description": "Fetch prices, currencies, protocols, leases, earn positions, staking data, governance proposals, fees, and more via /api/* REST endpoints. 85 documented paths in the OpenAPI spec.",
+      "tags": ["defi", "rest-api", "read-only"],
+      "examples": [
+        "What is the current APR on Nolus?",
+        "What assets does Nolus support?",
+        "What are the active leverage leases for address nolus1abc...?",
+        "Which liquidity pools are open?"
+      ]
+    },
+    {
+      "id": "build-unsigned-transactions",
+      "name": "Build unsigned transactions",
+      "description": "POST endpoints under /api/leases/*, /api/earn/*, /api/staking/*, etc. return unsigned Cosmos transaction messages for the user's wallet to sign. The backend never holds keys.",
+      "tags": ["defi", "rest-api", "transactions"],
+      "examples": [
+        "Build a quote for opening a leveraged lease",
+        "Prepare a deposit into the earn pool",
+        "Stake NLS to validator nolusvaloper1..."
+      ]
+    },
+    {
+      "id": "realtime-updates",
+      "name": "Real-time updates via WebSocket",
+      "description": "Subscribe at wss://app.nolus.io/ws for live price and position updates.",
+      "tags": ["defi", "websocket", "realtime"]
+    }
+  ]
+}

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,33 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://app.nolus.io/",
+      "service-desc": [
+        {
+          "href": "https://app.nolus.io/api/openapi.json",
+          "type": "application/json",
+          "title": "Nolus Protocol Webapp API (OpenAPI 3.1)"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://nolus.io/",
+          "type": "text/html",
+          "title": "Nolus Protocol — product overview and whitepaper"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://app.nolus.io/api/health",
+          "type": "application/json",
+          "title": "Liveness probe"
+        },
+        {
+          "href": "https://app.nolus.io/api/health/detailed",
+          "type": "application/json",
+          "title": "Readiness probe with per-service health"
+        }
+      ]
+    }
+  ]
+}

--- a/public/.well-known/mcp.json
+++ b/public/.well-known/mcp.json
@@ -1,0 +1,86 @@
+{
+  "name": "Nolus Protocol MCP Server",
+  "description": "Model Context Protocol server exposing Nolus Protocol query tools (prices, leases, pools, oracle, wallet balances) and unsigned transaction builders. Distributed as a stdio MCP server via the @nolus/nolusjs npm package — users install and run locally.",
+  "version": "1.0.0",
+  "transport": "stdio",
+  "repository": "https://github.com/nolus-protocol/nolus.js",
+  "documentation": "https://github.com/nolus-protocol/nolus.js#mcp-server",
+  "install": {
+    "registry": "npm",
+    "package": "@nolus/nolusjs",
+    "command": "npx",
+    "args": ["tsx", "node_modules/@nolus/nolusjs/src/mcp/server.ts"]
+  },
+  "capabilities": {
+    "tools": true,
+    "resources": false,
+    "prompts": false
+  },
+  "networks": {
+    "mainnet": {
+      "name": "Pirin",
+      "default": true,
+      "envOverrides": [
+        "NOLUS_PIRIN_RPC_URL",
+        "NOLUS_PIRIN_ADMIN_ADDRESS",
+        "NOLUS_PIRIN_CHAIN_ID"
+      ]
+    },
+    "testnet": {
+      "name": "Rila",
+      "envOverrides": [
+        "NOLUS_RILA_RPC_URL",
+        "NOLUS_RILA_ADMIN_ADDRESS",
+        "NOLUS_RILA_CHAIN_ID"
+      ]
+    }
+  },
+  "toolCategories": [
+    {
+      "name": "Queries",
+      "description": "Read-only tools for fetching protocol data",
+      "tools": [
+        "get_protocols",
+        "get_protocol",
+        "get_platform",
+        "get_lease_quote",
+        "get_open_leases",
+        "get_leaser_config",
+        "get_lease_status",
+        "get_lpp_balance",
+        "get_lpp_config",
+        "get_lpp_price",
+        "get_lender_deposit",
+        "get_lender_rewards",
+        "get_deposit_capacity",
+        "get_lpn",
+        "get_oracle_prices",
+        "get_asset_price",
+        "get_currencies",
+        "get_oracle_config",
+        "calculate_rewards",
+        "get_wallet_balance",
+        "get_block_height",
+        "get_chain_id"
+      ]
+    },
+    {
+      "name": "Transaction builders",
+      "description": "Generate unsigned transactions for user wallet signing",
+      "tools": [
+        "prepare_open_lease",
+        "prepare_repay_lease",
+        "prepare_close_lease",
+        "prepare_change_close_policy",
+        "prepare_deposit_lpp",
+        "prepare_withdraw_lpp",
+        "prepare_claim_lpp_rewards",
+        "prepare_transfer_tokens"
+      ]
+    }
+  ],
+  "restApiAlternative": {
+    "description": "For agents that prefer REST over stdio MCP, the same data is available via the webapp backend.",
+    "openapi": "https://app.nolus.io/api/openapi.json"
+  }
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+User-agent: *
+Content-Signal: search=no, ai-input=no, ai-train=no
+Disallow: /
+Allow: /.well-known/
+
+# The Nolus webapp is a wallet-gated DeFi interface — there is nothing
+# indexable to render without user interaction. Agents should instead
+# consume the REST API (https://app.nolus.io/api/openapi.json) or
+# the Nolus.js MCP server.


### PR DESCRIPTION
## Summary

Publish machine-readable discovery metadata under `/.well-known/*` so AI agents can find the programmatic surface of app.nolus.io (REST API, WebSocket, and the nolus.js MCP server) without rendering the wallet-gated SPA.

Part 3/3 of the agent-readiness plan. Depends on PR #108 (OpenAPI spec) landing first — the `api-catalog` file references `/api/openapi.json`.

## What's added

| File | Purpose |
|---|---|
| `public/robots.txt` | `Disallow: /` (nothing indexable) + `Allow: /.well-known/` + Content Signals (`search=no, ai-input=no, ai-train=no`). Wallet-gated UI is not suitable for training or search — the REST API is the canonical surface. |
| `public/.well-known/api-catalog` | RFC 9727 linkset pointing to `/api/openapi.json` + health probes |
| `public/.well-known/agent.json` | A2A Agent Card — 3 skills (read data, build unsigned txs, realtime) |
| `public/.well-known/agent-skills/index.json` | 16 concrete skills mapped to existing REST endpoints |
| `public/.well-known/mcp.json` | Metadata for Nolus.js stdio MCP server (mirrors marketing site) |

## Why `Disallow: /` + `Allow: /.well-known/`?

The webapp is a wallet-gated DeFi interface — the HTML is an empty SPA shell that requires browser-extension wallet interaction to become useful. There's nothing for a search engine or training crawler to usefully index. But agents discovering Nolus programmatically *should* reach the catalog and spec.

## Test plan

- [x] `jq empty` on all 4 JSON files — valid
- [x] robots.txt syntactically valid
- [x] `public/` ships verbatim to `dist/` via Vite (no exclusions)
- [x] `ServeDir` (the Rust backend's static handler) serves real files before SPA fallback — verified in reconnaissance
- [ ] After deploy to `app-dev.nolus.io`:
  - `curl https://app-dev.nolus.io/robots.txt` returns text
  - `curl https://app-dev.nolus.io/.well-known/agent.json` returns JSON (not SPA fallback)
  - `curl https://app-dev.nolus.io/.well-known/api-catalog` returns JSON
  - Re-scan on isitagentready.com — expect Level 0 → Level 2+

## Merge order

Wait for PR #108 (OpenAPI spec) to deploy first. Otherwise `/.well-known/api-catalog` will point at a 404 for a brief window.

## Follow-up

- **nginx `Link:` headers** — the last remaining agent-readiness gap. Non-repo config change on the frontends server.