### PR TITLE
fix(static): align agent-card + mcp server-card with scanner spec paths

### DIFF
--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -1,13 +1,28 @@
 {
   "name": "Nolus Webapp Backend",
-  "description": "Public REST API for the Nolus Protocol webapp (app.nolus.io). Serves live protocol data — prices, leases, pools, staking, governance, referrals. Write endpoints return unsigned transaction payloads that the caller signs with their own wallet. For programmatic invocation, see the OpenAPI document at /api/openapi.json.",
+  "version": "1.0.0",
+  "description": "Public REST API for the Nolus Protocol webapp (app.nolus.io). Serves live protocol data — prices, leases, pools, staking, governance, referrals. Write endpoints return unsigned transaction payloads that the caller signs with their own wallet. The authoritative machine-readable contract is the OpenAPI 3.1 document at /api/openapi.json.",
   "url": "https://app.nolus.io/",
   "provider": {
     "organization": "Nolus Protocol",
     "url": "https://nolus.io/"
   },
-  "version": "1.0.0",
   "documentationUrl": "https://app.nolus.io/api/openapi.json",
+  "supportedInterfaces": [
+    {
+      "url": "https://app.nolus.io/api/",
+      "transport": "https",
+      "protocol": "rest",
+      "description": "REST API (OpenAPI 3.1)",
+      "contentType": "application/json"
+    },
+    {
+      "url": "wss://app.nolus.io/ws",
+      "transport": "wss",
+      "protocol": "websocket",
+      "description": "Real-time price and position updates"
+    }
+  ],
   "capabilities": {
     "streaming": true,
     "pushNotifications": false,

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -16,7 +16,7 @@
       "type": "mcp",
       "transport": "stdio",
       "package": "@nolus/nolusjs",
-      "card": "https://app.nolus.io/.well-known/mcp.json",
+      "card": "https://app.nolus.io/.well-known/mcp/server-card.json",
       "description": "Nolus.js MCP server — 20+ query tools and 8 transaction builders"
     },
     {

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,21 +1,27 @@
 {
-  "name": "Nolus Protocol MCP Server",
-  "description": "Model Context Protocol server exposing Nolus Protocol query tools (prices, leases, pools, oracle, wallet balances) and unsigned transaction builders. Distributed as a stdio MCP server via the @nolus/nolusjs npm package — users install and run locally.",
-  "version": "1.0.0",
-  "transport": "stdio",
-  "repository": "https://github.com/nolus-protocol/nolus.js",
-  "documentation": "https://github.com/nolus-protocol/nolus.js#mcp-server",
-  "install": {
-    "registry": "npm",
-    "package": "@nolus/nolusjs",
-    "command": "npx",
-    "args": ["tsx", "node_modules/@nolus/nolusjs/src/mcp/server.ts"]
+  "serverInfo": {
+    "name": "Nolus Protocol MCP Server",
+    "version": "1.0.0"
+  },
+  "description": "Model Context Protocol server exposing Nolus Protocol query tools (prices, leases, pools, oracle, wallet balances) and unsigned transaction builders. Distributed as a stdio MCP server via the @nolus/nolusjs npm package — users install and run locally; there is no hosted HTTP endpoint.",
+  "transport": {
+    "type": "stdio",
+    "install": {
+      "registry": "npm",
+      "package": "@nolus/nolusjs",
+      "command": "npx",
+      "args": ["tsx", "node_modules/@nolus/nolusjs/src/mcp/server.ts"]
+    }
   },
   "capabilities": {
-    "tools": true,
-    "resources": false,
-    "prompts": false
+    "tools": {
+      "listChanged": false
+    },
+    "resources": {},
+    "prompts": {}
   },
+  "repository": "https://github.com/nolus-protocol/nolus.js",
+  "documentation": "https://github.com/nolus-protocol/nolus.js#mcp-server",
   "networks": {
     "mainnet": {
       "name": "Pirin",


### PR DESCRIPTION
## Summary

Follow-up to PR #109. The isitagentready.com scan rejected our A2A and MCP cards because the spec paths and JSON shapes were wrong. This aligns them with the standards the scanner validates against.

## Changes

**A2A Agent Card — moved + restructured**
- `/.well-known/agent.json` → `/.well-known/agent-card.json` (spec-canonical path)
- Added `supportedInterfaces` array (REST + WebSocket) per A2A spec
- Kept `skills`, `capabilities`, provider info

**MCP Server Card — moved + restructured (SEP-1649)**
- `/.well-known/mcp.json` → `/.well-known/mcp/server-card.json`
- Changed shape:
  - `name` flat → `serverInfo: { name, version }`
  - `transport: "stdio"` flat → `transport: { type: "stdio", install: {...} }`
  - `capabilities.tools: true` → `capabilities.tools: { listChanged: false }`, `capabilities.resources: {}`, `capabilities.prompts: {}`
- Kept `networks`, `toolCategories`, `restApiAlternative` extensions (non-required, informational)

**Agent skills manifest**
- Updated `sources[].card` to point at the new mcp server-card path

## Spec references

- SEP-1649 (MCP Server Card): https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127
- A2A agent-card.json: Google A2A Protocol convention

## Test plan

- [x] `jq empty` on all 4 JSON files
- [ ] After deploy: re-scan app.nolus.io on isitagentready.com — expect `a2aAgentCard` and `mcpServerCard` to flip from FAIL to PASS
- [ ] `curl https://app-dev.nolus.io/.well-known/agent-card.json` returns the new JSON
- [ ] `curl https://app-dev.nolus.io/.well-known/mcp/server-card.json` returns the new JSON

## Note

Same renames also needed on the marketing site (`nolus.io_v2`). Separate PR to follow.