### PR TITLE
ci: unify deploy flow — main as single source of truth

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -3,7 +3,7 @@ name: Deploy dev
 on:
   push:
     branches:
-      - dev
+      - main
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -3,7 +3,6 @@ name: Validate PR
 on:
   pull_request:
     branches:
-      - dev
       - main
 
 concurrency:


### PR DESCRIPTION
## Summary

Match the `nolus.io_v2` CI/CD pattern. Eliminates the `dev`/`main` split that has required manual sync PRs and leaves the door open for drift between what's QAed and what's released.

## Before

```
feature branch ──PR──▶ dev ──push──▶ [deploy-dev fires] ──▶ app-dev.nolus.io
                                 │
                                 └─ tag v*.*.* on any branch ──▶ [deploy-prod fires] ──▶ app.nolus.io

(separately) dev ──sync PR──▶ main
```

- Tag could be cut from `dev` tip while `main` lagged — not the case right now, but structurally possible
- Contributors had to know which branch to target (`dev` for features, `main` for syncs)
- Two-step review loop to get code onto `main`

## After

```
feature branch ──PR──▶ main ──merge──▶ [deploy-dev fires] ──▶ app-dev.nolus.io (staging)
                                  │
                                  └─ git tag v*.*.* ──▶ [deploy-prod fires] ──▶ app.nolus.io
```

Identical to `nolus.io_v2`. One branch, one review loop, main is always the source of truth for both staging and prod.

## Changes

| File | Change |
|---|---|
| `deploy-dev.yaml` | Trigger: `branches: [dev]` → `branches: [main]` |
| `pr-validate.yaml` | Trigger: `branches: [dev, main]` → `branches: [main]` |
| `deploy-prod.yaml` | **Unchanged** |

Everything else identical: same env vars, rclone targets, systemd services (`webapp-dev` / `webapp-prod`), ports.

## web-components versioning

`package.json` pins `web-components` to an immutable git tag: `github:nolus-protocol/web-components#v2.0.66`. `npm ci` resolves to the same commit regardless of which branch the build runs from, so web-components version is decoupled from the webapp's branching strategy.

Asymmetry preserved between staging and prod:
- **Staging** (`deploy-dev.yaml`) retains `npm update web-components` before `npm ci` — QA covers the latest tip of whatever ref `package.json` points at (useful when testing a floating ref during development)
- **Production** (`deploy-prod.yaml`) does not — builds are deterministic against the `package-lock.json`

## Risks

- **Transition window:** between merge and the next feature PR, pushes to `dev` silently stop deploying. Mitigation: delete `dev` branch as part of the cutover (see follow-up below).
- **Open PRs targeting `dev`:** none currently — verified via `gh pr list`.
- **Existing `v3.1.0` tag** points at a commit that's now in both `main` and `dev` — no action needed.

## Follow-up after merge

Delete the `dev` branch on GitHub. Local checkouts switch to `main`:

```
git checkout main && git pull && git branch -D dev
```

## Test plan

- [ ] `pr-validate` runs green on this PR (self-test of the new trigger)
- [ ] After merge: `deploy-dev` fires on the merge commit → `app-dev.nolus.io` gets a fresh bundle with identical functionality to the current running version
- [ ] Next `v*.*.*` tag from `main` still triggers `deploy-prod` correctly