### PR TITLE
feat(frontend): expose in-page WebMCP tools — read + connect + navigate

### DIFF
--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -42,6 +42,32 @@ jobs:
           VITE_APP_URL: https://app.nolus.io
         run: npm run build
 
+      - name: WebMCP scope guard — no tx-signing reachable + agent-card commitment intact
+        run: |
+          set -e
+          # Policy: src/common/webmcp/ must never reach a signing surface.
+          # If this grep matches, the WebMCP module imports something that can sign
+          # or broadcast a transaction. Reject the PR.
+          # Test files (*.test.ts) are excluded — their docblocks legitimately name the
+          # forbidden tokens to document the policy; they cannot themselves move funds.
+          if grep -rE --include='*.ts' --include='*.vue' --exclude='*.test.ts' --exclude='*.spec.ts' \
+                  '\b(signTx|signDirect|signAndBroadcast|broadcastTx|simulate[A-Za-z]*Tx|NolusWalletFactory)\b|@/networks/(cosm|evm|sol)/.*Wallet|wallet\.(sign|broadcast)' \
+                  src/common/webmcp/ 2>/dev/null; then
+            echo "FAIL: src/common/webmcp/ references a signing/broadcast surface — policy violation."
+            echo "      WebMCP scope is connect + read + navigate only. See src/common/webmcp/tools.ts docblock."
+            exit 1
+          fi
+
+          # The agent-card publicly commits that WebMCP never exposes tx signing.
+          # If a PR weakens the commitment, fail loudly.
+          if ! grep -q "never will be" public/.well-known/agent-card.json; then
+            echo "FAIL: public/.well-known/agent-card.json no longer contains the 'never will be'"
+            echo "      commitment that WebMCP exposes no tx-signing tools."
+            exit 1
+          fi
+
+          echo "OK — WebMCP scope guard passed."
+
       - name: Validate .well-known JSON files in dist/
         run: |
           set -e

--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -1,7 +1,7 @@
 {
   "name": "Nolus Webapp Backend",
   "version": "1.0.0",
-  "description": "Public REST API for the Nolus Protocol webapp (app.nolus.io). Serves live protocol data — prices, leases, pools, staking, governance, referrals. Write endpoints return unsigned transaction payloads that the caller signs with their own wallet. The authoritative machine-readable contract is the OpenAPI 3.1 document at /api/openapi.json.",
+  "description": "Public REST API for the Nolus Protocol webapp (app.nolus.io). Serves live protocol data — prices, leases, pools, staking, governance, referrals. Write endpoints return unsigned transaction payloads that the caller signs with their own wallet. The authoritative machine-readable contract is the OpenAPI 3.1 document at /api/openapi.json.\n\nAGENT ROUTING — pick the right surface for the task:\n• REST + WebSocket (this card): general-purpose, address-parameterized queries; pre-built unsigned tx payloads for any caller.\n• @nolus/nolusjs stdio MCP (https://github.com/nolus-protocol/nolus.js#mcp-server): the FULL trading instrument. Runs locally in your agent (Claude Desktop, Cursor, etc.). Includes tx-builder tools (open lease, repay, deposit LPP, withdraw, stake, vote) that produce unsigned txs for the user's wallet. Use this when the agent runs outside the browser or when the user wants programmatic trading actions.\n• In-page WebMCP (in supportedInterfaces below): VIEW + CONNECT + NAVIGATE ONLY, runs inside the user's browser tab on app.nolus.io. Tools auto-bind to the already-connected wallet (no address parameter). Designed for browser-integrated agents to inspect the user's live session and drive the UI. Does NOT sign or broadcast transactions and never will — signing remains the wallet popup's responsibility. For tx execution, hand off to @nolus/nolusjs MCP or to the dApp's UI flow.",
   "url": "https://app.nolus.io/",
   "provider": {
     "organization": "Nolus Protocol",
@@ -21,6 +21,12 @@
       "transport": "wss",
       "protocol": "websocket",
       "description": "Real-time price and position updates"
+    },
+    {
+      "url": "https://app.nolus.io/",
+      "transport": "in-page",
+      "protocol": "webmcp",
+      "description": "In-page WebMCP tools — wallet-scoped reads (balances, leases, earn, staking), wallet connect, and UI navigation, registered via navigator.modelContext.registerTool. Tools auto-bind to the user's connected wallet — no address parameter required. SCOPE: connect, read, and navigate only. Transaction signing is intentionally NOT exposed via WebMCP and never will be — txs go through the explicit user-driven UI flow with the wallet popup as the consent surface. See https://webmachinelearning.github.io/webmcp/."
     }
   ],
   "capabilities": {
@@ -59,6 +65,18 @@
       "name": "Real-time updates via WebSocket",
       "description": "Subscribe at wss://app.nolus.io/ws for live price and position updates.",
       "tags": ["defi", "websocket", "realtime"]
+    },
+    {
+      "id": "in-page-webmcp-tools",
+      "name": "In-page WebMCP tools",
+      "description": "Browser-side tools registered via navigator.modelContext on app.nolus.io. Wallet-scoped reads (get_balances, get_open_leases, get_earn_positions, get_staking_delegations) auto-bind to the connected wallet — no address argument needed. Plus get_connected_wallet, get_prices, connect_wallet (opens the wallet extension popup, never signs), and navigate(route) for driving the UI. SCOPE: connect, read, navigate only — transaction signing is NOT exposed and never will be. WHEN TO USE: pick WebMCP when the agent runs in the user's browser and you want to inspect their live in-page session or drive the UI. For TRADING ACTIONS (open/close lease, deposit, repay, stake, vote) use the @nolus/nolusjs stdio MCP server — it's the real trading instrument. WebMCP is the view + UI driver, nolus.js MCP is the trading instrument; they are complements, not substitutes.",
+      "tags": ["defi", "webmcp", "browser", "wallet-scoped", "read-only-and-navigation"],
+      "examples": [
+        "Connect my Keplr wallet",
+        "What is my current LTV across open leases?",
+        "Take me to the earn page",
+        "How much NLS am I currently staking and what are my pending rewards?"
+      ]
     }
   ]
 }

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,6 +1,6 @@
 {
   "name": "Nolus Webapp — Agent Skills",
-  "description": "Machine-readable index of agent-callable skills on app.nolus.io. The REST API is the primary surface; 85 documented endpoints live in the OpenAPI spec. The Nolus.js MCP server wraps these as tools for AI assistants.",
+  "description": "Machine-readable index of agent-callable skills on app.nolus.io. The REST API is the primary general-purpose surface (85 endpoints in the OpenAPI spec). The @nolus/nolusjs stdio MCP server is the FULL trading instrument for local/desktop agents (queries + tx builders). In-page WebMCP is VIEW + CONNECT + NAVIGATE only — for browser-resident agents inspecting the user's live session and driving the UI; never signs transactions. Pick the source that matches where the agent runs and what action it needs.",
   "version": "1.0.0",
   "provider": {
     "organization": "Nolus Protocol",
@@ -10,19 +10,26 @@
     {
       "type": "openapi",
       "url": "https://app.nolus.io/api/openapi.json",
-      "description": "OpenAPI 3.1 spec — the authoritative machine-readable contract for all public endpoints"
+      "description": "OpenAPI 3.1 spec — the authoritative machine-readable contract for all public endpoints. General-purpose; address-parameterized."
     },
     {
       "type": "mcp",
       "transport": "stdio",
       "package": "@nolus/nolusjs",
       "card": "https://app.nolus.io/.well-known/mcp/server-card.json",
-      "description": "Nolus.js MCP server — 20+ query tools and 8 transaction builders"
+      "description": "Nolus.js MCP server — the real trading instrument. 20+ query tools and 8 transaction builders (open lease, repay, deposit LPP, withdraw, stake, vote, transfer). Runs locally in the user's agent (Claude Desktop, Cursor, etc.). Use for programmatic trading actions."
+    },
+    {
+      "type": "webmcp",
+      "transport": "in-page",
+      "url": "https://app.nolus.io/",
+      "card": "https://app.nolus.io/.well-known/agent-card.json",
+      "description": "In-page WebMCP via navigator.modelContext on app.nolus.io. View + connect + navigate only — auto-binds to the user's connected wallet. Never signs or broadcasts transactions. Use for browser-resident agents inspecting live in-page state; for tx execution, hand off to the @nolus/nolusjs MCP server or the dApp's UI flow."
     },
     {
       "type": "websocket",
       "url": "wss://app.nolus.io/ws",
-      "description": "Real-time price and position updates"
+      "description": "Real-time price and position updates. Subscribe alongside any of the above sources."
     }
   ],
   "skills": [

--- a/src/common/webmcp/index.ts
+++ b/src/common/webmcp/index.ts
@@ -1,0 +1,62 @@
+/**
+ * WebMCP integration entry point.
+ *
+ * Feature-detects `navigator.modelContext` (Chrome WebMCP EPP, currently behind
+ * a flag). Bails silently on browsers that don't support it — no console noise,
+ * no errors, no impact on other users.
+ *
+ * Spec: https://webmachinelearning.github.io/webmcp/
+ *
+ * SCOPE: connect + read + navigate only. No tx-signing tools — see tools.ts.
+ */
+
+import type { Router } from "vue-router";
+import { buildTools, type WebMcpTool } from "./tools";
+
+interface ModelContextRegisterOptions {
+  signal?: AbortSignal;
+}
+
+interface ModelContext {
+  registerTool(tool: WebMcpTool, options?: ModelContextRegisterOptions): void;
+}
+
+declare global {
+  interface Navigator {
+    readonly modelContext?: ModelContext;
+  }
+}
+
+let abortController: AbortController | null = null;
+
+export function initWebMcp(router: Router): void {
+  if (typeof navigator === "undefined" || !navigator.modelContext) {
+    return;
+  }
+
+  // Idempotent — drop any prior registration before re-registering (HMR / repeat init).
+  disposeWebMcp();
+
+  abortController = new AbortController();
+  const signal = abortController.signal;
+
+  for (const tool of buildTools(router)) {
+    try {
+      navigator.modelContext.registerTool(tool, { signal });
+    } catch (e) {
+      // A single bad tool shouldn't poison the rest. Log and continue.
+      console.warn(`[WebMCP] Failed to register tool "${tool.name}":`, e);
+    }
+  }
+}
+
+export function disposeWebMcp(): void {
+  if (abortController) {
+    abortController.abort();
+    abortController = null;
+  }
+}
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => disposeWebMcp());
+}

--- a/src/common/webmcp/tools.test.ts
+++ b/src/common/webmcp/tools.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Source-level snapshot of the WebMCP tool surface.
+ *
+ * Reads tools.ts as text and pattern-extracts tool metadata. Avoids loading
+ * the module (its transitive imports — Pinia stores, ThemeManager, etc. —
+ * touch jsdom APIs at evaluation time and would require heavy mocking).
+ *
+ * This is the anti-drift guard for the project policy: connect + read +
+ * navigate ONLY. If you add or remove a tool, update the expected sets below
+ * consciously — the diff is the prompt to ask "is this within scope?"
+ *
+ * Adding any tx-signing tool (anything that calls a wallet method to sign /
+ * broadcast / simulate a transaction) is forbidden by policy and is also
+ * caught by the CI scope guard in .github/workflows/pr-validate.yaml.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SOURCE = readFileSync(resolve(__dirname, "tools.ts"), "utf-8");
+
+const ALLOWED_TOOLS = [
+  "connect_wallet",
+  "get_balances",
+  "get_connected_wallet",
+  "get_earn_positions",
+  "get_open_leases",
+  "get_prices",
+  "get_staking_delegations",
+  "navigate"
+] as const;
+
+const READ_ONLY_TOOLS = [
+  "get_balances",
+  "get_connected_wallet",
+  "get_earn_positions",
+  "get_open_leases",
+  "get_prices",
+  "get_staking_delegations"
+] as const;
+
+const ACTION_TOOLS = ["connect_wallet", "navigate"] as const;
+
+/**
+ * Extract every `name: "<tool_name>"` literal from the tool definitions.
+ * Anchored on `name:` to avoid matching arbitrary "name" strings inside
+ * descriptions or comments.
+ */
+function extractToolNames(source: string): string[] {
+  const matches = source.matchAll(/^\s*name:\s*"([^"]+)"/gm);
+  return Array.from(matches, (m) => m[1]);
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * For each tool name, find whether its definition block contains
+ * `readOnlyHint: true`. Tool blocks are bounded by the next top-level
+ * `name:` (or EOF).
+ */
+function extractReadOnlyTools(source: string, allNames: readonly string[]): string[] {
+  const readOnly: string[] = [];
+  for (const name of allNames) {
+    const start = source.search(new RegExp(`name:\\s*"${escapeRegex(name)}"`));
+    if (start === -1) continue;
+
+    const tail = source.slice(start + 1);
+    const nextMatch = tail.match(/\n\s{4,}name:\s*"/);
+    const end = nextMatch ? start + 1 + (nextMatch.index ?? tail.length) : source.length;
+    const block = source.slice(start, end);
+
+    if (/readOnlyHint:\s*true/.test(block)) {
+      readOnly.push(name);
+    }
+  }
+  return readOnly;
+}
+
+describe("WebMCP tool surface (source-level)", () => {
+  const names = extractToolNames(SOURCE);
+
+  it("registers exactly the policy-allowed tool set", () => {
+    expect(names.slice().sort()).toEqual([...ALLOWED_TOOLS].sort());
+  });
+
+  it("marks read tools with readOnlyHint=true", () => {
+    const readOnly = extractReadOnlyTools(SOURCE, names).sort();
+    expect(readOnly).toEqual([...READ_ONLY_TOOLS].sort());
+  });
+
+  it("does not mark action tools as read-only", () => {
+    const readOnly = new Set(extractReadOnlyTools(SOURCE, names));
+    const violators = ACTION_TOOLS.filter((name) => readOnly.has(name));
+    expect(violators).toEqual([]);
+  });
+
+  it("uses tool names that comply with the WebMCP spec character set", () => {
+    // Spec: 1–128 chars, alphanumeric + _ - . only
+    const re = /^[A-Za-z0-9_.-]{1,128}$/;
+    for (const n of names) {
+      expect(n).toMatch(re);
+    }
+  });
+});

--- a/src/common/webmcp/tools.ts
+++ b/src/common/webmcp/tools.ts
@@ -1,0 +1,290 @@
+/**
+ * WebMCP tool definitions.
+ *
+ * Each tool is a thin adapter over Pinia stores — they read whatever the user's
+ * already-loaded session has, so calls are essentially free (no extra backend hits).
+ *
+ * Tilt the surface toward wallet-scoped + UI-driven tools — the stdio MCP server
+ * in @nolus/nolusjs already covers the universal read-only queries.
+ *
+ * SCOPE BOUNDARY: connect + read + navigate ONLY. Never expose tx-signing tools
+ * (open lease, deposit, stake, vote, swap, etc.) via WebMCP. Transactions must
+ * stay inside the explicit user-driven UI flow with the wallet popup as the
+ * single authoritative consent surface.
+ */
+
+import type { Router } from "vue-router";
+import {
+  useConnectionStore,
+  useBalancesStore,
+  useLeasesStore,
+  useEarnStore,
+  useStakingStore,
+  usePricesStore,
+  useWalletStore,
+  WalletActions
+} from "@/common/stores";
+import { RouteNames } from "@/router/RouteNames";
+import { WalletManager } from "@/common/utils/WalletManager";
+import { WalletConnectMechanism } from "@/common/types";
+
+interface ToolAnnotations {
+  readOnlyHint?: boolean;
+}
+
+export interface WebMcpClient {
+  requestUserInteraction<T>(callback: () => Promise<T>): Promise<T>;
+}
+
+export interface WebMcpTool {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema: object;
+  execute: (input: unknown, client?: WebMcpClient) => Promise<unknown>;
+  annotations?: ToolAnnotations;
+}
+
+const MECHANISM_BY_LABEL: Record<string, WalletConnectMechanism> = {
+  keplr: WalletConnectMechanism.KEPLR,
+  leap: WalletConnectMechanism.LEAP,
+  phantom: WalletConnectMechanism.EVM_PHANTOM,
+  solflare: WalletConnectMechanism.SOL_SOLFLARE,
+  ledger: WalletConnectMechanism.LEDGER
+};
+
+const ACTION_BY_MECHANISM: Record<WalletConnectMechanism, WalletActions> = {
+  [WalletConnectMechanism.KEPLR]: WalletActions.CONNECT_KEPLR,
+  [WalletConnectMechanism.LEAP]: WalletActions.CONNECT_LEAP,
+  [WalletConnectMechanism.EVM_PHANTOM]: WalletActions.CONNECT_EVM_PHANTOM,
+  [WalletConnectMechanism.SOL_SOLFLARE]: WalletActions.CONNECT_SOL_SOLFLARE,
+  [WalletConnectMechanism.LEDGER]: WalletActions.CONNECT_LEDGER,
+  [WalletConnectMechanism.LEDGER_BLUETOOTH]: WalletActions.CONNECT_LEDGER
+};
+
+const MECHANISM_LABELS = Object.keys(MECHANISM_BY_LABEL);
+
+const NO_INPUT_SCHEMA = {
+  type: "object",
+  properties: {},
+  additionalProperties: false
+} as const;
+
+const ROUTE_VALUES = Object.values(RouteNames) as string[];
+
+export function buildTools(router: Router): WebMcpTool[] {
+  return [
+    {
+      name: "get_connected_wallet",
+      title: "Get connected wallet",
+      description:
+        "Returns the currently connected Nolus wallet (bech32 address) and connection status. " +
+        "If `connected` is false, the user needs to click the Connect Wallet button in the UI before " +
+        "wallet-scoped tools (balances, leases, earn, staking) will return data.",
+      inputSchema: NO_INPUT_SCHEMA,
+      annotations: { readOnlyHint: true },
+      async execute() {
+        const conn = useConnectionStore();
+        return {
+          connected: conn.isWalletConnected,
+          address: conn.walletAddress,
+          ws_state: conn.wsState
+        };
+      }
+    },
+
+    {
+      name: "get_balances",
+      title: "Get token balances",
+      description:
+        "Returns the connected wallet's token balances across all supported assets, with the " +
+        "aggregate USD value. Returns an empty array when no wallet is connected.",
+      inputSchema: NO_INPUT_SCHEMA,
+      annotations: { readOnlyHint: true },
+      async execute() {
+        const balances = useBalancesStore();
+        return {
+          address: balances.address,
+          total_value_usd: balances.totalValueUsd,
+          balances: balances.balances,
+          last_updated: balances.lastUpdated?.toISOString() ?? null
+        };
+      }
+    },
+
+    {
+      name: "get_open_leases",
+      title: "Get open leverage positions",
+      description:
+        "Returns the connected wallet's open Nolus leases (leveraged spot positions) with full " +
+        "per-position state — collateral, debt, status, and any optimistic in-progress flag — plus " +
+        "aggregate unrealized PnL and total collateral value in USD. Includes the WebSocket-driven " +
+        "live status that REST snapshots may not yet reflect.",
+      inputSchema: NO_INPUT_SCHEMA,
+      annotations: { readOnlyHint: true },
+      async execute() {
+        const leases = useLeasesStore();
+        return {
+          owner: leases.owner,
+          count: leases.openLeases.length,
+          total_pnl: leases.totalPnl.toString(),
+          total_collateral_usd: leases.totalCollateralUsd.toString(),
+          leases: leases.openLeases,
+          last_updated: leases.lastUpdated?.toISOString() ?? null
+        };
+      }
+    },
+
+    {
+      name: "get_earn_positions",
+      title: "Get liquidity pool positions",
+      description:
+        "Returns the connected wallet's liquidity provider positions in Nolus earn pools, plus the " +
+        "list of available pools with their current APYs. Use the pool list to suggest where the " +
+        "user could deposit additional funds.",
+      inputSchema: NO_INPUT_SCHEMA,
+      annotations: { readOnlyHint: true },
+      async execute() {
+        const earn = useEarnStore();
+        return {
+          address: earn.address,
+          total_deposited_usd: earn.totalDepositedUsd,
+          positions: earn.positions,
+          pools: earn.pools.map((p) => ({
+            protocol: p.protocol,
+            apy: p.apy,
+            lpp_address: p.lpp_address
+          })),
+          last_updated: earn.lastUpdated?.toISOString() ?? null
+        };
+      }
+    },
+
+    {
+      name: "get_staking_delegations",
+      title: "Get NLS staking delegations",
+      description:
+        "Returns the connected wallet's NLS staking delegations, unbonding entries, and claimable " +
+        "rewards across validators, with aggregate totals.",
+      inputSchema: NO_INPUT_SCHEMA,
+      annotations: { readOnlyHint: true },
+      async execute() {
+        const staking = useStakingStore();
+        return {
+          address: staking.address,
+          total_staked: staking.totalStaked,
+          total_rewards: staking.totalRewards,
+          delegations: staking.delegations,
+          unbonding: staking.unbonding,
+          rewards: staking.rewards,
+          last_updated: staking.lastUpdated?.toISOString() ?? null
+        };
+      }
+    },
+
+    {
+      name: "get_prices",
+      title: "Get oracle prices",
+      description:
+        "Returns the current oracle prices for all supported assets, keyed by `ticker@protocol` or " +
+        "IBC denom. Updated in real time via WebSocket (~6s cadence).",
+      inputSchema: NO_INPUT_SCHEMA,
+      annotations: { readOnlyHint: true },
+      async execute() {
+        const prices = usePricesStore();
+        return {
+          prices: prices.prices,
+          last_updated: prices.lastUpdated?.toISOString() ?? null
+        };
+      }
+    },
+
+    {
+      name: "connect_wallet",
+      title: "Connect wallet",
+      description:
+        "Open the user's wallet extension to connect a wallet. Pass `mechanism` to pick the extension " +
+        `(${MECHANISM_LABELS.join(", ")}); omit it to reconnect with the previously-used extension. ` +
+        "The user must approve in their extension popup. NEVER use this to sign transactions — this " +
+        "tool only establishes the wallet session; tx signing is not exposed via WebMCP.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          mechanism: {
+            type: "string",
+            enum: MECHANISM_LABELS,
+            description: "Wallet extension to use. Omit to reconnect using the last-used extension."
+          }
+        },
+        additionalProperties: false
+      },
+      async execute(input, client) {
+        const requested = (input as { mechanism?: unknown } | null | undefined)?.mechanism;
+        let mechanism: WalletConnectMechanism | undefined;
+
+        if (typeof requested === "string") {
+          mechanism = MECHANISM_BY_LABEL[requested];
+          if (!mechanism) {
+            throw new Error(`Unknown mechanism: ${requested}. Valid: ${MECHANISM_LABELS.join(", ")}`);
+          }
+        } else {
+          const previous = WalletManager.getWalletConnectMechanism();
+          if (!previous) {
+            throw new Error(
+              `No previously-used wallet found. Pass mechanism (${MECHANISM_LABELS.join(", ")}) to choose one.`
+            );
+          }
+          mechanism = previous as WalletConnectMechanism;
+        }
+
+        const action = ACTION_BY_MECHANISM[mechanism];
+        if (!action) {
+          throw new Error(`No connect action mapped for mechanism: ${mechanism}`);
+        }
+
+        // Wallet extensions require a user-gesture context to surface their popup.
+        // Per WebMCP spec, agent-driven calls go through requestUserInteraction so
+        // the browser can re-establish that gesture context before invoking the
+        // extension. Fall back to a direct call if the runtime didn't supply a client.
+        const connect = async () => {
+          const wallet = useWalletStore();
+          await wallet[action]();
+          const conn = useConnectionStore();
+          return {
+            connected: conn.isWalletConnected,
+            address: conn.walletAddress,
+            mechanism
+          };
+        };
+
+        return client ? client.requestUserInteraction(connect) : connect();
+      }
+    },
+
+    {
+      name: "navigate",
+      title: "Navigate to a page",
+      description: `Navigate the user to one of the dApp's main pages. Valid routes: ${ROUTE_VALUES.join(", ")}.`,
+      inputSchema: {
+        type: "object",
+        properties: {
+          route: {
+            type: "string",
+            enum: ROUTE_VALUES,
+            description: "Target route name."
+          }
+        },
+        required: ["route"],
+        additionalProperties: false
+      },
+      async execute(input) {
+        const route = (input as { route?: unknown } | null | undefined)?.route;
+        if (typeof route !== "string" || !ROUTE_VALUES.includes(route)) {
+          throw new Error(`Unknown route: ${String(route)}. Valid: ${ROUTE_VALUES.join(", ")}`);
+        }
+        await router.push({ name: route });
+        return { navigated_to: route };
+      }
+    }
+  ];
+}

--- a/src/entry-client.ts
+++ b/src/entry-client.ts
@@ -15,6 +15,7 @@ import { fetchEndpoints } from "./common/utils/EndpointService";
 import { initTheme } from "./common/utils/ThemeManager";
 import { useConnectionStore } from "./common/stores/connection";
 import { useWalletStore } from "./common/stores/wallet";
+import { initWebMcp } from "./common/webmcp";
 
 const { app, router } = createApp();
 
@@ -56,6 +57,9 @@ async function bootstrap() {
     },
     { immediate: true }
   );
+
+  // Expose in-page tools to WebMCP-capable browsers (no-op elsewhere).
+  initWebMcp(router);
 }
 
 router


### PR DESCRIPTION
## Summary

Browser-resident AI agents (Chrome WebMCP EPP) can now inspect the user's already-loaded session and drive the dApp UI via `navigator.modelContext.registerTool()`. Eight tools, all wallet-scoped or UI-driven; tools auto-bind to the connected wallet so the agent never needs an address parameter.

| Tool | Type | Source |
|---|---|---|
| `get_connected_wallet` | read | `useConnectionStore` |
| `get_balances` | read | `useBalancesStore` |
| `get_open_leases` | read | `useLeasesStore` (with WebSocket-fresh state) |
| `get_earn_positions` | read | `useEarnStore` |
| `get_staking_delegations` | read | `useStakingStore` |
| `get_prices` | read | `usePricesStore` |
| `connect_wallet({ mechanism? })` | action | Opens wallet extension popup; never signs |
| `navigate({ route })` | action | `router.push({ name })` against `RouteNames` enum |

## Hard scope: connect + read + navigate ONLY

Transaction signing is **NOT** exposed via WebMCP and never will be. The wallet popup remains the sole consent surface for any value transfer. For trading actions (open lease, deposit, repay, stake, vote) agents use the `@nolus/nolusjs` stdio MCP server — the real trading instrument — or the dApp's UI flow.

## Policy enforcement (three layers)

1. **Code** — module docblock in `src/common/webmcp/tools.ts` and `src/common/webmcp/index.ts` states the boundary in the file the contributor edits.
2. **Test** — `src/common/webmcp/tools.test.ts` snapshots the registered tool set + `readOnlyHint` distribution. Adding a tool requires a conscious snapshot update.
3. **CI** — new `WebMCP scope guard` step in `pr-validate.yaml` fails the PR if anything under `src/common/webmcp/` imports a signing surface (`signTx`, `signDirect`, `signAndBroadcast`, `broadcastTx`, `simulate*Tx`, `NolusWalletFactory`, `wallet.sign*`, `wallet.broadcast*`, `@/networks/{cosm,evm,sol}/*Wallet`) or if `agent-card.json` drops the "never will be" commitment.

## Public agent-routing matrix

`agent-card.json` and `agent-skills/index.json` now describe machine-readably which surface to use:

- **REST + WebSocket** — general-purpose, address-parameterized.
- **`@nolus/nolusjs` stdio MCP** — full trading instrument; runs locally; tx-builder tools.
- **In-page WebMCP** (this PR) — browser-resident view + UI driver; never signs; complements the stdio MCP, doesn't duplicate.

## Browser availability

WebMCP is currently behind a Chrome flag (Early Preview Program). The integration feature-detects `'modelContext' in navigator` and gracefully no-ops on every other browser (no console noise, no errors). No new dependencies.

## Security review

Multi-perspective audit (adversarial + differential reviews, plus the `sharp-edges` skill). Verdict: **safe to ship** — fund-loss surface is no greater than what already exists.

- All dynamic dispatch in `connect_wallet` is bounded to 5 `CONNECT_*` actions; cannot reach `DISCONNECT` / `LOAD_*`.
- Phantom/Solflare connect signs only the deterministic address-derivation message (visible in the wallet popup), not a value-bearing transaction.
- `navigate` is restricted to `RouteNames` enum values; no path/query/hash injection possible.
- No tool reaches `wallet.signTx`, `simulateBankTransferTx`, `signAndBroadcast`, etc. (verified via grep + the new CI scope guard).
- All read tools return data already public on-chain; no JWT, intercom token, or session secret exposed.

The sharp-edges audit identified the design's temporal weakness (future PRs could drift): mitigated by adding the snapshot test + CI scope guard.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 23 tests pass (existing 19 + 4 new snapshot tests)
- [x] `npm run build` — clean
- [x] CI scope guard passes locally (greps `src/common/webmcp/` for signing surface)
- [x] `agent-card.json` + `agent-skills/index.json` valid JSON (`jq empty`)
- [x] "never will be" commitment string present in `agent-card.json`
- [ ] Manual smoke test in Chrome with WebMCP flag enabled — connect wallet via tool, read balances, navigate to /earn
- [ ] Manual smoke test in non-WebMCP browser — confirm zero console output and no functional regression

## Files changed

- `src/common/webmcp/index.ts` (NEW) — `initWebMcp(router)`, feature-detect, AbortController teardown, HMR dispose
- `src/common/webmcp/tools.ts` (NEW) — 8 tool definitions, scope-boundary docblock
- `src/common/webmcp/tools.test.ts` (NEW) — source-level snapshot test
- `src/entry-client.ts` — adds `initWebMcp(router)` call after stores boot
- `public/.well-known/agent-card.json` — adds `webmcp` interface + skill, with explicit "no tx signing, ever" language and routing guidance
- `public/.well-known/agent-skills/index.json` — adds `webmcp` source + tightens routing matrix in description
- `.github/workflows/pr-validate.yaml` — adds WebMCP scope-guard step