### PR TITLE
test: Phase 2 — backend security boundaries + startup validation

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1408,6 +1408,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "governor",
+ "http-body-util",
  "jsonwebtoken",
  "lazy_static",
  "mini-moka",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -75,9 +75,10 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 utoipa = { version = "5", features = ["axum_extras", "chrono", "preserve_order"] }
 
 [dev-dependencies]
-wiremock = "0.6"
 futures = "0.3"
+http-body-util = "0.1"
 tempfile = "3.10"
+wiremock = "0.6"
 
 [profile.release]
 lto = true

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -466,6 +466,71 @@ mod tests {
         assert!(result.warnings.len() >= 4);
     }
 
+    // ========================================================================
+    // F4 startup-validation coverage: verify every admin.enabled/api_key
+    // combination. The reject case (`test_validate_admin_enabled_no_key`
+    // above) covers the existing `AdminEnabledNoKey` error; the three tests
+    // below add the positive/compatible cases so all four branches of the
+    // (enabled × api_key) matrix are exercised.
+    // ========================================================================
+
+    #[test]
+    fn validate_rejects_admin_enabled_without_api_key() {
+        let mut config = create_test_config();
+        config.admin.enabled = true;
+        config.admin.api_key = String::new();
+        let result = config.validate();
+        assert!(!result.is_ok(), "must reject enabled + empty key");
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| matches!(e, ConfigError::AdminEnabledNoKey)),
+            "must surface AdminEnabledNoKey"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_admin_enabled_with_api_key() {
+        let mut config = create_test_config();
+        config.admin.enabled = true;
+        config.admin.api_key = "secret".to_string();
+        let result = config.validate();
+        assert!(
+            result.is_ok(),
+            "enabled + non-empty key must validate, errors: {:?}",
+            result.errors
+        );
+        assert!(
+            !result
+                .errors
+                .iter()
+                .any(|e| matches!(e, ConfigError::AdminEnabledNoKey)),
+            "must NOT flag AdminEnabledNoKey"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_admin_disabled_without_api_key() {
+        // Disabled + empty key is the default production state — must pass.
+        let mut config = create_test_config();
+        config.admin.enabled = false;
+        config.admin.api_key = String::new();
+        let result = config.validate();
+        assert!(
+            result.is_ok(),
+            "disabled + empty key must validate, errors: {:?}",
+            result.errors
+        );
+        assert!(
+            !result
+                .errors
+                .iter()
+                .any(|e| matches!(e, ConfigError::AdminEnabledNoKey)),
+            "must NOT flag AdminEnabledNoKey"
+        );
+    }
+
     #[test]
     fn test_validation_result_methods() {
         let empty = ValidationResult {

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -188,3 +188,315 @@ impl From<reqwest::Error> for AppError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Pin the current behavior of `AppError` → HTTP response mapping.
+    //!
+    //! Phase 2 scope note: the user VETOED sanitizing
+    //! `Internal` / `ExternalApi` / `ChainRpc` response bodies. Detailed
+    //! error text is intentionally preserved so that (a) users see what
+    //! went wrong and (b) debugging is faster. These tests lock that
+    //! contract in place — an accidental future sanitization will fail CI.
+    //!
+    //! Envelope shape (confirmed from `IntoResponse` impl above):
+    //! `{ "error": { "code": "<CODE>", "message": "<msg>", "field"?, "details"?, "retry_after"? } }`
+    //! — the top-level key is `error` (an object), NOT flat `{code, message}`.
+    //! `field`, `details`, `retry_after` are omitted via
+    //! `skip_serializing_if = "Option::is_none"`.
+    use super::*;
+    use crate::test_utils::collect_body_str;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use serde_json::{json, Value};
+
+    /// Parse an AppError response body as JSON. Also asserts the
+    /// Content-Type header says `application/json` — this is the one
+    /// place that check lives.
+    async fn parse_json_body(resp: axum::response::Response) -> Value {
+        let ct = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .cloned()
+            .expect("response missing Content-Type");
+        let ct_str = ct.to_str().expect("Content-Type not valid ASCII");
+        assert!(
+            ct_str.contains("application/json"),
+            "expected application/json, got {ct_str}"
+        );
+        let body = collect_body_str(resp).await;
+        serde_json::from_str(&body).expect("body is not valid JSON")
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Status code mapping — one test per variant
+    // ──────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn app_error_validation_returns_400_with_field_and_details() {
+        let err = AppError::Validation {
+            message: "bad input".to_string(),
+            field: Some("email".to_string()),
+            details: Some(json!({"reason": "invalid"})),
+        };
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = parse_json_body(resp).await;
+        let msg = body["error"]["message"].as_str().unwrap();
+        assert!(msg.contains("bad input"), "message was: {msg}");
+        assert_eq!(body["error"]["field"], "email");
+    }
+
+    #[tokio::test]
+    async fn app_error_not_found_returns_404() {
+        let err = AppError::NotFound {
+            resource: "lease-123".to_string(),
+        };
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = parse_json_body(resp).await;
+        let msg = body["error"]["message"].as_str().unwrap();
+        assert!(msg.contains("lease-123"), "message was: {msg}");
+    }
+
+    #[tokio::test]
+    async fn app_error_unauthorized_returns_401() {
+        let resp = AppError::Unauthorized.into_response();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body = parse_json_body(resp).await;
+        assert_eq!(body["error"]["code"], "UNAUTHORIZED");
+    }
+
+    #[tokio::test]
+    async fn app_error_forbidden_returns_403() {
+        let resp = AppError::Forbidden.into_response();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = parse_json_body(resp).await;
+        assert_eq!(body["error"]["code"], "FORBIDDEN");
+    }
+
+    #[tokio::test]
+    async fn app_error_rate_limited_returns_429_with_retry_after() {
+        let err = AppError::RateLimited {
+            retry_after: Some(30),
+        };
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        let body = parse_json_body(resp).await;
+        assert_eq!(body["error"]["code"], "RATE_LIMITED");
+        assert_eq!(body["error"]["retry_after"], 30);
+    }
+
+    #[tokio::test]
+    async fn app_error_external_api_returns_502_with_full_detail() {
+        let err = AppError::ExternalApi {
+            api: "etl".to_string(),
+            message: "upstream timeout".to_string(),
+        };
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        let body = parse_json_body(resp).await;
+        let msg = body["error"]["message"].as_str().unwrap();
+        // Current format: "{api}: {message}". Both components must leak
+        // through — this is the non-sanitized behavior under test.
+        assert!(msg.contains("etl"), "message was: {msg}");
+        assert!(msg.contains("upstream timeout"), "message was: {msg}");
+    }
+
+    #[tokio::test]
+    async fn app_error_chain_rpc_returns_502_with_full_detail() {
+        let err = AppError::ChainRpc {
+            chain: "nolus".to_string(),
+            message: "RPC 503".to_string(),
+        };
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        let body = parse_json_body(resp).await;
+        let msg = body["error"]["message"].as_str().unwrap();
+        assert!(msg.contains("nolus"), "message was: {msg}");
+        assert!(msg.contains("RPC 503"), "message was: {msg}");
+    }
+
+    #[tokio::test]
+    async fn app_error_swap_route_failed_returns_502() {
+        let err = AppError::SwapRouteFailed {
+            message: "no route from A to B".to_string(),
+        };
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        let body = parse_json_body(resp).await;
+        assert_eq!(body["error"]["code"], "SWAP_ROUTE_FAILED");
+        let msg = body["error"]["message"].as_str().unwrap();
+        assert!(msg.contains("no route from A to B"), "message was: {msg}");
+    }
+
+    #[tokio::test]
+    async fn app_error_service_unavailable_returns_503() {
+        let err = AppError::ServiceUnavailable {
+            message: "db offline".to_string(),
+        };
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = parse_json_body(resp).await;
+        assert_eq!(body["error"]["code"], "SERVICE_UNAVAILABLE");
+        let msg = body["error"]["message"].as_str().unwrap();
+        assert!(msg.contains("db offline"), "message was: {msg}");
+    }
+
+    #[tokio::test]
+    async fn app_error_internal_returns_500_with_detail() {
+        let err = AppError::Internal("some detail".to_string());
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = parse_json_body(resp).await;
+        assert_eq!(body["error"]["code"], "INTERNAL_ERROR");
+        let msg = body["error"]["message"].as_str().unwrap();
+        assert!(msg.contains("some detail"), "message was: {msg}");
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Conversion tests
+    // ──────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn from_anyhow_error_produces_internal_variant_preserving_context() {
+        use anyhow::Context;
+        let anyhow_err: anyhow::Error = Err::<(), _>(anyhow::anyhow!("outer error"))
+            .context("during fetch")
+            .unwrap_err();
+        let app_err: AppError = anyhow_err.into();
+        match app_err {
+            AppError::Internal(msg) => {
+                // `anyhow::Error::to_string()` returns the top context
+                // (here: "during fetch"). The inner cause is preserved
+                // via the `Display` chain when using `{:#}` or
+                // `source()`, but `to_string()` only yields the top.
+                // Assert the top context is present, which is the
+                // contract `From<anyhow::Error>` commits to today.
+                assert!(
+                    msg.contains("during fetch"),
+                    "expected 'during fetch' context in Internal variant, got: {msg}"
+                );
+            }
+            other => panic!("expected AppError::Internal, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn from_reqwest_error_produces_external_api_variant_with_http_api_name() {
+        // Provoke a reqwest::Error by firing a request at an unroutable
+        // port (TCP 1 on loopback). A 100ms timeout bounds the test.
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(100))
+            .build()
+            .expect("reqwest client build");
+        let reqwest_err = client
+            .get("http://127.0.0.1:1/")
+            .send()
+            .await
+            .expect_err("request to 127.0.0.1:1 must fail");
+        let app_err: AppError = reqwest_err.into();
+        match app_err {
+            AppError::ExternalApi { api, message } => {
+                assert_eq!(api, "HTTP");
+                assert!(
+                    !message.is_empty(),
+                    "expected non-empty reqwest error message"
+                );
+            }
+            other => panic!("expected AppError::ExternalApi, got {other:?}"),
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Response body structure
+    // ──────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn app_error_response_body_is_json() {
+        // parse_json_body does the Content-Type + JSON-parse assertion.
+        let resp = AppError::Unauthorized.into_response();
+        let _ = parse_json_body(resp).await;
+    }
+
+    #[tokio::test]
+    async fn app_error_response_body_has_code_and_message_fields() {
+        // Actual envelope is `{ "error": { "code", "message", ... } }`.
+        // The `error` wrapper is part of the ErrorResponse struct.
+        let resp = AppError::Unauthorized.into_response();
+        let body = parse_json_body(resp).await;
+        let err_obj = body
+            .get("error")
+            .expect("top-level 'error' key missing from response body");
+        assert!(
+            err_obj.get("code").is_some(),
+            "error.code missing: {err_obj}"
+        );
+        assert!(
+            err_obj.get("message").is_some(),
+            "error.message missing: {err_obj}"
+        );
+    }
+
+    #[tokio::test]
+    async fn app_error_validation_response_includes_field_and_details() {
+        let err = AppError::Validation {
+            message: "bad input".to_string(),
+            field: Some("email".to_string()),
+            details: Some(json!({"reason": "invalid", "len": 0})),
+        };
+        let resp = err.into_response();
+        let body = parse_json_body(resp).await;
+        let err_obj = &body["error"];
+        assert_eq!(err_obj["field"], "email");
+        assert_eq!(err_obj["details"]["reason"], "invalid");
+        assert_eq!(err_obj["details"]["len"], 0);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Behavior preservation (documentation tests)
+    // ──────────────────────────────────────────────────────────────────
+
+    /// Documents the INTENTIONAL non-sanitization of
+    /// `AppError::Internal`. Detailed errors surface the issue to the
+    /// user (better UX, faster debugging). Secrets are not present in
+    /// error strings because API keys are sent in headers, never URLs.
+    ///
+    /// If this test starts failing, the change likely sanitized the
+    /// body to a generic "Internal server error" string — that was
+    /// explicitly vetoed by the user. Revert the source change; do not
+    /// "fix" this test.
+    #[tokio::test]
+    async fn app_error_internal_does_preserve_detailed_message_not_sanitized() {
+        let detailed = "connection refused to upstream at http://etl.internal:8080".to_string();
+        let resp = AppError::Internal(detailed.clone()).into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = parse_json_body(resp).await;
+        let msg = body["error"]["message"].as_str().unwrap();
+        assert_eq!(
+            msg, detailed,
+            "AppError::Internal body MUST preserve the full message verbatim (non-sanitized by design)"
+        );
+    }
+
+    /// Documents the INTENTIONAL non-sanitization of
+    /// `AppError::ExternalApi`. Both the upstream API name and its
+    /// error message leak through. Same rationale as
+    /// `app_error_internal_does_preserve_detailed_message_not_sanitized`.
+    #[tokio::test]
+    async fn app_error_external_api_does_preserve_api_and_message() {
+        let err = AppError::ExternalApi {
+            api: "etl-upstream-v2".to_string(),
+            message: "503 Service Unavailable: backend pool drained".to_string(),
+        };
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        let body = parse_json_body(resp).await;
+        let msg = body["error"]["message"].as_str().unwrap();
+        // Exact format: "{api}: {message}" — both components verbatim.
+        assert_eq!(
+            msg, "etl-upstream-v2: 503 Service Unavailable: backend pool drained",
+            "AppError::ExternalApi body MUST preserve the full api:message string verbatim"
+        );
+    }
+}

--- a/backend/src/handlers/spa.rs
+++ b/backend/src/handlers/spa.rs
@@ -46,7 +46,10 @@ impl Service<Request<Body>> for SpaFallback {
 
         Box::pin(async move {
             // Try to serve the static file first
-            let response = serve_dir.call(req).await.unwrap();
+            let response = serve_dir
+                .call(req)
+                .await
+                .expect("ServeDir::Error is Infallible; cannot fail");
 
             // If the file was not found (404) or ServeDir is trying to
             // redirect to a directory with a trailing slash (3xx), serve
@@ -60,24 +63,124 @@ impl Service<Request<Body>> for SpaFallback {
                 let index_req = Request::builder()
                     .uri(Uri::from_static("/index.html"))
                     .body(Body::empty())
-                    .unwrap();
+                    .expect("static /index.html URI and empty body are always valid");
 
                 // Create a new ServeDir to serve index.html
                 let mut index_serve = ServeDir::new(&static_dir);
-                let index_response = index_serve.call(index_req).await.unwrap();
+                let index_response = index_serve
+                    .call(index_req)
+                    .await
+                    .expect("ServeDir::Error is Infallible; cannot fail");
 
                 // Return with 200 OK status instead of preserving the original status
                 let (mut parts, body) = index_response.into_parts();
                 parts.status = StatusCode::OK;
                 // Add cache control header to prevent caching of the fallback
-                parts
-                    .headers
-                    .insert("cache-control", "no-cache".parse().unwrap());
+                parts.headers.insert(
+                    "cache-control",
+                    "no-cache"
+                        .parse()
+                        .expect("\"no-cache\" is a valid static HeaderValue"),
+                );
 
                 Ok(Response::from_parts(parts, Body::new(body)))
             } else {
                 Ok(response.map(Body::new))
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::collect_body_str;
+    use std::fs;
+    use tempfile::tempdir;
+    use tower::ServiceExt;
+
+    /// Build a SpaFallback rooted at a tempdir containing an `index.html`.
+    /// Returns `(service, TempDir)` — keep the TempDir alive for the test.
+    fn make_service_with_index(index_body: &str) -> (SpaFallback, tempfile::TempDir) {
+        let dir = tempdir().expect("tempdir");
+        fs::write(dir.path().join("index.html"), index_body).expect("write index.html");
+        let service = create_spa_fallback(
+            dir.path().to_string_lossy().into_owned(),
+            "index.html".to_string(),
+        );
+        (service, dir)
+    }
+
+    #[tokio::test]
+    async fn spa_fallback_serves_index_html_for_missing_route() {
+        let (service, _dir) = make_service_with_index("<p>test</p>");
+        let req = Request::builder()
+            .uri("/nonexistent")
+            .body(Body::empty())
+            .expect("valid request");
+
+        let resp = service.oneshot(req).await.expect("Infallible");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = collect_body_str(resp).await;
+        assert!(
+            body.contains("test"),
+            "fallback body should contain index.html content, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn spa_fallback_serves_static_file_when_it_exists() {
+        let (service, dir) = make_service_with_index("<p>index</p>");
+        fs::write(dir.path().join("file.css"), "body { color: red; }").expect("write css");
+
+        let req = Request::builder()
+            .uri("/file.css")
+            .body(Body::empty())
+            .expect("valid request");
+
+        let resp = service.oneshot(req).await.expect("Infallible");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = collect_body_str(resp).await;
+        assert!(
+            body.contains("color: red"),
+            "expected to serve the static file contents, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn spa_fallback_sets_no_cache_header_on_fallback() {
+        let (service, _dir) = make_service_with_index("<p>test</p>");
+        let req = Request::builder()
+            .uri("/missing-route")
+            .body(Body::empty())
+            .expect("valid request");
+
+        let resp = service.oneshot(req).await.expect("Infallible");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let cache_control = resp
+            .headers()
+            .get("cache-control")
+            .expect("cache-control header must be set on fallback");
+        assert_eq!(cache_control, "no-cache");
+    }
+
+    #[tokio::test]
+    async fn spa_fallback_returns_with_ok_status_not_404() {
+        // Regression guard: the whole point of the SPA fallback is converting
+        // 404 → 200 OK so the client can handle routing itself.
+        let (service, _dir) = make_service_with_index("<p>spa</p>");
+        let req = Request::builder()
+            .uri("/definitely/not/a/file")
+            .body(Body::empty())
+            .expect("valid request");
+
+        let resp = service.oneshot(req).await.expect("Infallible");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "fallback must return 200 OK, not {}",
+            resp.status()
+        );
+        assert_ne!(resp.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -35,7 +35,10 @@ pub mod refresh;
 mod translations;
 mod validation;
 
-use crate::config::AppConfig;
+#[cfg(test)]
+mod test_utils;
+
+use crate::config::{AppConfig, ServerConfig};
 use crate::config_store::ConfigStore;
 use crate::handlers::websocket::WebSocketManager;
 use crate::translations::{
@@ -76,8 +79,24 @@ async fn main() -> anyhow::Result<()> {
         .json()
         .init();
 
-    // Load configuration
+    // Load and validate configuration. Validation enforces invariants like
+    // "admin cannot be enabled without an api_key" — failing here prevents the
+    // admin_auth middleware's 403 from being the only line of defense against
+    // misconfig. We fail fast on errors and log warnings.
     let config = AppConfig::load()?;
+    let validation = config.validate();
+    for warning in &validation.warnings {
+        tracing::warn!("Config warning: {warning}");
+    }
+    if !validation.is_ok() {
+        for err in &validation.errors {
+            tracing::error!("Config error: {err}");
+        }
+        anyhow::bail!(
+            "Configuration validation failed with {} error(s); refusing to start",
+            validation.errors.len()
+        );
+    }
     let addr: SocketAddr = format!("{}:{}", config.server.host, config.server.port)
         .parse()
         .expect("Invalid server address");
@@ -219,22 +238,49 @@ async fn shutdown_signal() {
     }
 }
 
-fn create_router(state: Arc<AppState>) -> Router {
-    // CORS configuration
-    let cors = match &state.config.server.cors_origins {
+/// Build the CORS layer from server config, emitting startup warnings for
+/// common misconfigurations:
+/// - `cors_origins = None`         → allow-all (public API default) + warn
+/// - `cors_origins = Some(vec![])` → block all cross-origin requests + warn
+/// - `cors_origins = Some(list)`   → allow listed origins; warn per malformed entry
+fn build_cors_layer(server: &ServerConfig) -> CorsLayer {
+    match &server.cors_origins {
+        None => {
+            warn!(
+                "CORS_ORIGINS not configured — allowing all origins. \
+                 Set CORS_ORIGINS in production."
+            );
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods(Any)
+                .allow_headers(Any)
+        }
+        Some(origins) if origins.is_empty() => {
+            warn!("CORS_ORIGINS is set but empty — all cross-origin requests will be blocked");
+            CorsLayer::new()
+                .allow_origin(AllowOrigin::list(Vec::<axum::http::HeaderValue>::new()))
+                .allow_methods(Any)
+                .allow_headers(Any)
+        }
         Some(origins) => {
-            let header_values: Vec<axum::http::HeaderValue> =
-                origins.iter().filter_map(|o| o.parse().ok()).collect();
+            let mut header_values: Vec<axum::http::HeaderValue> = Vec::with_capacity(origins.len());
+            for origin in origins {
+                match origin.parse::<axum::http::HeaderValue>() {
+                    Ok(hv) => header_values.push(hv),
+                    Err(_) => warn!("Dropping malformed CORS origin: {origin}"),
+                }
+            }
             CorsLayer::new()
                 .allow_origin(AllowOrigin::list(header_values))
                 .allow_methods(Any)
                 .allow_headers(Any)
         }
-        None => CorsLayer::new()
-            .allow_origin(Any)
-            .allow_methods(Any)
-            .allow_headers(Any),
-    };
+    }
+}
+
+fn create_router(state: Arc<AppState>) -> Router {
+    // CORS configuration
+    let cors = build_cors_layer(&state.config.server);
 
     // Rate limiting configuration
     let standard_rate_limit = create_rate_limit_state(standard_rate_limit_config());
@@ -706,4 +752,173 @@ fn create_router(state: Arc<AppState>) -> Router {
         .layer(CompressionLayer::new())
         .layer(cors)
         .with_state(state)
+}
+
+#[cfg(test)]
+mod cors_tests {
+    //! Tests for `build_cors_layer`.
+    //!
+    //! These tests mount the built `CorsLayer` on a minimal router and fire
+    //! real HTTP requests via `tower::ServiceExt::oneshot`. They assert on
+    //! the `Access-Control-Allow-Origin` response header set by the layer —
+    //! which is the contract visible to clients.
+    //!
+    //! The startup warnings themselves are plain `tracing::warn!` calls and
+    //! are validated by inspection of `build_cors_layer` (no log-capture
+    //! infrastructure is worth wiring up for one-line tracing statements).
+    use super::*;
+    use crate::config::ServerConfig;
+    use axum::body::Body;
+    use axum::http::{header, HeaderValue, Method, Request, StatusCode};
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    fn server_config_with(cors: Option<Vec<String>>) -> ServerConfig {
+        ServerConfig {
+            host: "127.0.0.1".to_string(),
+            port: 0,
+            cors_origins: cors,
+        }
+    }
+
+    fn router_with_cors(server: &ServerConfig) -> Router {
+        Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(build_cors_layer(server))
+    }
+
+    fn preflight(origin: &str, method: &str) -> Request<Body> {
+        Request::builder()
+            .method(Method::OPTIONS)
+            .uri("/")
+            .header(header::ORIGIN, origin)
+            .header(header::ACCESS_CONTROL_REQUEST_METHOD, method)
+            .body(Body::empty())
+            .expect("build preflight request")
+    }
+
+    fn simple_get(origin: &str) -> Request<Body> {
+        Request::builder()
+            .method(Method::GET)
+            .uri("/")
+            .header(header::ORIGIN, origin)
+            .body(Body::empty())
+            .expect("build simple GET")
+    }
+
+    #[tokio::test]
+    async fn cors_layer_allows_listed_origin_in_response_headers() {
+        let server = server_config_with(Some(vec!["https://app.nolus.io".to_string()]));
+        let app = router_with_cors(&server);
+
+        let resp = app
+            .oneshot(simple_get("https://app.nolus.io"))
+            .await
+            .expect("service oneshot");
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let allow_origin = resp
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .expect("allow-origin header present for listed origin");
+        assert_eq!(
+            allow_origin,
+            &HeaderValue::from_static("https://app.nolus.io")
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_layer_rejects_unlisted_origin() {
+        let server = server_config_with(Some(vec!["https://app.nolus.io".to_string()]));
+        let app = router_with_cors(&server);
+
+        let resp = app
+            .oneshot(simple_get("https://evil.com"))
+            .await
+            .expect("service oneshot");
+
+        // tower-http CorsLayer strategy: for unlisted origins, no
+        // Access-Control-Allow-Origin header is emitted, so the browser's
+        // same-origin policy rejects the response.
+        let allow_origin = resp.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN);
+        assert_ne!(
+            allow_origin,
+            Some(&HeaderValue::from_static("https://evil.com")),
+            "evil.com must not appear in allow-origin header"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_layer_handles_preflight_options_request() {
+        let server = server_config_with(Some(vec!["https://app.nolus.io".to_string()]));
+        let app = router_with_cors(&server);
+
+        let resp = app
+            .oneshot(preflight("https://app.nolus.io", "POST"))
+            .await
+            .expect("service oneshot");
+
+        // tower-http returns 200 OK for preflight by default.
+        assert!(
+            resp.status() == StatusCode::OK || resp.status() == StatusCode::NO_CONTENT,
+            "preflight should be 200 or 204, got {}",
+            resp.status()
+        );
+        assert!(
+            resp.headers()
+                .contains_key(header::ACCESS_CONTROL_ALLOW_METHODS),
+            "preflight response must include Access-Control-Allow-Methods"
+        );
+    }
+
+    /// Documents the allow-all default: when `CORS_ORIGINS` is unset, every
+    /// origin is allowed. This is the intended default for a public Nolus
+    /// API, and a production warning (`tracing::warn!`) fires at startup to
+    /// nudge operators to lock it down.
+    #[tokio::test]
+    async fn cors_layer_allows_any_when_unconfigured_documented() {
+        let server = server_config_with(None);
+        let app = router_with_cors(&server);
+
+        let resp = app
+            .oneshot(simple_get("https://literally-anywhere.example"))
+            .await
+            .expect("service oneshot");
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let allow_origin = resp
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .expect("allow-origin present when cors_origins=None");
+        // `Any` serializes to the wildcard "*".
+        assert_eq!(allow_origin, &HeaderValue::from_static("*"));
+    }
+
+    /// Documents F7: `CORS_ORIGINS=""` (empty vec) blocks every
+    /// cross-origin request. The startup warning in `build_cors_layer`
+    /// surfaces this to operators; the HTTP-level assertion here confirms
+    /// the layer actually emits no allow-origin header for any caller.
+    #[tokio::test]
+    async fn cors_layer_empty_vec_blocks_cross_origin_requests() {
+        let server = server_config_with(Some(vec![]));
+        let app = router_with_cors(&server);
+
+        for origin in [
+            "https://app.nolus.io",
+            "https://evil.com",
+            "http://localhost:5173",
+        ] {
+            let resp = app
+                .clone()
+                .oneshot(simple_get(origin))
+                .await
+                .expect("service oneshot");
+
+            let allow_origin = resp.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN);
+            assert!(
+                allow_origin.is_none(),
+                "origin {origin} must not be allowed when cors_origins is empty, got {allow_origin:?}"
+            );
+        }
+    }
 }

--- a/backend/src/middleware/admin_auth.rs
+++ b/backend/src/middleware/admin_auth.rs
@@ -10,7 +10,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use std::sync::Arc;
-use tracing::warn;
+use tracing::{error, warn};
 
 use crate::AppState;
 
@@ -64,12 +64,22 @@ pub async fn admin_auth_middleware(
         .into_response();
     }
 
-    // Check if API key is configured
+    // Check if API key is configured.
+    // If admin is enabled but the key is empty, return the same 403 response
+    // as the fully-disabled branch so attackers cannot distinguish the two
+    // cases (no "Admin API key not configured" disclosure). Log loudly for
+    // ops — this is a deploy-time misconfiguration that should be fixed.
+    // `AppConfig::validate()` is expected to reject this at startup, so
+    // reaching this branch in production indicates validation was bypassed.
     if state.config.admin.api_key.is_empty() {
-        warn!("Admin API access attempted but no API key is configured");
+        error!(
+            "Admin API is enabled but ADMIN_API_KEY is empty. \
+             Service will reject all admin requests with 403. \
+             Check deploy environment variables."
+        );
         return AdminAuthError {
-            status: StatusCode::INTERNAL_SERVER_ERROR,
-            message: "Admin API key not configured",
+            status: StatusCode::FORBIDDEN,
+            message: "Admin API is disabled",
         }
         .into_response();
     }
@@ -219,5 +229,185 @@ mod tests {
         };
         let response = error.into_response();
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    // ========================================================================
+    // Middleware integration tests — exercise every branch of
+    // `admin_auth_middleware` end-to-end through an axum Router.
+    // ========================================================================
+
+    use crate::test_utils::{collect_body_str, test_app_state_with_config, test_config_with_admin};
+    use axum::{
+        body::Body,
+        http::{HeaderValue, Request},
+        middleware::from_fn_with_state,
+        routing::get,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    /// Build a minimal router with a single protected route, wired through
+    /// `admin_auth_middleware` with the provided admin config. Returns a
+    /// fully-constructed `Router<()>` ready for `oneshot`.
+    async fn protected_router(enabled: bool, api_key: &str) -> Router {
+        let state = test_app_state_with_config(test_config_with_admin(enabled, api_key)).await;
+        Router::new()
+            .route("/protected", get(|| async { "ok" }))
+            .layer(from_fn_with_state(state.clone(), admin_auth_middleware))
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn admin_auth_middleware_rejects_when_admin_disabled_with_403() {
+        let app = protected_router(false, "").await;
+        let req = Request::builder()
+            .uri("/protected")
+            .body(Body::empty())
+            .expect("valid request");
+
+        let resp = app.oneshot(req).await.expect("router call");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = collect_body_str(resp).await;
+        assert!(
+            body.contains("Admin API is disabled"),
+            "body should use disabled message, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_auth_middleware_rejects_empty_api_key_with_403_not_500_f4_regression() {
+        // F4 regression: previously returned 500 + "Admin API key not configured",
+        // leaking the fact that admin was enabled but misconfigured. Must now
+        // return the same 403 + "Admin API is disabled" as the disabled branch.
+        let app = protected_router(true, "").await;
+        let req = Request::builder()
+            .uri("/protected")
+            .header("Authorization", "Bearer anything")
+            .body(Body::empty())
+            .expect("valid request");
+
+        let resp = app.oneshot(req).await.expect("router call");
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "must return 403, not 500 — see F4"
+        );
+        let body = collect_body_str(resp).await;
+        assert!(
+            body.contains("Admin API is disabled"),
+            "must surface disabled-style message, got: {body}"
+        );
+        assert!(
+            !body.contains("not configured"),
+            "must NOT disclose misconfiguration, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_auth_middleware_rejects_missing_authorization_header_with_401() {
+        let app = protected_router(true, "correct-key").await;
+        let req = Request::builder()
+            .uri("/protected")
+            .body(Body::empty())
+            .expect("valid request");
+
+        let resp = app.oneshot(req).await.expect("router call");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body = collect_body_str(resp).await;
+        assert!(
+            body.contains("Missing Authorization header"),
+            "body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_auth_middleware_rejects_non_utf8_authorization_header_with_401() {
+        let app = protected_router(true, "correct-key").await;
+        // HeaderValue with non-ASCII/non-UTF8 bytes fails `to_str()`.
+        let bad = HeaderValue::from_bytes(&[0xff, 0xfe, 0xfd]).expect("valid header bytes");
+        let req = Request::builder()
+            .uri("/protected")
+            .header("Authorization", bad)
+            .body(Body::empty())
+            .expect("valid request");
+
+        let resp = app.oneshot(req).await.expect("router call");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body = collect_body_str(resp).await;
+        assert!(
+            body.contains("Invalid Authorization header encoding"),
+            "body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_auth_middleware_rejects_wrong_format_header_with_401() {
+        let app = protected_router(true, "correct-key").await;
+        let req = Request::builder()
+            .uri("/protected")
+            .header("Authorization", "Basic xyz")
+            .body(Body::empty())
+            .expect("valid request");
+
+        let resp = app.oneshot(req).await.expect("router call");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body = collect_body_str(resp).await;
+        assert!(
+            body.contains("Invalid Authorization header format"),
+            "body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_auth_middleware_rejects_wrong_token_with_401() {
+        let app = protected_router(true, "correct").await;
+        let req = Request::builder()
+            .uri("/protected")
+            .header("Authorization", "Bearer wrong")
+            .body(Body::empty())
+            .expect("valid request");
+
+        let resp = app.oneshot(req).await.expect("router call");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body = collect_body_str(resp).await;
+        assert!(body.contains("Invalid API key"), "body: {body}");
+    }
+
+    #[tokio::test]
+    async fn admin_auth_middleware_allows_correct_bearer_token_with_200() {
+        let app = protected_router(true, "correct").await;
+        let req = Request::builder()
+            .uri("/protected")
+            .header("Authorization", "Bearer correct")
+            .body(Body::empty())
+            .expect("valid request");
+
+        let resp = app.oneshot(req).await.expect("router call");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = collect_body_str(resp).await;
+        assert_eq!(body, "ok");
+    }
+
+    #[tokio::test]
+    async fn admin_auth_middleware_does_not_disclose_misconfig_in_response_body_f4() {
+        // Hardened assertion: even with a seemingly-plausible auth header,
+        // the empty-api-key branch must not hint at the misconfiguration.
+        let app = protected_router(true, "").await;
+        let req = Request::builder()
+            .uri("/protected")
+            .header("Authorization", "Bearer some-token")
+            .body(Body::empty())
+            .expect("valid request");
+
+        let resp = app.oneshot(req).await.expect("router call");
+        let body = collect_body_str(resp).await.to_lowercase();
+        assert!(
+            !body.contains("not configured"),
+            "body must not disclose misconfig ('not configured'), got: {body}"
+        );
+        assert!(
+            !body.contains("api_key"),
+            "body must not mention api_key internals, got: {body}"
+        );
     }
 }

--- a/backend/src/middleware/rate_limit.rs
+++ b/backend/src/middleware/rate_limit.rs
@@ -498,4 +498,222 @@ mod tests {
 
         assert_eq!(state.limiters.read().await.len(), 1);
     }
+
+    // ---------------------------------------------------------------------
+    // extract_client_ip direct tests
+    //
+    // These exercise the module-private `extract_client_ip` helper. They
+    // document the current "trust headers first, fall back to ConnectInfo"
+    // policy. See `extract_client_ip_trusts_xff_unconditionally_intentional`
+    // below for the security rationale.
+    // ---------------------------------------------------------------------
+
+    use axum::http::Request as HttpRequest;
+
+    fn req_with_headers(headers: &[(&str, &str)]) -> HttpRequest<()> {
+        let mut builder = HttpRequest::builder().uri("/");
+        for (k, v) in headers {
+            builder = builder.header(*k, *v);
+        }
+        builder
+            .body(())
+            .expect("request builder cannot fail with valid headers")
+    }
+
+    #[test]
+    fn extract_client_ip_returns_xff_first_ip_when_header_present() {
+        let req = req_with_headers(&[("x-forwarded-for", "1.2.3.4, 5.6.7.8")]);
+        let ip = extract_client_ip(&req, None);
+        assert_eq!(ip, Some(Ipv4Addr::new(1, 2, 3, 4).into()));
+    }
+
+    #[test]
+    fn extract_client_ip_returns_x_real_ip_when_only_that_header_present() {
+        let req = req_with_headers(&[("x-real-ip", "10.0.0.1")]);
+        let ip = extract_client_ip(&req, None);
+        assert_eq!(ip, Some(Ipv4Addr::new(10, 0, 0, 1).into()));
+    }
+
+    #[test]
+    fn extract_client_ip_prefers_xff_over_x_real_ip() {
+        let req = req_with_headers(&[("x-forwarded-for", "1.2.3.4"), ("x-real-ip", "9.9.9.9")]);
+        let ip = extract_client_ip(&req, None);
+        assert_eq!(ip, Some(Ipv4Addr::new(1, 2, 3, 4).into()));
+    }
+
+    #[test]
+    fn extract_client_ip_returns_connect_info_when_no_headers() {
+        let req = req_with_headers(&[]);
+        let addr: SocketAddr = "127.0.0.1:8080"
+            .parse()
+            .expect("hard-coded socket addr parses");
+        let ci = ConnectInfo(addr);
+        let ip = extract_client_ip(&req, Some(&ci));
+        assert_eq!(ip, Some(Ipv4Addr::new(127, 0, 0, 1).into()));
+    }
+
+    #[test]
+    fn extract_client_ip_returns_none_when_no_headers_and_no_connect_info() {
+        let req = req_with_headers(&[]);
+        assert_eq!(extract_client_ip(&req, None), None);
+    }
+
+    #[test]
+    fn extract_client_ip_rejects_malformed_xff_and_falls_back_to_x_real_ip() {
+        // NOTE: this documents a known quirk in the current implementation —
+        // a malformed XFF *first hop* falls through to X-Real-IP only because
+        // the XFF branch uses `.next()` + parse; if the *first* IP fails to
+        // parse the entire header is abandoned. That happens to give us the
+        // X-Real-IP fallback. Test asserts the observable behavior.
+        let req = req_with_headers(&[("x-forwarded-for", "not-an-ip"), ("x-real-ip", "1.2.3.4")]);
+        let ip = extract_client_ip(&req, None);
+        assert_eq!(ip, Some(Ipv4Addr::new(1, 2, 3, 4).into()));
+    }
+
+    #[test]
+    fn extract_client_ip_trims_whitespace_in_xff_chain() {
+        let req = req_with_headers(&[("x-forwarded-for", "  1.2.3.4  , 5.6.7.8  ")]);
+        let ip = extract_client_ip(&req, None);
+        assert_eq!(ip, Some(Ipv4Addr::new(1, 2, 3, 4).into()));
+    }
+
+    /// Documents intentional behavior: `X-Forwarded-For` is trusted unconditionally
+    /// for rate-limit bookkeeping. This is NOT a security boundary — IP-based rate
+    /// limiting is a blunt control applied uniformly to all connections. Nginx +
+    /// authentication + CORS are the real security boundaries.
+    ///
+    /// If you're considering changing this to fail-closed without headers, first
+    /// wire ConnectInfo through the router at main.rs::create_router (currently
+    /// hardcoded `None`), otherwise you'll reject all requests.
+    #[test]
+    fn extract_client_ip_trusts_xff_unconditionally_intentional() {
+        // An attacker-controlled XFF value is returned verbatim. That's fine
+        // here: the rate limiter treats the claimed IP as a bucket key; a
+        // user who forges XFF only moves themselves between buckets and does
+        // not gain any privileged access.
+        let req = req_with_headers(&[("x-forwarded-for", "192.168.100.100")]);
+        let ip = extract_client_ip(&req, None);
+        assert_eq!(ip, Some(Ipv4Addr::new(192, 168, 100, 100).into()));
+    }
+
+    // ---------------------------------------------------------------------
+    // rate_limit_middleware end-to-end tests
+    // ---------------------------------------------------------------------
+
+    use axum::body::Body;
+    use axum::middleware as axum_middleware;
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
+
+    fn handler_router(state: Arc<RateLimitState>) -> Router {
+        Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(axum_middleware::from_fn(move |req, next| {
+                let state = state.clone();
+                async move { rate_limit_middleware(state, None, req, next).await }
+            }))
+    }
+
+    fn request_from(ip: &str) -> axum::http::Request<Body> {
+        axum::http::Request::builder()
+            .uri("/")
+            .header("x-forwarded-for", ip)
+            .body(Body::empty())
+            .expect("request builder cannot fail with valid header")
+    }
+
+    #[tokio::test]
+    async fn rate_limit_middleware_accepts_request_with_valid_xff() {
+        let state = create_rate_limit_state(RateLimitConfig {
+            requests_per_second: 10,
+            burst_size: 20,
+            enabled: true,
+            whitelist: vec![],
+        });
+        let app = handler_router(state);
+
+        let resp = app
+            .oneshot(request_from("1.2.3.4"))
+            .await
+            .expect("service oneshot");
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn rate_limit_middleware_rejects_with_429_when_no_ip_extractable() {
+        let state = create_rate_limit_state(RateLimitConfig {
+            requests_per_second: 10,
+            burst_size: 20,
+            enabled: true,
+            whitelist: vec![],
+        });
+        let app = handler_router(state);
+
+        let req = axum::http::Request::builder()
+            .uri("/")
+            .body(Body::empty())
+            .expect("request builder cannot fail");
+        let resp = app.oneshot(req).await.expect("service oneshot");
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn rate_limit_middleware_rejects_with_429_when_rate_exceeded() {
+        let state = create_rate_limit_state(RateLimitConfig {
+            requests_per_second: 1,
+            burst_size: 1,
+            enabled: true,
+            whitelist: vec![],
+        });
+        let app = handler_router(state);
+
+        // First request: allowed by burst.
+        let r1 = app
+            .clone()
+            .oneshot(request_from("7.7.7.7"))
+            .await
+            .expect("oneshot 1");
+        assert_eq!(r1.status(), StatusCode::OK);
+
+        // Second request: burst exhausted, governor refuses immediately.
+        let r2 = app
+            .clone()
+            .oneshot(request_from("7.7.7.7"))
+            .await
+            .expect("oneshot 2");
+        assert_eq!(r2.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        // Third request: still limited.
+        let r3 = app
+            .oneshot(request_from("7.7.7.7"))
+            .await
+            .expect("oneshot 3");
+        assert_eq!(r3.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn rate_limit_middleware_allows_whitelisted_ip_past_limit() {
+        let whitelisted: IpAddr = Ipv4Addr::new(1, 2, 3, 4).into();
+        let state = create_rate_limit_state(RateLimitConfig {
+            requests_per_second: 1,
+            burst_size: 1,
+            enabled: true,
+            whitelist: vec![whitelisted],
+        });
+        let app = handler_router(state);
+
+        for i in 0..10 {
+            let resp = app
+                .clone()
+                .oneshot(request_from("1.2.3.4"))
+                .await
+                .expect("oneshot");
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "whitelisted request {i} must pass"
+            );
+        }
+    }
 }

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -1,0 +1,179 @@
+//! Test-only helpers for constructing minimal AppState instances and
+//! reading axum response bodies in integration tests.
+//!
+//! Gated `#[cfg(test)]` — never compiled in release builds.
+//! Keep this file LEAN. Phase 0 deleted 433 LOC of unused factory code;
+//! only add what's actively used.
+
+#![cfg(test)]
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::response::Response;
+use http_body_util::BodyExt;
+
+use crate::config::{AdminConfig, AppConfig, ExternalApiConfig, ProtocolsConfig, ServerConfig};
+use crate::config_store::ConfigStore;
+use crate::data_cache::AppDataCache;
+use crate::external;
+use crate::handlers::websocket::WebSocketManager;
+use crate::translations::{
+    llm::{LlmClient, LlmConfig},
+    TranslationStorage,
+};
+use crate::AppState;
+
+/// Minimal AppConfig with safe defaults: admin disabled, `127.0.0.1:1` stub
+/// URLs for every external API (unroutable — no DNS, fast fail), no CORS.
+pub fn test_config() -> AppConfig {
+    AppConfig {
+        server: ServerConfig {
+            host: "127.0.0.1".to_string(),
+            port: 0,
+            cors_origins: None,
+        },
+        external: ExternalApiConfig {
+            etl_api_url: "http://127.0.0.1:1/".to_string(),
+            skip_api_url: "http://127.0.0.1:1/".to_string(),
+            skip_api_key: None,
+            nolus_rpc_url: "http://127.0.0.1:1/".to_string(),
+            nolus_rest_url: "http://127.0.0.1:1/".to_string(),
+            referral_api_url: "http://127.0.0.1:1/".to_string(),
+            referral_api_token: "stub".to_string(),
+            zero_interest_api_url: "http://127.0.0.1:1/".to_string(),
+            zero_interest_api_token: "stub".to_string(),
+            intercom_app_id: "stub".to_string(),
+            intercom_secret_key: "stub".to_string(),
+        },
+        admin: AdminConfig {
+            enabled: false,
+            api_key: String::new(),
+        },
+        protocols: ProtocolsConfig::default(),
+    }
+}
+
+/// Config helper for admin middleware tests.
+pub fn test_config_with_admin(enabled: bool, api_key: &str) -> AppConfig {
+    let mut c = test_config();
+    c.admin.enabled = enabled;
+    c.admin.api_key = api_key.to_string();
+    c
+}
+
+/// Default minimal AppState (admin disabled).
+pub async fn test_app_state() -> Arc<AppState> {
+    test_app_state_with_config(test_config()).await
+}
+
+/// Build an AppState with the given config. All external clients are
+/// constructed with unroutable `127.0.0.1:1` stub URLs — tests must never
+/// trigger actual HTTP calls on this state. Tempdirs backing ConfigStore /
+/// TranslationStorage are kept alive via `TempDir::keep()` (no
+/// `mem::forget`), so the paths persist for the test binary's lifetime.
+pub async fn test_app_state_with_config(config: AppConfig) -> Arc<AppState> {
+    // 1ms timeout is fine here: stub URLs resolve to 127.0.0.1 (no DNS),
+    // and tests must never actually issue HTTP calls on this state.
+    let http_client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(1))
+        .build()
+        .expect("reqwest client builder cannot fail with only a timeout set");
+
+    let etl_client =
+        external::etl::EtlClient::new(config.external.etl_api_url.clone(), http_client.clone());
+    let skip_client = external::skip::SkipClient::new(
+        config.external.skip_api_url.clone(),
+        config.external.skip_api_key.clone(),
+        http_client.clone(),
+    );
+    let chain_client = external::chain::ChainClient::new(
+        config.external.nolus_rest_url.clone(),
+        http_client.clone(),
+    );
+    let referral_client = external::referral::ReferralClient::new(&config, http_client.clone());
+    let zero_interest_client =
+        external::zero_interest::ZeroInterestClient::new(&config, http_client.clone());
+
+    // ConfigStore + TranslationStorage need real directories. Use tempdirs
+    // and leak the guard via `TempDir::keep()` so the dir survives for the
+    // lifetime of the test binary (AppState clones outlive the test fn).
+    let config_dir = tempfile::tempdir().expect("tempdir for ConfigStore").keep();
+    let config_store = ConfigStore::new(&config_dir);
+    config_store
+        .init()
+        .await
+        .expect("ConfigStore init failed in test_utils");
+
+    let translation_dir = tempfile::tempdir()
+        .expect("tempdir for TranslationStorage")
+        .keep();
+    let translation_storage = TranslationStorage::new(&translation_dir);
+    translation_storage
+        .init()
+        .await
+        .expect("TranslationStorage init failed in test_utils");
+
+    let llm_client = LlmClient::new(LlmConfig {
+        api_key: String::new(),
+        model: "stub".to_string(),
+        base_url: Some("http://127.0.0.1:1/".to_string()),
+    });
+
+    Arc::new(AppState {
+        config,
+        etl_client,
+        skip_client,
+        chain_client,
+        referral_client,
+        zero_interest_client,
+        data_cache: AppDataCache::new(),
+        ws_manager: WebSocketManager::new(16),
+        config_store,
+        translation_storage,
+        llm_client,
+        startup_time: Instant::now(),
+    })
+}
+
+/// Collect an axum response body to bytes.
+pub async fn collect_body(resp: Response) -> Vec<u8> {
+    resp.into_body()
+        .collect()
+        .await
+        .expect("response body collection failed")
+        .to_bytes()
+        .to_vec()
+}
+
+/// Convenience: collect and UTF-8 decode.
+pub async fn collect_body_str(resp: Response) -> String {
+    String::from_utf8(collect_body(resp).await).expect("response body not valid UTF-8")
+}
+
+#[cfg(test)]
+mod smoke {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_utils_factory_produces_valid_app_state() {
+        let state = test_app_state().await;
+        assert!(!state.config.admin.enabled);
+        assert_eq!(state.config.admin.api_key, "");
+    }
+
+    #[tokio::test]
+    async fn test_utils_factory_with_admin_enabled() {
+        let state = test_app_state_with_config(test_config_with_admin(true, "secret123")).await;
+        assert!(state.config.admin.enabled);
+        assert_eq!(state.config.admin.api_key, "secret123");
+    }
+
+    #[tokio::test]
+    async fn collect_body_reads_bytes() {
+        use axum::response::IntoResponse;
+        let resp = "hello".into_response();
+        let body = collect_body(resp).await;
+        assert_eq!(body, b"hello");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the 6-phase test-suite remediation. Focus: Rust backend security boundary tests + two targeted source fixes. Stacks on top of #119 (Phase 1). GitHub will auto-retarget to `main` when Phase 0/1 merge.

## Scope revised vs original plan (per user direction)

**DROPPED:**
- Error sanitization — detailed errors preserved intentionally (better UX + faster debugging; no secrets in error strings since API keys travel in headers, not URLs). Tests now document the non-sanitization contract and will trip if anyone adds it.
- `TRUSTED_PROXIES` defense-in-depth — IP-based rate limiting is by-design a blunt uniform control; nginx + auth + CORS are the real security boundaries.

## Source fixes

### F4 — admin auth info disclosure
`src/middleware/admin_auth.rs` — when `admin.enabled=true && admin.api_key.is_empty()`, middleware now returns 403 "Admin API is disabled" (matching the disabled branch) instead of 500 "Admin API key not configured". Attackers cannot distinguish misconfig from disabled. `tracing::error!` logs the misconfig for ops visibility.

### Startup validation wired (MEDIUM finding from Security Review)
`src/main.rs` — `AppConfig::validate()` was defined but **never called**. Now called after `AppConfig::load()`; service refuses to start on config errors (e.g., admin enabled without api_key) and logs warnings. Turns the middleware 403 into a proper defense-in-depth backstop rather than the only line of defense.

### C2 — spa.rs unwrap cleanup
`src/handlers/spa.rs` — 4 `.unwrap()` → `.expect("<reason>")`. All were Infallible (`ServeDir::Error`) or static-literal safe. Pure text change documenting the invariants.

### H2 — CORS silent defaults made visible
`src/main.rs` — `build_cors_layer` extracted; `tracing::warn!` fires for (a) `CORS_ORIGINS` unset (still allow-all — public API default), (b) malformed origin silently dropped (was fully silent), (c) empty list (`CORS_ORIGINS=""` blocks all cross-origin).

## Tests added: +52 (backend total: 163 → 215)

| File | New tests | What |
|---|---|---|
| `admin_auth.rs` | 8 | Middleware E2E for all 6 branches + F4 regression + misconfig-non-disclosure |
| `config.rs` | 3 | `validate()` matrix over admin enabled × api_key |
| `error.rs` | 17 | Every AppError variant → response mapping, From<anyhow>/From<reqwest>, envelope structure, explicit behavior-preservation tests for `Internal` / `ExternalApi` |
| `rate_limit.rs` | 12 | `extract_client_ip` all branches, middleware E2E, XFF intentional-trust documentation test |
| `main.rs` | 5 | CORS layer: listed origin, unlisted origin, preflight, unconfigured-allow-all, empty-vec-block-all |
| `spa.rs` | 4 | Fallback tests: 404→index.html, static file, no-cache header, 200 status rewrite |
| `test_utils.rs` | 3 | Factory smoke tests |

## Test infrastructure

- `http-body-util = "0.1"` dev-dep for collecting axum Response bodies
- `backend/src/test_utils.rs` (~180 LOC, `#[cfg(test)]`-gated) — `test_app_state()` factory, `collect_body` / `collect_body_str` helpers. Uses `TempDir::keep()` (not `mem::forget`) and `http://127.0.0.1:1/` stub URLs (no DNS).
- `#[cfg(test)] mod test_utils;` restored in `main.rs` (the 433-LOC predecessor deleted in Phase 0 had 0 external callers; this version is lean and actually used)

## Audit findings addressed

- **C2** spa.rs unwraps → resolved (typed `.expect()` with Infallible invariants documented)
- **F4** admin auth info disclosure → resolved (403 + ops log)
- **H2** CORS silent defaults → resolved (warnings + tests)
- **H3** admin_auth middleware never tested E2E → resolved (8 tests cover all branches)
- **NEW MEDIUM** (surfaced during Security Review): `AppConfig::validate()` never called at startup → resolved (service refuses to boot on config errors)

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo build --all-targets` clean
- [x] `cargo test --all-targets` — 215/215 pass
- [x] Pre-mortem (identified 5 HIGH/CRITICAL risks → incorporated into revised plan)
- [x] Scope Guard: PASS (no silent drops, no `trusted_proxies` in diff, `error.rs` IntoResponse byte-identical to base)
- [x] Diff Reviewer: PASS (2 minor cosmetic findings noted, not blocking)
- [x] Security Review: MEDIUM finding surfaced (`validate()` never called) → fixed in this PR
- [x] Husky pre-commit hook: frontend lint + test (271) + build — all green

## Non-blocking items for future phases

- Minor: `cors_layer_rejects_unlisted_origin` could use `assert!(header.is_none())` for stricter check than `assert_ne!`
- Cosmetic: overlap between existing `test_validate_admin_enabled_no_key` and new `validate_rejects_admin_enabled_without_api_key`
- Low: `CORS_ORIGINS=""` vs unset produces opposite behaviors (block-all vs allow-all) — documented via tests but could add comment at config parsing site

## Next phases

- Phase 3: state & data integrity (Pinia stores, `data_cache.rs`, `refresh.rs`, external client malformed-response tests)
- Phase 4: wallet & signing paths
- Phase 5: end-to-end HTTP + WS handler tests (backend)
- Phase 6: component & view integration (frontend Vue components)