### PR TITLE
test: Phase 4 — wallet & signing paths

### DIFF
--- a/src/common/composables/useAsyncOperation.test.ts
+++ b/src/common/composables/useAsyncOperation.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useAsyncOperation } from "./useAsyncOperation";
+import { ApiError } from "@/common/api/types/common";
+
+describe("useAsyncOperation", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("starts with loading=false, empty error, and null errorDetails", () => {
+    const { loading, error, errorDetails } = useAsyncOperation();
+    expect(loading.value).toBe(false);
+    expect(error.value).toBe("");
+    expect(errorDetails.value).toBeNull();
+  });
+
+  it("flips loading to true during the call, then back to false after success", async () => {
+    const { loading, run } = useAsyncOperation();
+    let loadingDuring = false;
+    const result = await run(async () => {
+      loadingDuring = loading.value;
+      return "ok";
+    });
+    expect(loadingDuring).toBe(true);
+    expect(loading.value).toBe(false);
+    expect(result).toBe("ok");
+  });
+
+  it("resets error + errorDetails at the start of a new run", async () => {
+    const { error, errorDetails, run } = useAsyncOperation();
+    await run(async () => {
+      throw new Error("first");
+    });
+    expect(error.value).toBe("first");
+    expect(errorDetails.value?.message).toBe("first");
+
+    // next run — state should reset even before the callback runs
+    let errDuring = "not-reset";
+    let detailsDuring: unknown = "not-reset";
+    await run(async () => {
+      errDuring = error.value;
+      detailsDuring = errorDetails.value;
+      return 1;
+    });
+    expect(errDuring).toBe("");
+    expect(detailsDuring).toBeNull();
+  });
+
+  it("populates ApiError fields (status, code) in errorDetails", async () => {
+    const { error, errorDetails, run } = useAsyncOperation();
+    const result = await run(async () => {
+      throw new ApiError(429, "rate_limited", "slow down");
+    });
+    expect(result).toBeNull();
+    expect(error.value).toBe("slow down");
+    expect(errorDetails.value).toEqual({ message: "slow down", status: 429, code: "rate_limited" });
+  });
+
+  it("for non-ApiError, errorDetails omits status and code", async () => {
+    const { errorDetails, run } = useAsyncOperation();
+    await run(async () => {
+      throw new Error("boom");
+    });
+    expect(errorDetails.value).toEqual({ message: "boom" });
+    expect(errorDetails.value).not.toHaveProperty("status");
+  });
+
+  it("wraps non-Error thrown values (string, number) into Error messages", async () => {
+    const { error, errorDetails, run } = useAsyncOperation();
+    await run(async () => {
+      throw "just a string";
+    });
+    expect(error.value).toBe("just a string");
+    expect(errorDetails.value?.message).toBe("just a string");
+  });
+
+  it("logs caught exceptions to console.error", async () => {
+    const { run } = useAsyncOperation();
+    const err = new Error("logged");
+    await run(async () => {
+      throw err;
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledWith("[useAsyncOperation]", err);
+  });
+
+  it("always resets loading to false, even when the callback throws", async () => {
+    const { loading, run } = useAsyncOperation();
+    await run(async () => {
+      throw new Error("x");
+    });
+    expect(loading.value).toBe(false);
+  });
+});

--- a/src/common/utils/SkipRoute.test.ts
+++ b/src/common/utils/SkipRoute.test.ts
@@ -1,6 +1,26 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SkipRouter } from "./SkipRoute";
 import type { SkipMsg } from "@/common/api/types/swap";
+import { BackendApi } from "@/common/api";
+import { fetchNetworkStatus } from "./ConfigService";
+
+vi.mock("@/common/api", () => ({
+  BackendApi: {
+    getSkipChains: vi.fn(),
+    getSkipRoute: vi.fn(),
+    getSkipMessages: vi.fn(),
+    getSkipStatus: vi.fn(),
+    trackSkipTransaction: vi.fn()
+  }
+}));
+
+vi.mock("./ConfigService", () => ({
+  fetchNetworkStatus: vi.fn()
+}));
+
+vi.mock("@/i18n", () => ({
+  i18n: { t: (k: string) => k }
+}));
 
 // Test getTx returns a properly constructed message for each supported type
 // and that MsgExecuteContract (the C1 regression) now builds instead of throwing.
@@ -114,5 +134,377 @@ describe("SkipRouter.getTx", () => {
       funds: []
     };
     expect(() => SkipRouter.getTx(msg, msgJSON)).toThrow(/unexpected msg type/);
+  });
+});
+
+describe("SkipRouter.getRoute — revert flag is always set to true on the response", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Preload the static chainId to avoid the network-status fetch during getClient()
+    (fetchNetworkStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      result: { node_info: { network: "nolus-1" } }
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sets route.revert = true even when the backend omits it", async () => {
+    (BackendApi.getSkipRoute as ReturnType<typeof vi.fn>).mockResolvedValue({
+      chain_ids: [],
+      operations: [],
+      amount_in: "1",
+      amount_out: "2",
+      source_asset_denom: "a",
+      dest_asset_denom: "b",
+      source_asset_chain_id: "c1",
+      dest_asset_chain_id: "c2"
+    });
+    const route = await SkipRouter.getRoute("a", "b", "1", false, "c1", "c2");
+    expect(route.revert).toBe(true);
+  });
+
+  it("forces revert=true even when revert=true was passed (path sets amount_out)", async () => {
+    (BackendApi.getSkipRoute as ReturnType<typeof vi.fn>).mockResolvedValue({
+      chain_ids: [],
+      operations: [],
+      revert: false, // backend says false — we MUST override to true
+      amount_in: "1",
+      amount_out: "1",
+      source_asset_denom: "a",
+      dest_asset_denom: "b",
+      source_asset_chain_id: "c1",
+      dest_asset_chain_id: "c2"
+    });
+    const route = await SkipRouter.getRoute("a", "b", "1", true);
+    expect(route.revert).toBe(true);
+    const req = (BackendApi.getSkipRoute as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(req.amount_out).toBe("1");
+    expect(req.amount_in).toBeUndefined();
+  });
+
+  it("sends amount_in when revert=false", async () => {
+    (BackendApi.getSkipRoute as ReturnType<typeof vi.fn>).mockResolvedValue({
+      chain_ids: [],
+      operations: [],
+      amount_in: "1",
+      amount_out: "2",
+      source_asset_denom: "a",
+      dest_asset_denom: "b",
+      source_asset_chain_id: "c1",
+      dest_asset_chain_id: "c2"
+    });
+    await SkipRouter.getRoute("a", "b", "10", false);
+    const req = (BackendApi.getSkipRoute as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(req.amount_in).toBe("10");
+    expect(req.amount_out).toBeUndefined();
+  });
+});
+
+describe("SkipRouter.submitRoute / transaction()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mkWallet(address: string) {
+    return {
+      address,
+      simulateMultiTx: vi.fn().mockResolvedValue({
+        txHash: "deadbeef",
+        txBytes: new Uint8Array([1, 2, 3]),
+        usedFee: {}
+      })
+    };
+  }
+
+  it("invokes simulateMultiTx per tx and callback with (txData, wallet, chainId)", async () => {
+    const wNolus = mkWallet("nolus1a");
+    const wOsmo = mkWallet("osmo1a");
+
+    (BackendApi.getSkipMessages as ReturnType<typeof vi.fn>).mockResolvedValue({
+      txs: [
+        {
+          cosmos_tx: {
+            chain_id: "osmosis-1",
+            msgs: [
+              {
+                msg_type_url: "/cosmos.bank.v1beta1.MsgSend",
+                msg: JSON.stringify({
+                  from_address: "osmo1a",
+                  to_address: "osmo1b",
+                  amount: [{ denom: "uosmo", amount: "1" }]
+                })
+              }
+            ]
+          }
+        }
+      ]
+    });
+
+    const callback = vi.fn().mockResolvedValue(undefined);
+    const route = {
+      chain_ids: ["osmosis-1"],
+      revert: true,
+      operations: [],
+      amount_in: "1",
+      amount_out: "2",
+      source_asset_denom: "a",
+      dest_asset_denom: "b",
+      source_asset_chain_id: "c1",
+      dest_asset_chain_id: "c2"
+    };
+
+    await SkipRouter.submitRoute(
+      route as unknown as Parameters<typeof SkipRouter.submitRoute>[0],
+      { "nolus-1": wNolus, "osmosis-1": wOsmo } as unknown as Parameters<typeof SkipRouter.submitRoute>[1],
+      callback
+    );
+
+    expect(wOsmo.simulateMultiTx).toHaveBeenCalledTimes(1);
+    const msgs = wOsmo.simulateMultiTx.mock.calls[0][0];
+    expect(msgs[0].msgTypeUrl).toBe("/cosmos.bank.v1beta1.MsgSend");
+    expect(msgs[0].msg.fromAddress).toBe("osmo1a");
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0][1]).toBe(wOsmo);
+    expect(callback.mock.calls[0][2]).toBe("osmosis-1");
+  });
+
+  it("when route.revert=true passes amount_in/amount_out from the route as-is", async () => {
+    (BackendApi.getSkipMessages as ReturnType<typeof vi.fn>).mockResolvedValue({ txs: [] });
+    const route = {
+      chain_ids: [],
+      revert: true,
+      operations: [],
+      amount_in: "IN",
+      amount_out: "OUT",
+      source_asset_denom: "SRC",
+      dest_asset_denom: "DST",
+      source_asset_chain_id: "c1",
+      dest_asset_chain_id: "c2"
+    };
+    await SkipRouter.submitRoute(
+      route as unknown as Parameters<typeof SkipRouter.submitRoute>[0],
+      {},
+      vi.fn()
+    );
+    const req = (BackendApi.getSkipMessages as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(req.amount_in).toBe("IN");
+    expect(req.amount_out).toBe("OUT");
+  });
+
+  it("builds address_list in route.chain_ids order", async () => {
+    (BackendApi.getSkipMessages as ReturnType<typeof vi.fn>).mockResolvedValue({ txs: [] });
+    const route = {
+      chain_ids: ["nolus-1", "osmosis-1"],
+      revert: true,
+      operations: [],
+      amount_in: "1",
+      amount_out: "2",
+      source_asset_denom: "a",
+      dest_asset_denom: "b",
+      source_asset_chain_id: "c1",
+      dest_asset_chain_id: "c2"
+    };
+    const nolus = mkWallet("nolus1X");
+    const osmo = mkWallet("osmo1X");
+    await SkipRouter.submitRoute(
+      route as unknown as Parameters<typeof SkipRouter.submitRoute>[0],
+      { "nolus-1": nolus, "osmosis-1": osmo } as unknown as Parameters<typeof SkipRouter.submitRoute>[1],
+      vi.fn()
+    );
+    const req = (BackendApi.getSkipMessages as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(req.address_list).toEqual(["nolus1X", "osmo1X"]);
+  });
+
+  it("handles MsgTransfer in the response", async () => {
+    const w = mkWallet("nolus1a");
+    (BackendApi.getSkipMessages as ReturnType<typeof vi.fn>).mockResolvedValue({
+      txs: [
+        {
+          cosmos_tx: {
+            chain_id: "nolus-1",
+            msgs: [
+              {
+                msg_type_url: "/ibc.applications.transfer.v1.MsgTransfer",
+                msg: JSON.stringify({
+                  source_port: "transfer",
+                  source_channel: "channel-0",
+                  sender: "nolus1a",
+                  receiver: "osmo1b",
+                  token: { denom: "unls", amount: "1" },
+                  timeout_timestamp: "1"
+                })
+              }
+            ]
+          }
+        }
+      ]
+    });
+    const route = {
+      chain_ids: ["nolus-1"],
+      revert: true,
+      operations: [],
+      amount_in: "1",
+      amount_out: "2",
+      source_asset_denom: "a",
+      dest_asset_denom: "b",
+      source_asset_chain_id: "c1",
+      dest_asset_chain_id: "c2"
+    };
+    await SkipRouter.submitRoute(
+      route as unknown as Parameters<typeof SkipRouter.submitRoute>[0],
+      { "nolus-1": w } as unknown as Parameters<typeof SkipRouter.submitRoute>[1],
+      vi.fn()
+    );
+    const msg = w.simulateMultiTx.mock.calls[0][0][0];
+    expect(msg.msgTypeUrl).toBe("/ibc.applications.transfer.v1.MsgTransfer");
+    expect(msg.msg.sourceChannel).toBe("channel-0");
+  });
+
+  it("propagates wallet.simulateMultiTx errors (no silent swallow)", async () => {
+    const w = {
+      address: "nolus1a",
+      simulateMultiTx: vi.fn().mockRejectedValue(new Error("sim failed"))
+    };
+    (BackendApi.getSkipMessages as ReturnType<typeof vi.fn>).mockResolvedValue({
+      txs: [
+        {
+          cosmos_tx: {
+            chain_id: "nolus-1",
+            msgs: [
+              {
+                msg_type_url: "/cosmos.bank.v1beta1.MsgSend",
+                msg: JSON.stringify({ from_address: "a", to_address: "b", amount: [] })
+              }
+            ]
+          }
+        }
+      ]
+    });
+    const route = {
+      chain_ids: ["nolus-1"],
+      revert: true,
+      operations: [],
+      amount_in: "1",
+      amount_out: "2",
+      source_asset_denom: "a",
+      dest_asset_denom: "b",
+      source_asset_chain_id: "c1",
+      dest_asset_chain_id: "c2"
+    };
+    await expect(
+      SkipRouter.submitRoute(
+        route as unknown as Parameters<typeof SkipRouter.submitRoute>[0],
+        { "nolus-1": w } as unknown as Parameters<typeof SkipRouter.submitRoute>[1],
+        vi.fn()
+      )
+    ).rejects.toThrow(/sim failed/);
+  });
+
+  it("callback errors propagate (don't swallow user callback failures)", async () => {
+    const w = mkWallet("nolus1a");
+    (BackendApi.getSkipMessages as ReturnType<typeof vi.fn>).mockResolvedValue({
+      txs: [
+        {
+          cosmos_tx: {
+            chain_id: "nolus-1",
+            msgs: [
+              {
+                msg_type_url: "/cosmos.bank.v1beta1.MsgSend",
+                msg: JSON.stringify({ from_address: "a", to_address: "b", amount: [] })
+              }
+            ]
+          }
+        }
+      ]
+    });
+    const route = {
+      chain_ids: ["nolus-1"],
+      revert: true,
+      operations: [],
+      amount_in: "1",
+      amount_out: "2",
+      source_asset_denom: "a",
+      dest_asset_denom: "b",
+      source_asset_chain_id: "c1",
+      dest_asset_chain_id: "c2"
+    };
+    await expect(
+      SkipRouter.submitRoute(
+        route as unknown as Parameters<typeof SkipRouter.submitRoute>[0],
+        { "nolus-1": w } as unknown as Parameters<typeof SkipRouter.submitRoute>[1],
+        vi.fn().mockRejectedValue(new Error("cb boom"))
+      )
+    ).rejects.toThrow(/cb boom/);
+  });
+
+  it("handles empty txs list (no wallet calls)", async () => {
+    (BackendApi.getSkipMessages as ReturnType<typeof vi.fn>).mockResolvedValue({ txs: [] });
+    const route = {
+      chain_ids: [],
+      revert: true,
+      operations: [],
+      amount_in: "1",
+      amount_out: "2",
+      source_asset_denom: "a",
+      dest_asset_denom: "b",
+      source_asset_chain_id: "c1",
+      dest_asset_chain_id: "c2"
+    };
+    const cb = vi.fn();
+    await SkipRouter.submitRoute(
+      route as unknown as Parameters<typeof SkipRouter.submitRoute>[0],
+      {},
+      cb
+    );
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+describe("SkipRouter.fetchStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns status on STATE_COMPLETED_SUCCESS", async () => {
+    (BackendApi.getSkipStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: "STATE_COMPLETED_SUCCESS",
+      error: ""
+    });
+    const res = await SkipRouter.fetchStatus("hash", "chain");
+    expect(res.state).toBe("STATE_COMPLETED_SUCCESS");
+  });
+
+  it("throws on STATE_ABANDONED", async () => {
+    (BackendApi.getSkipStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: "STATE_ABANDONED",
+      error: ""
+    });
+    await expect(SkipRouter.fetchStatus("h", "c")).rejects.toThrow();
+  });
+
+  it("throws on STATE_COMPLETED_ERROR", async () => {
+    (BackendApi.getSkipStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: "STATE_COMPLETED_ERROR",
+      error: ""
+    });
+    await expect(SkipRouter.fetchStatus("h", "c")).rejects.toThrow();
+  });
+
+  it("throws when the backend returns an error string", async () => {
+    (BackendApi.getSkipStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: "STATE_PENDING",
+      error: "rate limited"
+    });
+    await expect(SkipRouter.fetchStatus("h", "c")).rejects.toBe("rate limited");
   });
 });

--- a/src/common/utils/SkipRoute.test.ts
+++ b/src/common/utils/SkipRoute.test.ts
@@ -287,11 +287,7 @@ describe("SkipRouter.submitRoute / transaction()", () => {
       source_asset_chain_id: "c1",
       dest_asset_chain_id: "c2"
     };
-    await SkipRouter.submitRoute(
-      route as unknown as Parameters<typeof SkipRouter.submitRoute>[0],
-      {},
-      vi.fn()
-    );
+    await SkipRouter.submitRoute(route as unknown as Parameters<typeof SkipRouter.submitRoute>[0], {}, vi.fn());
     const req = (BackendApi.getSkipMessages as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(req.amount_in).toBe("IN");
     expect(req.amount_out).toBe("OUT");
@@ -457,11 +453,7 @@ describe("SkipRouter.submitRoute / transaction()", () => {
       dest_asset_chain_id: "c2"
     };
     const cb = vi.fn();
-    await SkipRouter.submitRoute(
-      route as unknown as Parameters<typeof SkipRouter.submitRoute>[0],
-      {},
-      cb
-    );
+    await SkipRouter.submitRoute(route as unknown as Parameters<typeof SkipRouter.submitRoute>[0], {}, cb);
     expect(cb).not.toHaveBeenCalled();
   });
 });

--- a/src/networks/cosm/BaseWallet.test.ts
+++ b/src/networks/cosm/BaseWallet.test.ts
@@ -19,51 +19,45 @@ vi.hoisted(() => {
 
 // Mock the heavy parent class before importing. We track calls to super()
 // constructor args via `superCtorArgs`.
-const {
-  superCtorArgs,
-  superSendTokens,
-  superGetSequence,
-  superGetChainId,
-  withExtensionsMock,
-  encodeMock
-} = vi.hoisted(() => ({
-  superCtorArgs: vi.fn(),
-  superSendTokens: vi.fn(),
-  superGetSequence: vi.fn(),
-  superGetChainId: vi.fn(),
-  withExtensionsMock: vi.fn(),
-  encodeMock: vi.fn((_obj: unknown) => new Uint8Array([1, 2, 3, 4]))
-}));
+const { superCtorArgs, superSendTokens, superGetSequence, superGetChainId, withExtensionsMock, encodeMock } =
+  vi.hoisted(() => ({
+    superCtorArgs: vi.fn(),
+    superSendTokens: vi.fn(),
+    superGetSequence: vi.fn(),
+    superGetChainId: vi.fn(),
+    withExtensionsMock: vi.fn(),
+    encodeMock: vi.fn((_obj: unknown) => new Uint8Array([1, 2, 3, 4]))
+  }));
 
 vi.mock("@cosmjs/cosmwasm-stargate", async (orig) => {
   const actual: Record<string, unknown> = await (orig as () => Promise<Record<string, unknown>>)();
   return {
     ...actual,
     SigningCosmWasmClient: class {
-    registry = { encode: encodeMock, encodeAsAny: (msg: unknown) => ({ encoded: msg }) };
-    aminoTypes = {
-      toAmino: (m: { value: unknown }) => ({ type: "amino-msg", value: m.value }),
-      fromAmino: (m: { value: unknown }) => ({ typeUrl: "/x", value: m.value })
-    };
-    constructor(...args: unknown[]) {
-      superCtorArgs(...args);
-    }
-    async sendTokens(...args: unknown[]) {
-      return superSendTokens(...args);
-    }
-    async getSequence(...args: unknown[]) {
-      return superGetSequence(...args);
-    }
-    async getChainId(...args: unknown[]) {
-      return superGetChainId(...args);
-    }
-    forceGetQueryClient() {
-      return {
-        tx: {
-          simulate: vi.fn().mockResolvedValue({ gasInfo: { gasUsed: 100000n } })
-        }
+      registry = { encode: encodeMock, encodeAsAny: (msg: unknown) => ({ encoded: msg }) };
+      aminoTypes = {
+        toAmino: (m: { value: unknown }) => ({ type: "amino-msg", value: m.value }),
+        fromAmino: (m: { value: unknown }) => ({ typeUrl: "/x", value: m.value })
       };
-    }
+      constructor(...args: unknown[]) {
+        superCtorArgs(...args);
+      }
+      async sendTokens(...args: unknown[]) {
+        return superSendTokens(...args);
+      }
+      async getSequence(...args: unknown[]) {
+        return superGetSequence(...args);
+      }
+      async getChainId(...args: unknown[]) {
+        return superGetChainId(...args);
+      }
+      forceGetQueryClient() {
+        return {
+          tx: {
+            simulate: vi.fn().mockResolvedValue({ gasInfo: { gasUsed: 100000n } })
+          }
+        };
+      }
     }
   };
 });
@@ -227,9 +221,11 @@ describe("BaseWallet", () => {
       const bw = buildBaseWallet(directSigner as unknown as OfflineSigner);
       await bw.useAccount();
       // For getAccount in sequence() - patched via queryClientBase auth
-      const queryAuth = (bw as unknown as {
-        queryClientBase: { auth: { account: ReturnType<typeof vi.fn> } };
-      }).queryClientBase.auth;
+      const queryAuth = (
+        bw as unknown as {
+          queryClientBase: { auth: { account: ReturnType<typeof vi.fn> } };
+        }
+      ).queryClientBase.auth;
       queryAuth.account.mockResolvedValue({
         typeUrl: "/cosmos.auth.v1beta1.BaseAccount",
         value: new Uint8Array()
@@ -238,12 +234,7 @@ describe("BaseWallet", () => {
       const bwAny = bw as unknown as { getAccount: (a: string) => Promise<unknown> };
       bwAny.getAccount = vi.fn().mockResolvedValue({ sequence: 0, accountNumber: 1 });
 
-      const out = await bw.simulateBankTransferTx(
-        "nolus1to",
-        [{ denom: "unls", amount: "100" }],
-        1.2,
-        "0.025unls"
-      );
+      const out = await bw.simulateBankTransferTx("nolus1to", [{ denom: "unls", amount: "100" }], 1.2, "0.025unls");
       expect(out).toHaveProperty("txHash");
       expect(out).toHaveProperty("txBytes");
       expect(out).toHaveProperty("usedFee");
@@ -277,27 +268,33 @@ describe("BaseWallet", () => {
   describe("getAccount", () => {
     it("returns null when the rpc error is 'NotFound'", async () => {
       const bw = buildBaseWallet();
-      const queryAuth = (bw as unknown as {
-        queryClientBase: { auth: { account: ReturnType<typeof vi.fn> } };
-      }).queryClientBase.auth;
+      const queryAuth = (
+        bw as unknown as {
+          queryClientBase: { auth: { account: ReturnType<typeof vi.fn> } };
+        }
+      ).queryClientBase.auth;
       queryAuth.account.mockRejectedValue(new Error("rpc error: code = NotFound"));
       await expect(bw.getAccount("nolus1addr")).resolves.toBeNull();
     });
 
     it("rethrows non-NotFound errors", async () => {
       const bw = buildBaseWallet();
-      const queryAuth = (bw as unknown as {
-        queryClientBase: { auth: { account: ReturnType<typeof vi.fn> } };
-      }).queryClientBase.auth;
+      const queryAuth = (
+        bw as unknown as {
+          queryClientBase: { auth: { account: ReturnType<typeof vi.fn> } };
+        }
+      ).queryClientBase.auth;
       queryAuth.account.mockRejectedValue(new Error("internal boom"));
       await expect(bw.getAccount("nolus1addr")).rejects.toThrow(/internal boom/);
     });
 
     it("returns null for a missing account (undefined response)", async () => {
       const bw = buildBaseWallet();
-      const queryAuth = (bw as unknown as {
-        queryClientBase: { auth: { account: ReturnType<typeof vi.fn> } };
-      }).queryClientBase.auth;
+      const queryAuth = (
+        bw as unknown as {
+          queryClientBase: { auth: { account: ReturnType<typeof vi.fn> } };
+        }
+      ).queryClientBase.auth;
       queryAuth.account.mockResolvedValue(undefined);
       await expect(bw.getAccount("nolus1addr")).resolves.toBeNull();
     });
@@ -319,7 +316,7 @@ describe("BaseWallet", () => {
         "memo"
       );
       expect(txRaw).toBeDefined();
-      expect((signer.signAmino as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+      expect(signer.signAmino as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
     });
 
     it("uses the DIRECT path when signer implements signDirect", async () => {
@@ -335,20 +332,18 @@ describe("BaseWallet", () => {
         { amount: [{ denom: "unls", amount: "1" }], gas: "100000" },
         "memo"
       );
-      expect((signer.signDirect as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+      expect(signer.signDirect as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
     });
 
     it("uses explicitSignerData when provided (skipping getSequence/getChainId)", async () => {
       const signer = fakeDirectSigner();
       const bw = buildBaseWallet(signer as unknown as OfflineSigner);
       await bw.useAccount();
-      await bw.sign(
-        "nolus1addr",
-        [{ typeUrl: "/x", value: {} }],
-        { amount: [], gas: "1" },
-        "",
-        { accountNumber: 42, sequence: 99, chainId: "custom-chain" }
-      );
+      await bw.sign("nolus1addr", [{ typeUrl: "/x", value: {} }], { amount: [], gas: "1" }, "", {
+        accountNumber: 42,
+        sequence: 99,
+        chainId: "custom-chain"
+      });
       // getSequence / getChainId not called
       expect(superGetSequence).not.toHaveBeenCalled();
       expect(superGetChainId).not.toHaveBeenCalled();

--- a/src/networks/cosm/BaseWallet.test.ts
+++ b/src/networks/cosm/BaseWallet.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Stub window.matchMedia BEFORE any imports (utils barrel pulls in ThemeManager
+// which reads matchMedia at module load in jsdom).
+vi.hoisted(() => {
+  if (typeof window !== "undefined" && !window.matchMedia) {
+    (window as unknown as { matchMedia: () => unknown }).matchMedia = () => ({
+      matches: false,
+      media: "",
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false
+    });
+  }
+});
+
+// Mock the heavy parent class before importing. We track calls to super()
+// constructor args via `superCtorArgs`.
+const {
+  superCtorArgs,
+  superSendTokens,
+  superGetSequence,
+  superGetChainId,
+  withExtensionsMock,
+  encodeMock
+} = vi.hoisted(() => ({
+  superCtorArgs: vi.fn(),
+  superSendTokens: vi.fn(),
+  superGetSequence: vi.fn(),
+  superGetChainId: vi.fn(),
+  withExtensionsMock: vi.fn(),
+  encodeMock: vi.fn((_obj: unknown) => new Uint8Array([1, 2, 3, 4]))
+}));
+
+vi.mock("@cosmjs/cosmwasm-stargate", async (orig) => {
+  const actual: Record<string, unknown> = await (orig as () => Promise<Record<string, unknown>>)();
+  return {
+    ...actual,
+    SigningCosmWasmClient: class {
+    registry = { encode: encodeMock, encodeAsAny: (msg: unknown) => ({ encoded: msg }) };
+    aminoTypes = {
+      toAmino: (m: { value: unknown }) => ({ type: "amino-msg", value: m.value }),
+      fromAmino: (m: { value: unknown }) => ({ typeUrl: "/x", value: m.value })
+    };
+    constructor(...args: unknown[]) {
+      superCtorArgs(...args);
+    }
+    async sendTokens(...args: unknown[]) {
+      return superSendTokens(...args);
+    }
+    async getSequence(...args: unknown[]) {
+      return superGetSequence(...args);
+    }
+    async getChainId(...args: unknown[]) {
+      return superGetChainId(...args);
+    }
+    forceGetQueryClient() {
+      return {
+        tx: {
+          simulate: vi.fn().mockResolvedValue({ gasInfo: { gasUsed: 100000n } })
+        }
+      };
+    }
+    }
+  };
+});
+
+vi.mock("@cosmjs/stargate", async (orig) => {
+  const actual: Record<string, unknown> = await (orig as () => Promise<Record<string, unknown>>)();
+  return {
+    ...actual,
+    QueryClient: {
+      withExtensions: (...args: unknown[]) => {
+        withExtensionsMock(...args);
+        // return a shape we can instruct
+        return {
+          auth: { account: vi.fn() },
+          tx: {
+            simulate: vi.fn().mockResolvedValue({ gasInfo: { gasUsed: 100000n } })
+          }
+        };
+      }
+    },
+    calculateFee: vi.fn(() => ({ amount: [{ denom: "unls", amount: "2500" }], gas: "100000" }))
+  };
+});
+
+import { BaseWallet } from "./BaseWallet";
+import type { OfflineSigner, OfflineDirectSigner } from "@cosmjs/proto-signing";
+
+function fakeSigner(overrides: Partial<OfflineSigner> = {}): OfflineSigner {
+  return {
+    getAccounts: vi.fn(async () => [
+      { address: "nolus1addr", pubkey: new Uint8Array(33).fill(2), algo: "secp256k1" as const }
+    ]),
+    signAmino: vi.fn(async () => ({
+      signature: { signature: "YWJj", pub_key: { type: "t", value: "v" } },
+      signed: {
+        accountNumber: "1",
+        sequence: "0",
+        chainId: "nolus-1",
+        msgs: [],
+        memo: "",
+        fee: { amount: [{ denom: "unls", amount: "1" }], gas: "100000" }
+      }
+    })),
+    ...overrides
+  } as unknown as OfflineSigner;
+}
+
+function fakeDirectSigner(): OfflineDirectSigner {
+  return {
+    getAccounts: vi.fn(async () => [
+      { address: "nolus1addr", pubkey: new Uint8Array(33).fill(2), algo: "secp256k1" as const }
+    ]),
+    signDirect: vi.fn(async (_addr: string, signDoc: unknown) => ({
+      signed: signDoc,
+      signature: { signature: "YWJj", pub_key: { type: "t", value: "v" } }
+    }))
+  } as unknown as OfflineDirectSigner;
+}
+
+function buildBaseWallet(signer: OfflineSigner = fakeSigner(), gasMultiplier = 1.5) {
+  return new BaseWallet(
+    { disconnect: vi.fn() } as unknown as Parameters<typeof BaseWallet>[0],
+    signer,
+    {} as never,
+    "rpc-url",
+    "api-url",
+    "nolus",
+    gasMultiplier,
+    "0.025unls",
+    "https://explorer"
+  );
+}
+
+describe("BaseWallet", () => {
+  beforeEach(() => {
+    superCtorArgs.mockClear();
+    superSendTokens.mockReset();
+    superGetSequence.mockReset();
+    superGetChainId.mockReset();
+    withExtensionsMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("calls super with tmClient, signer, options", () => {
+      const signer = fakeSigner();
+      buildBaseWallet(signer);
+      const args = superCtorArgs.mock.calls[0];
+      expect(args[1]).toBe(signer);
+    });
+
+    it("stores rpc/api/prefix/gas fields", () => {
+      const bw = buildBaseWallet();
+      expect(bw.rpc).toBe("rpc-url");
+      expect(bw.api).toBe("api-url");
+      expect(bw.prefix).toBe("nolus");
+      expect(bw.gasMultiplier).toBe(1.5);
+      expect(bw.explorer).toBe("https://explorer");
+    });
+
+    it("builds a queryClientBase with QueryClient.withExtensions", () => {
+      buildBaseWallet();
+      expect(withExtensionsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("type defaults to 'cosmos'", () => {
+      const bw = buildBaseWallet();
+      expect(bw.type).toBe("cosmos");
+    });
+  });
+
+  describe("useAccount", () => {
+    it("populates address/pubKey/algo from signer.getAccounts()[0]", async () => {
+      const bw = buildBaseWallet();
+      const ok = await bw.useAccount();
+      expect(ok).toBe(true);
+      expect(bw.address).toBe("nolus1addr");
+      expect(bw.pubKey).toBeInstanceOf(Uint8Array);
+      expect(bw.algo).toBe("secp256k1");
+    });
+
+    it("throws when signer returns no accounts", async () => {
+      const signer = fakeSigner({ getAccounts: vi.fn(async () => []) });
+      const bw = buildBaseWallet(signer);
+      await expect(bw.useAccount()).rejects.toThrow(/Missing account/);
+    });
+  });
+
+  describe("getSigner", () => {
+    it("returns the offline signer passed to the constructor", async () => {
+      const signer = fakeSigner();
+      const bw = buildBaseWallet(signer);
+      await expect(bw.getSigner()).resolves.toBe(signer);
+    });
+  });
+
+  describe("transferAmount", () => {
+    it("delegates to this.sendTokens with the sender address", async () => {
+      superSendTokens.mockResolvedValue({ code: 0 });
+      const bw = buildBaseWallet();
+      await bw.useAccount();
+      const amt = [{ denom: "unls", amount: "100" }];
+      await bw.transferAmount("nolus1to", amt, "auto", "memo");
+      expect(superSendTokens).toHaveBeenCalledWith("nolus1addr", "nolus1to", amt, "auto", "memo");
+    });
+
+    it("throws when the sender address isn't set (useAccount was never called)", async () => {
+      const bw = buildBaseWallet();
+      // Do NOT call useAccount
+      await expect(bw.transferAmount("nolus1to", [], "auto")).rejects.toThrow(/Sender address is missing/);
+    });
+  });
+
+  describe("simulateBankTransferTx", () => {
+    it("round-trips through simulateTx and returns txHash/txBytes/usedFee", async () => {
+      superGetSequence.mockResolvedValue({ accountNumber: 1, sequence: 0 });
+      const directSigner = fakeDirectSigner();
+      const bw = buildBaseWallet(directSigner as unknown as OfflineSigner);
+      await bw.useAccount();
+      // For getAccount in sequence() - patched via queryClientBase auth
+      const queryAuth = (bw as unknown as {
+        queryClientBase: { auth: { account: ReturnType<typeof vi.fn> } };
+      }).queryClientBase.auth;
+      queryAuth.account.mockResolvedValue({
+        typeUrl: "/cosmos.auth.v1beta1.BaseAccount",
+        value: new Uint8Array()
+      });
+      // But accountFromAny will throw on empty — so stub getAccount directly
+      const bwAny = bw as unknown as { getAccount: (a: string) => Promise<unknown> };
+      bwAny.getAccount = vi.fn().mockResolvedValue({ sequence: 0, accountNumber: 1 });
+
+      const out = await bw.simulateBankTransferTx(
+        "nolus1to",
+        [{ denom: "unls", amount: "100" }],
+        1.2,
+        "0.025unls"
+      );
+      expect(out).toHaveProperty("txHash");
+      expect(out).toHaveProperty("txBytes");
+      expect(out).toHaveProperty("usedFee");
+    });
+  });
+
+  describe("simulateSendIbcTokensTx", () => {
+    it("computes timeoutTimestamp from Date.now() + timeOut and builds a MsgTransfer", async () => {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      superGetSequence.mockResolvedValue({ accountNumber: 1, sequence: 0 });
+      const directSigner = fakeDirectSigner();
+      const bw = buildBaseWallet(directSigner as unknown as OfflineSigner);
+      await bw.useAccount();
+      const bwAny = bw as unknown as { getAccount: (a: string) => Promise<unknown> };
+      bwAny.getAccount = vi.fn().mockResolvedValue({ sequence: 0, accountNumber: 1 });
+
+      const out = await bw.simulateSendIbcTokensTx({
+        toAddress: "nolus1to",
+        amount: { denom: "unls", amount: "1" },
+        sourcePort: "transfer",
+        sourceChannel: "channel-0",
+        timeOut: 60,
+        gasMultiplier: 1.2,
+        gasPrice: "0.025unls"
+      });
+      expect(out).toHaveProperty("txHash");
+      vi.useRealTimers();
+    });
+  });
+
+  describe("getAccount", () => {
+    it("returns null when the rpc error is 'NotFound'", async () => {
+      const bw = buildBaseWallet();
+      const queryAuth = (bw as unknown as {
+        queryClientBase: { auth: { account: ReturnType<typeof vi.fn> } };
+      }).queryClientBase.auth;
+      queryAuth.account.mockRejectedValue(new Error("rpc error: code = NotFound"));
+      await expect(bw.getAccount("nolus1addr")).resolves.toBeNull();
+    });
+
+    it("rethrows non-NotFound errors", async () => {
+      const bw = buildBaseWallet();
+      const queryAuth = (bw as unknown as {
+        queryClientBase: { auth: { account: ReturnType<typeof vi.fn> } };
+      }).queryClientBase.auth;
+      queryAuth.account.mockRejectedValue(new Error("internal boom"));
+      await expect(bw.getAccount("nolus1addr")).rejects.toThrow(/internal boom/);
+    });
+
+    it("returns null for a missing account (undefined response)", async () => {
+      const bw = buildBaseWallet();
+      const queryAuth = (bw as unknown as {
+        queryClientBase: { auth: { account: ReturnType<typeof vi.fn> } };
+      }).queryClientBase.auth;
+      queryAuth.account.mockResolvedValue(undefined);
+      await expect(bw.getAccount("nolus1addr")).resolves.toBeNull();
+    });
+  });
+
+  describe("sign", () => {
+    it("uses the AMINO path when signer is not a direct signer", async () => {
+      // amino signer — no signDirect present
+      const signer = fakeSigner();
+      const bw = buildBaseWallet(signer);
+      await bw.useAccount();
+      superGetSequence.mockResolvedValue({ accountNumber: 1, sequence: 0 });
+      superGetChainId.mockResolvedValue("nolus-1");
+
+      const txRaw = await bw.sign(
+        "nolus1addr",
+        [{ typeUrl: "/cosmos.bank.v1beta1.MsgSend", value: {} }],
+        { amount: [{ denom: "unls", amount: "1" }], gas: "100000" },
+        "memo"
+      );
+      expect(txRaw).toBeDefined();
+      expect((signer.signAmino as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses the DIRECT path when signer implements signDirect", async () => {
+      const signer = fakeDirectSigner();
+      const bw = buildBaseWallet(signer as unknown as OfflineSigner);
+      await bw.useAccount();
+      superGetSequence.mockResolvedValue({ accountNumber: 1, sequence: 0 });
+      superGetChainId.mockResolvedValue("nolus-1");
+
+      await bw.sign(
+        "nolus1addr",
+        [{ typeUrl: "/cosmos.bank.v1beta1.MsgSend", value: {} }],
+        { amount: [{ denom: "unls", amount: "1" }], gas: "100000" },
+        "memo"
+      );
+      expect((signer.signDirect as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses explicitSignerData when provided (skipping getSequence/getChainId)", async () => {
+      const signer = fakeDirectSigner();
+      const bw = buildBaseWallet(signer as unknown as OfflineSigner);
+      await bw.useAccount();
+      await bw.sign(
+        "nolus1addr",
+        [{ typeUrl: "/x", value: {} }],
+        { amount: [], gas: "1" },
+        "",
+        { accountNumber: 42, sequence: 99, chainId: "custom-chain" }
+      );
+      // getSequence / getChainId not called
+      expect(superGetSequence).not.toHaveBeenCalled();
+      expect(superGetChainId).not.toHaveBeenCalled();
+    });
+
+    it("throws when the signer has no account matching the signerAddress", async () => {
+      const signer = fakeDirectSigner();
+      const bw = buildBaseWallet(signer as unknown as OfflineSigner);
+      await bw.useAccount();
+      superGetSequence.mockResolvedValue({ accountNumber: 1, sequence: 0 });
+      superGetChainId.mockResolvedValue("nolus-1");
+      await expect(
+        bw.sign("nolus1different", [{ typeUrl: "/x", value: {} }], { amount: [], gas: "1" }, "")
+      ).rejects.toThrow(/Failed to retrieve account from signer/);
+    });
+  });
+
+  describe("simulateMultiTx", () => {
+    it("builds a tx via sign() with combined gasUsed * gasMultiplier", async () => {
+      const signer = fakeDirectSigner();
+      const bw = buildBaseWallet(signer as unknown as OfflineSigner, 2.0);
+      await bw.useAccount();
+      const bwAny = bw as unknown as { getAccount: (a: string) => Promise<unknown> };
+      bwAny.getAccount = vi.fn().mockResolvedValue({ sequence: 0, accountNumber: 1 });
+      superGetSequence.mockResolvedValue({ accountNumber: 1, sequence: 0 });
+      superGetChainId.mockResolvedValue("nolus-1");
+
+      const out = await bw.simulateMultiTx(
+        [
+          { msg: { fromAddress: "a", toAddress: "b", amount: [] }, msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend" },
+          { msg: { fromAddress: "a", toAddress: "c", amount: [] }, msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend" }
+        ],
+        "memo"
+      );
+      expect(out).toHaveProperty("txHash");
+      expect(out).toHaveProperty("txBytes");
+      expect(out).toHaveProperty("usedFee");
+    });
+
+    it("handles empty message list without throwing", async () => {
+      const signer = fakeDirectSigner();
+      const bw = buildBaseWallet(signer as unknown as OfflineSigner);
+      await bw.useAccount();
+      const bwAny = bw as unknown as { getAccount: (a: string) => Promise<unknown> };
+      bwAny.getAccount = vi.fn().mockResolvedValue({ sequence: 0, accountNumber: 1 });
+      superGetSequence.mockResolvedValue({ accountNumber: 1, sequence: 0 });
+      superGetChainId.mockResolvedValue("nolus-1");
+
+      const out = await bw.simulateMultiTx([], "");
+      expect(out).toHaveProperty("txHash");
+    });
+  });
+});

--- a/src/networks/cosm/NolusWalletOverride.test.ts
+++ b/src/networks/cosm/NolusWalletOverride.test.ts
@@ -31,12 +31,14 @@ interface FakeOfflineSigner {
 
 // We create a "fake" NolusWallet by Object-shape casting; we only touch the
 // properties/methods the override reads.
-function buildFakeWallet(opts: {
-  simulate?: { gasInfo: { gasUsed: bigint | number } };
-  signerSequence?: number;
-  offlineSigner?: FakeOfflineSigner;
-  pubKey?: Uint8Array;
-} = {}): NolusWallet & Record<string, unknown> {
+function buildFakeWallet(
+  opts: {
+    simulate?: { gasInfo: { gasUsed: bigint | number } };
+    signerSequence?: number;
+    offlineSigner?: FakeOfflineSigner;
+    pubKey?: Uint8Array;
+  } = {}
+): NolusWallet & Record<string, unknown> {
   const defaultPub = new Uint8Array(33);
   defaultPub[0] = 0x02;
   for (let i = 1; i < 33; i++) defaultPub[i] = i;
@@ -102,9 +104,7 @@ describe("NolusWalletOverride", () => {
       currentFeeConfig = null;
       const w = buildFakeWallet();
       applyNolusWalletOverrides(w);
-      await expect((w.gasPrices as () => Promise<unknown>)()).rejects.toThrow(
-        /Gas fee config not available/
-      );
+      await expect((w.gasPrices as () => Promise<unknown>)()).rejects.toThrow(/Gas fee config not available/);
     });
   });
 
@@ -135,9 +135,7 @@ describe("NolusWalletOverride", () => {
       applyNolusWalletOverrides(w);
       currentFeeConfig = null; // drop config before call
       const fn = w.simulateTx as Override<"simulateTx">;
-      await expect(fn({} as never, "/cosmos.bank.v1beta1.MsgSend")).rejects.toThrow(
-        /Gas fee config not available/
-      );
+      await expect(fn({} as never, "/cosmos.bank.v1beta1.MsgSend")).rejects.toThrow(/Gas fee config not available/);
     });
 
     it("uses default memo of empty string when not provided", async () => {
@@ -218,9 +216,9 @@ describe("NolusWalletOverride", () => {
       const w = buildFakeWallet();
       applyNolusWalletOverrides(w);
       const fn = (w as unknown as { getGasInfo: (...args: unknown[]) => Promise<unknown> }).getGasInfo;
-      await expect(
-        fn([{ msg: {}, msgTypeUrl: "/x" }], "", { type: "t", value: "v" }, 0)
-      ).rejects.toThrow(/Gas fee config not available/);
+      await expect(fn([{ msg: {}, msgTypeUrl: "/x" }], "", { type: "t", value: "v" }, 0)).rejects.toThrow(
+        /Gas fee config not available/
+      );
     });
 
     it("rounds fractional gas values (0.5 rounds to nearest)", async () => {

--- a/src/networks/cosm/NolusWalletOverride.test.ts
+++ b/src/networks/cosm/NolusWalletOverride.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the config store used by the overrides module. Each test can adjust
+// the return value via `setFeeConfig(...)`.
+let currentFeeConfig: { gas_prices: Record<string, string>; gas_multiplier: number } | null = null;
+const useConfigStoreMock = vi.fn(() => ({
+  get gasFeeConfig() {
+    return currentFeeConfig;
+  }
+}));
+
+vi.mock("@/common/stores/config", () => ({
+  useConfigStore: () => useConfigStoreMock()
+}));
+
+// The overrides use `TxRaw.encode(...).finish()` and `sha256` — mock only the
+// minimal bits. TxRaw.encode is left real (comes from cosmjs-types).
+vi.mock("@cosmjs/crypto", () => ({
+  sha256: (bytes: Uint8Array) => bytes // pass-through; test only checks txHash is hex-ish
+}));
+
+import { applyNolusWalletOverrides } from "./NolusWalletOverride";
+import type { NolusWallet } from "@nolus/nolusjs/build/wallet/NolusWallet";
+
+type Override<T extends keyof NolusWallet> = NolusWallet[T];
+
+interface FakeOfflineSigner {
+  simulateTx?: (...args: unknown[]) => unknown;
+  simulateMultiTx?: (...args: unknown[]) => unknown;
+}
+
+// We create a "fake" NolusWallet by Object-shape casting; we only touch the
+// properties/methods the override reads.
+function buildFakeWallet(opts: {
+  simulate?: { gasInfo: { gasUsed: bigint | number } };
+  signerSequence?: number;
+  offlineSigner?: FakeOfflineSigner;
+  pubKey?: Uint8Array;
+} = {}): NolusWallet & Record<string, unknown> {
+  const defaultPub = new Uint8Array(33);
+  defaultPub[0] = 0x02;
+  for (let i = 1; i < 33; i++) defaultPub[i] = i;
+
+  const wallet = {
+    address: "nolus1addr",
+    pubKey: opts.pubKey ?? defaultPub,
+    registry: {
+      encodeAsAny: vi.fn((msg: unknown) => ({ encoded: msg }))
+    },
+    getOfflineSigner: vi.fn(() => opts.offlineSigner ?? {}),
+    getSequence: vi.fn(async () => ({ sequence: opts.signerSequence ?? 1 })),
+    forceGetQueryClient: vi.fn(() => ({
+      tx: {
+        simulate: vi.fn(async () => opts.simulate ?? { gasInfo: { gasUsed: 100000 } })
+      }
+    })),
+    selectDynamicFee: vi.fn(async (gas: number) => ({
+      amount: [{ denom: "unls", amount: String(gas * 10) }],
+      gas: String(gas)
+    })),
+    sign: vi.fn(async () => ({
+      // Minimal shape such that TxRaw.encode(...) still works:
+      bodyBytes: new Uint8Array([0x0a, 0x00]),
+      authInfoBytes: new Uint8Array([0x12, 0x00]),
+      signatures: [new Uint8Array([0x01])]
+    }))
+  } as unknown as NolusWallet & Record<string, unknown>;
+
+  return wallet;
+}
+
+describe("NolusWalletOverride", () => {
+  beforeEach(() => {
+    currentFeeConfig = { gas_prices: { unls: "0.025" }, gas_multiplier: 1.5 };
+    useConfigStoreMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("gasPrices override", () => {
+    it("returns gas_prices from the backend config, converted to numbers", async () => {
+      const w = buildFakeWallet();
+      applyNolusWalletOverrides(w);
+      const prices = await (w.gasPrices as () => Promise<Record<string, number>>)();
+      expect(prices).toEqual({ unls: 0.025 });
+    });
+
+    it("handles multiple denoms", async () => {
+      currentFeeConfig = {
+        gas_prices: { unls: "0.01", uusdc: "0.002" },
+        gas_multiplier: 1.2
+      };
+      const w = buildFakeWallet();
+      applyNolusWalletOverrides(w);
+      const prices = await (w.gasPrices as () => Promise<Record<string, number>>)();
+      expect(prices).toEqual({ unls: 0.01, uusdc: 0.002 });
+    });
+
+    it("throws when gasFeeConfig is null (fail loudly, no fallbacks)", async () => {
+      currentFeeConfig = null;
+      const w = buildFakeWallet();
+      applyNolusWalletOverrides(w);
+      await expect((w.gasPrices as () => Promise<unknown>)()).rejects.toThrow(
+        /Gas fee config not available/
+      );
+    });
+  });
+
+  describe("simulateTx override", () => {
+    it("multiplies gasUsed by backend gas_multiplier (1.5)", async () => {
+      const w = buildFakeWallet({ simulate: { gasInfo: { gasUsed: 100000 } } });
+      applyNolusWalletOverrides(w);
+      const fn = w.simulateTx as Override<"simulateTx">;
+      const result = await fn({} as never, "/cosmos.bank.v1beta1.MsgSend", "memo");
+      // 100000 * 1.5 = 150000 rounded
+      expect((w.selectDynamicFee as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(150000);
+      expect(result).toHaveProperty("txHash");
+      expect(result).toHaveProperty("txBytes");
+      expect(result).toHaveProperty("usedFee");
+    });
+
+    it("delegates to offlineSigner.simulateTx when available (Ledger path)", async () => {
+      const simulateTxSigner = vi.fn().mockResolvedValue({ txHash: "abc", txBytes: new Uint8Array(), usedFee: {} });
+      const w = buildFakeWallet({ offlineSigner: { simulateTx: simulateTxSigner } });
+      applyNolusWalletOverrides(w);
+      const fn = w.simulateTx as Override<"simulateTx">;
+      await fn({ foo: "bar" } as never, "/cosmos.bank.v1beta1.MsgSend", "m");
+      expect(simulateTxSigner).toHaveBeenCalledWith({ foo: "bar" }, "m");
+    });
+
+    it("throws when gas fee config missing (during simulateTx path)", async () => {
+      const w = buildFakeWallet();
+      applyNolusWalletOverrides(w);
+      currentFeeConfig = null; // drop config before call
+      const fn = w.simulateTx as Override<"simulateTx">;
+      await expect(fn({} as never, "/cosmos.bank.v1beta1.MsgSend")).rejects.toThrow(
+        /Gas fee config not available/
+      );
+    });
+
+    it("uses default memo of empty string when not provided", async () => {
+      const w = buildFakeWallet();
+      applyNolusWalletOverrides(w);
+      const fn = w.simulateTx as Override<"simulateTx">;
+      await fn({} as never, "/cosmos.bank.v1beta1.MsgSend");
+      const signCalls = (w.sign as ReturnType<typeof vi.fn>).mock.calls;
+      expect(signCalls[0][3]).toBe("");
+    });
+  });
+
+  describe("simulateMultiTx override", () => {
+    it("multiplies sum-of-gas by gas_multiplier for multi-message tx", async () => {
+      const w = buildFakeWallet({ simulate: { gasInfo: { gasUsed: 200000n } } });
+      applyNolusWalletOverrides(w);
+      // simulateMultiTx is private on the NolusWallet type — override sets it anyway.
+      const fn = (w as unknown as { simulateMultiTx: (...args: unknown[]) => Promise<unknown> }).simulateMultiTx;
+      const res = await fn(
+        [
+          { msg: {}, msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend" },
+          { msg: {}, msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend" }
+        ],
+        "memo"
+      );
+      // 200000 * 1.5 = 300000
+      expect((w.selectDynamicFee as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(300000);
+      expect(res).toHaveProperty("txHash");
+    });
+
+    it("delegates to offlineSigner.simulateMultiTx when available", async () => {
+      const simulateMultiTxSigner = vi
+        .fn()
+        .mockResolvedValue({ txHash: "xyz", txBytes: new Uint8Array(), usedFee: {} });
+      const w = buildFakeWallet({ offlineSigner: { simulateMultiTx: simulateMultiTxSigner } });
+      applyNolusWalletOverrides(w);
+      const fn = (w as unknown as { simulateMultiTx: (...args: unknown[]) => Promise<unknown> }).simulateMultiTx;
+      const msgs = [{ msg: {}, msgTypeUrl: "/x" }];
+      await fn(msgs, "m");
+      expect(simulateMultiTxSigner).toHaveBeenCalledWith(msgs, "m");
+    });
+
+    it("encodes every message via registry.encodeAsAny exactly once", async () => {
+      const w = buildFakeWallet();
+      applyNolusWalletOverrides(w);
+      const fn = (w as unknown as { simulateMultiTx: (...args: unknown[]) => Promise<unknown> }).simulateMultiTx;
+      await fn(
+        [
+          { msg: { a: 1 }, msgTypeUrl: "/a" },
+          { msg: { b: 2 }, msgTypeUrl: "/b" },
+          { msg: { c: 3 }, msgTypeUrl: "/c" }
+        ],
+        ""
+      );
+      const encAsAny = w.registry.encodeAsAny as ReturnType<typeof vi.fn>;
+      expect(encAsAny).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("getGasInfo override", () => {
+    it("returns gas / usedFee / gasInfo shape", async () => {
+      const w = buildFakeWallet({ simulate: { gasInfo: { gasUsed: 60000 } } });
+      applyNolusWalletOverrides(w);
+      const fn = (w as unknown as { getGasInfo: (...args: unknown[]) => Promise<Record<string, unknown>> }).getGasInfo;
+      const out = await fn(
+        [{ msg: {}, msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend" }],
+        "memo",
+        { type: "tendermint/PubKeySecp256k1", value: "AA==" },
+        5
+      );
+      expect(out.gas).toBe(Math.round(60000 * 1.5));
+      expect(out.usedFee).toBeDefined();
+      expect(out.gasInfo).toBeDefined();
+    });
+
+    it("throws when gasFeeConfig is missing", async () => {
+      currentFeeConfig = null;
+      const w = buildFakeWallet();
+      applyNolusWalletOverrides(w);
+      const fn = (w as unknown as { getGasInfo: (...args: unknown[]) => Promise<unknown> }).getGasInfo;
+      await expect(
+        fn([{ msg: {}, msgTypeUrl: "/x" }], "", { type: "t", value: "v" }, 0)
+      ).rejects.toThrow(/Gas fee config not available/);
+    });
+
+    it("rounds fractional gas values (0.5 rounds to nearest)", async () => {
+      currentFeeConfig = { gas_prices: { unls: "0.01" }, gas_multiplier: 1.333 };
+      const w = buildFakeWallet({ simulate: { gasInfo: { gasUsed: 77777 } } });
+      applyNolusWalletOverrides(w);
+      const fn = (w as unknown as { getGasInfo: (...args: unknown[]) => Promise<{ gas: number }> }).getGasInfo;
+      const out = await fn([{ msg: {}, msgTypeUrl: "/x" }], "", { type: "t", value: "v" }, 0);
+      expect(out.gas).toBe(Math.round(77777 * 1.333));
+    });
+  });
+});

--- a/src/networks/cosm/Wallet.test.ts
+++ b/src/networks/cosm/Wallet.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the CometClient connect + StargateClient create before import.
+const connectCometMock = vi.fn();
+const stargateCreateMock = vi.fn();
+
+vi.mock("@cosmjs/tendermint-rpc", () => ({
+  connectComet: (...args: unknown[]) => connectCometMock(...args)
+}));
+
+vi.mock("@cosmjs/stargate", () => ({
+  StargateClient: {
+    create: (...args: unknown[]) => stargateCreateMock(...args)
+  }
+}));
+
+import { Wallet } from "./Wallet";
+
+function makeFakeStargate(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    getChainId: vi.fn().mockResolvedValue("nolus-test-1"),
+    getBalance: vi.fn().mockResolvedValue({ denom: "unls", amount: "1000" }),
+    getBlock: vi.fn().mockResolvedValue({ header: { height: 12345 } }),
+    disconnect: vi.fn(),
+    ...overrides
+  };
+}
+
+function makeFakeComet() {
+  return { disconnect: vi.fn() };
+}
+
+describe("Wallet", () => {
+  beforeEach(() => {
+    connectCometMock.mockReset();
+    stargateCreateMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("constructs via getInstance and wires rpc/api", async () => {
+    const comet = makeFakeComet();
+    const stargate = makeFakeStargate();
+    connectCometMock.mockResolvedValue(comet);
+    stargateCreateMock.mockResolvedValue(stargate);
+
+    const w = await Wallet.getInstance("rpc-url", "api-url");
+    expect(w.rpc).toBe("rpc-url");
+    expect(w.api).toBe("api-url");
+    expect(w.getTendermintClient()).toBe(comet);
+    expect(w.getStargateClient()).toBe(stargate);
+    expect(connectCometMock).toHaveBeenCalledWith("rpc-url");
+  });
+
+  it("getChainId returns the stargate chain id", async () => {
+    const comet = makeFakeComet();
+    const stargate = makeFakeStargate({ getChainId: vi.fn().mockResolvedValue("nolus-1") });
+    connectCometMock.mockResolvedValue(comet);
+    stargateCreateMock.mockResolvedValue(stargate);
+
+    const w = await Wallet.getInstance("rpc", "api");
+    await expect(w.getChainId()).resolves.toBe("nolus-1");
+  });
+
+  it("getChainId throws when stargate client is missing", async () => {
+    connectCometMock.mockResolvedValue(makeFakeComet());
+    stargateCreateMock.mockResolvedValue(makeFakeStargate({ getChainId: vi.fn().mockResolvedValue(undefined) }));
+
+    const w = await Wallet.getInstance("rpc", "api");
+    await expect(w.getChainId()).rejects.toThrow(/Chain id is missing/);
+  });
+
+  it("getBalance delegates to stargate.getBalance", async () => {
+    const bal = { denom: "unls", amount: "7777" };
+    const stargate = makeFakeStargate({ getBalance: vi.fn().mockResolvedValue(bal) });
+    connectCometMock.mockResolvedValue(makeFakeComet());
+    stargateCreateMock.mockResolvedValue(stargate);
+
+    const w = await Wallet.getInstance("rpc", "api");
+    await expect(w.getBalance("nolus1addr", "unls")).resolves.toEqual(bal);
+    expect(stargate.getBalance).toHaveBeenCalledWith("nolus1addr", "unls");
+  });
+
+  it("getBalance throws when stargate.getBalance returns a falsy value synchronously", async () => {
+    // getBalance() here returns `undefined` (falsy), so the null guard in the
+    // production code trips before awaiting.
+    const stargate = makeFakeStargate({ getBalance: vi.fn().mockReturnValue(undefined) });
+    connectCometMock.mockResolvedValue(makeFakeComet());
+    stargateCreateMock.mockResolvedValue(stargate);
+
+    const w = await Wallet.getInstance("rpc", "api");
+    await expect(w.getBalance("a", "u")).rejects.toThrow(/Balance is missing/);
+  });
+
+  it("getBlockHeight returns header.height", async () => {
+    const stargate = makeFakeStargate({ getBlock: vi.fn().mockResolvedValue({ header: { height: 99 } }) });
+    connectCometMock.mockResolvedValue(makeFakeComet());
+    stargateCreateMock.mockResolvedValue(stargate);
+
+    const w = await Wallet.getInstance("rpc", "api");
+    await expect(w.getBlockHeight()).resolves.toBe(99);
+  });
+
+  it("getBlockHeight throws when block has no header", async () => {
+    const stargate = makeFakeStargate({ getBlock: vi.fn().mockResolvedValue({}) });
+    connectCometMock.mockResolvedValue(makeFakeComet());
+    stargateCreateMock.mockResolvedValue(stargate);
+
+    const w = await Wallet.getInstance("rpc", "api");
+    await expect(w.getBlockHeight()).rejects.toThrow(/Block height is missing/);
+  });
+
+  it("destroy disconnects both underlying clients", async () => {
+    const comet = makeFakeComet();
+    const stargate = makeFakeStargate();
+    connectCometMock.mockResolvedValue(comet);
+    stargateCreateMock.mockResolvedValue(stargate);
+
+    const w = await Wallet.getInstance("rpc", "api");
+    w.destroy();
+    expect(stargate.disconnect).toHaveBeenCalledTimes(1);
+    expect(comet.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("destroy is a no-op when clients are missing (tolerates unwired state)", () => {
+    // Build a bare Wallet instance without calling setInstance to hit the undefined guards.
+    const bare = Object.create(Wallet.prototype) as Wallet;
+    (bare as unknown as { rpc: string; api: string }).rpc = "r";
+    (bare as unknown as { rpc: string; api: string }).api = "a";
+    expect(() => bare.destroy()).not.toThrow();
+  });
+});

--- a/src/networks/cosm/WalletFactory.test.ts
+++ b/src/networks/cosm/WalletFactory.test.ts
@@ -141,9 +141,7 @@ describe("WalletFactory", () => {
   describe("authenticateKeplr", () => {
     it("throws when Keplr is not installed", async () => {
       walletUtilsMock.getKeplr.mockResolvedValue(undefined);
-      await expect(authenticateKeplr(fakeWallet(), fakeNetwork())).rejects.toThrow(
-        /Keplr wallet is not installed/
-      );
+      await expect(authenticateKeplr(fakeWallet(), fakeNetwork())).rejects.toThrow(/Keplr wallet is not installed/);
     });
 
     it("throws when Keplr lacks experimentalSuggestChain", async () => {
@@ -151,9 +149,7 @@ describe("WalletFactory", () => {
         getOfflineSignerAuto: vi.fn(),
         experimentalSuggestChain: undefined
       });
-      await expect(authenticateKeplr(fakeWallet(), fakeNetwork())).rejects.toThrow(
-        /version is not latest/
-      );
+      await expect(authenticateKeplr(fakeWallet(), fakeNetwork())).rejects.toThrow(/version is not latest/);
     });
 
     it("wraps network fetch failures with 'Failed to fetch suggest chain.'", async () => {
@@ -163,9 +159,7 @@ describe("WalletFactory", () => {
         enable: vi.fn()
       });
 
-      await expect(authenticateKeplr(fakeWallet(), fakeNetwork())).rejects.toThrow(
-        /Failed to fetch suggest chain/
-      );
+      await expect(authenticateKeplr(fakeWallet(), fakeNetwork())).rejects.toThrow(/Failed to fetch suggest chain/);
     });
 
     it("happy path: suggestChain + enable + builds a BaseWallet with the right args", async () => {
@@ -205,9 +199,7 @@ describe("WalletFactory", () => {
   describe("authenticateLeap", () => {
     it("throws when Leap is not installed (label reflects leap)", async () => {
       walletUtilsMock.getLeap.mockResolvedValue(undefined);
-      await expect(authenticateLeap(fakeWallet(), fakeNetwork())).rejects.toThrow(
-        /Leap wallet is not installed/
-      );
+      await expect(authenticateLeap(fakeWallet(), fakeNetwork())).rejects.toThrow(/Leap wallet is not installed/);
     });
 
     it("happy path builds a BaseWallet", async () => {

--- a/src/networks/cosm/WalletFactory.test.ts
+++ b/src/networks/cosm/WalletFactory.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Shared state for the mocks — hoisted so they exist before the vi.mock
+// factories (which are themselves hoisted to the top of the module).
+const {
+  baseWalletCtor,
+  metamaskConnectCustom,
+  metamaskMakeWCOfflineSigner,
+  solanaConnectCustom,
+  solanaMakeWCOfflineSigner,
+  fetchEndpointsMock,
+  walletManagerMock,
+  walletUtilsMock,
+  bluetoothCreateMock,
+  webusbCreateMock
+} = vi.hoisted(() => ({
+  baseWalletCtor: vi.fn(),
+  metamaskConnectCustom: vi.fn().mockResolvedValue(undefined),
+  metamaskMakeWCOfflineSigner: vi.fn(() => ({ type: "evm", chainId: "nolus-1", getAccounts: async () => [] })),
+  solanaConnectCustom: vi.fn().mockResolvedValue(undefined),
+  solanaMakeWCOfflineSigner: vi.fn(() => ({ type: "svm", chainId: "nolus-1", getAccounts: async () => [] })),
+  fetchEndpointsMock: vi.fn().mockResolvedValue({ rpc: "r", api: "a" }),
+  walletManagerMock: { getWalletConnectMechanism: vi.fn(() => undefined) },
+  walletUtilsMock: { getKeplr: vi.fn(), getLeap: vi.fn() },
+  bluetoothCreateMock: vi.fn().mockResolvedValue({ type: "ble-transport" }),
+  webusbCreateMock: vi.fn().mockResolvedValue({ type: "usb-transport" })
+}));
+
+// Mock BaseWallet so we don't spin up SigningCosmWasmClient.
+vi.mock("./BaseWallet", () => {
+  return {
+    BaseWallet: class FakeBaseWallet {
+      args: unknown[];
+      address?: string;
+      useAccount = vi.fn().mockResolvedValue(true);
+      constructor(...args: unknown[]) {
+        this.args = args;
+        baseWalletCtor(...args);
+      }
+    }
+  };
+});
+
+vi.mock("../evm", () => ({
+  MetaMaskWallet: class {
+    connectCustom = metamaskConnectCustom;
+    makeWCOfflineSigner = metamaskMakeWCOfflineSigner;
+  }
+}));
+
+vi.mock("../sol", () => ({
+  SolanaWallet: class {
+    connectCustom = solanaConnectCustom;
+    makeWCOfflineSigner = solanaMakeWCOfflineSigner;
+  }
+}));
+
+vi.mock("@/common/utils/EndpointService", () => ({
+  fetchEndpoints: (...args: unknown[]) => fetchEndpointsMock(...args)
+}));
+
+vi.mock("@/common/utils", () => ({
+  WalletManager: walletManagerMock,
+  WalletUtils: walletUtilsMock,
+  Logger: { error: vi.fn() }
+}));
+
+// Ledger transport mocks — don't attempt real hardware/bluetooth connection.
+vi.mock("@ledgerhq/hw-transport-web-ble", () => ({
+  default: { create: (...args: unknown[]) => bluetoothCreateMock(...args) }
+}));
+
+vi.mock("@ledgerhq/hw-transport-webusb", () => ({
+  default: { create: (...args: unknown[]) => webusbCreateMock(...args) }
+}));
+
+vi.mock("@cosmjs/ledger-amino", () => ({
+  LedgerSigner: class {
+    transport: unknown;
+    opts: unknown;
+    constructor(transport: unknown, opts: unknown) {
+      this.transport = transport;
+      this.opts = opts;
+    }
+    async getAccounts() {
+      return [];
+    }
+  }
+}));
+
+import {
+  authenticateKeplr,
+  authenticateLeap,
+  authenticateLedger,
+  authenticateEvmPhantom,
+  authenticateSolFlare
+} from "./WalletFactory";
+import type { NetworkData } from "@/common/types";
+
+function fakeWallet(chainId = "nolus-1") {
+  return {
+    rpc: "rpc-url",
+    api: "api-url",
+    getTendermintClient: vi.fn(() => ({ kind: "comet" })),
+    getChainId: vi.fn().mockResolvedValue(chainId)
+  } as unknown as Parameters<typeof authenticateKeplr>[0];
+}
+
+function fakeNetwork(overrides: Partial<NetworkData> = {}): NetworkData {
+  return {
+    key: "nolus",
+    prefix: "nolus",
+    gasMultiplier: 1.4,
+    gasPrice: "0.025unls",
+    explorer: "https://explorer",
+    embedChainInfo: vi.fn(() => ({})),
+    ...overrides
+  } as unknown as NetworkData;
+}
+
+describe("WalletFactory", () => {
+  beforeEach(() => {
+    baseWalletCtor.mockClear();
+    metamaskConnectCustom.mockClear();
+    metamaskMakeWCOfflineSigner.mockClear();
+    solanaConnectCustom.mockClear();
+    solanaMakeWCOfflineSigner.mockClear();
+    bluetoothCreateMock.mockClear();
+    webusbCreateMock.mockClear();
+    walletManagerMock.getWalletConnectMechanism.mockReturnValue(undefined);
+    walletUtilsMock.getKeplr.mockReset();
+    walletUtilsMock.getLeap.mockReset();
+    fetchEndpointsMock.mockReset();
+    fetchEndpointsMock.mockResolvedValue({ rpc: "r", api: "a" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("authenticateKeplr", () => {
+    it("throws when Keplr is not installed", async () => {
+      walletUtilsMock.getKeplr.mockResolvedValue(undefined);
+      await expect(authenticateKeplr(fakeWallet(), fakeNetwork())).rejects.toThrow(
+        /Keplr wallet is not installed/
+      );
+    });
+
+    it("throws when Keplr lacks experimentalSuggestChain", async () => {
+      walletUtilsMock.getKeplr.mockResolvedValue({
+        getOfflineSignerAuto: vi.fn(),
+        experimentalSuggestChain: undefined
+      });
+      await expect(authenticateKeplr(fakeWallet(), fakeNetwork())).rejects.toThrow(
+        /version is not latest/
+      );
+    });
+
+    it("wraps network fetch failures with 'Failed to fetch suggest chain.'", async () => {
+      walletUtilsMock.getKeplr.mockResolvedValue({
+        getOfflineSignerAuto: vi.fn(),
+        experimentalSuggestChain: vi.fn().mockRejectedValue(new Error("network unreachable")),
+        enable: vi.fn()
+      });
+
+      await expect(authenticateKeplr(fakeWallet(), fakeNetwork())).rejects.toThrow(
+        /Failed to fetch suggest chain/
+      );
+    });
+
+    it("happy path: suggestChain + enable + builds a BaseWallet with the right args", async () => {
+      const offlineSigner = { getAccounts: async () => [] };
+      walletUtilsMock.getKeplr.mockResolvedValue({
+        getOfflineSignerAuto: vi.fn().mockResolvedValue(offlineSigner),
+        experimentalSuggestChain: vi.fn().mockResolvedValue(undefined),
+        enable: vi.fn().mockResolvedValue(undefined)
+      });
+
+      const network = fakeNetwork({
+        prefix: "nolus",
+        gasMultiplier: 1.5,
+        gasPrice: "0.025unls",
+        explorer: "https://e"
+      });
+      const wallet = fakeWallet("nolus-1");
+      const bw = await authenticateKeplr(wallet, network);
+
+      expect(baseWalletCtor).toHaveBeenCalledTimes(1);
+      // BaseWallet ctor arg order: (tm, signer, opts, rpc, api, prefix, gasMultiplier, gasPrice, explorer)
+      const args = baseWalletCtor.mock.calls[0];
+      expect(args[1]).toBe(offlineSigner);
+      expect(args[3]).toBe("rpc-url");
+      expect(args[4]).toBe("api-url");
+      expect(args[5]).toBe("nolus");
+      expect(args[6]).toBe(1.5);
+      expect(args[7]).toBe("0.025unls");
+      expect(args[8]).toBe("https://e");
+
+      // useAccount() was called during createWallet
+      const instance = bw as unknown as { useAccount: ReturnType<typeof vi.fn> };
+      expect(instance.useAccount).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("authenticateLeap", () => {
+    it("throws when Leap is not installed (label reflects leap)", async () => {
+      walletUtilsMock.getLeap.mockResolvedValue(undefined);
+      await expect(authenticateLeap(fakeWallet(), fakeNetwork())).rejects.toThrow(
+        /Leap wallet is not installed/
+      );
+    });
+
+    it("happy path builds a BaseWallet", async () => {
+      const offlineSigner = { getAccounts: async () => [] };
+      walletUtilsMock.getLeap.mockResolvedValue({
+        getOfflineSignerAuto: vi.fn().mockResolvedValue(offlineSigner),
+        experimentalSuggestChain: vi.fn().mockResolvedValue(undefined),
+        enable: vi.fn().mockResolvedValue(undefined)
+      });
+
+      await authenticateLeap(fakeWallet(), fakeNetwork());
+      expect(baseWalletCtor).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("authenticateLedger", () => {
+    it("uses WebUSB transport by default", async () => {
+      await authenticateLedger(fakeWallet(), fakeNetwork());
+      expect(webusbCreateMock).toHaveBeenCalledTimes(1);
+      expect(bluetoothCreateMock).not.toHaveBeenCalled();
+      expect(baseWalletCtor).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses Bluetooth transport when mechanism == LEDGER_BLUETOOTH", async () => {
+      walletManagerMock.getWalletConnectMechanism.mockReturnValue("ledger_bluetooth");
+      await authenticateLedger(fakeWallet(), fakeNetwork());
+      expect(bluetoothCreateMock).toHaveBeenCalledTimes(1);
+      expect(webusbCreateMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("authenticateEvmPhantom", () => {
+    it("creates MetaMaskWallet, connectCustom, passes WC signer to BaseWallet", async () => {
+      await authenticateEvmPhantom(fakeWallet(), fakeNetwork());
+      expect(fetchEndpointsMock).toHaveBeenCalledWith("nolus");
+      expect(metamaskConnectCustom).toHaveBeenCalledTimes(1);
+      expect(metamaskMakeWCOfflineSigner).toHaveBeenCalledTimes(1);
+      // The BaseWallet signer arg is the WC signer from MetaMask
+      expect(baseWalletCtor.mock.calls[0][1].type).toBe("evm");
+    });
+  });
+
+  describe("authenticateSolFlare", () => {
+    it("creates SolanaWallet and passes its WC signer to BaseWallet", async () => {
+      await authenticateSolFlare(fakeWallet(), fakeNetwork());
+      expect(solanaConnectCustom).toHaveBeenCalledTimes(1);
+      expect(solanaMakeWCOfflineSigner).toHaveBeenCalledTimes(1);
+      expect(baseWalletCtor.mock.calls[0][1].type).toBe("svm");
+    });
+
+    it("solflare errors during connectCustom propagate", async () => {
+      solanaConnectCustom.mockRejectedValueOnce(new Error("user denied"));
+      await expect(authenticateSolFlare(fakeWallet(), fakeNetwork())).rejects.toThrow(/user denied/);
+      // BaseWallet is not created on failure
+      expect(baseWalletCtor).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cross-cutting", () => {
+    it("createWallet passes the tendermint client from the Wallet instance", async () => {
+      const offlineSigner = { getAccounts: async () => [] };
+      walletUtilsMock.getKeplr.mockResolvedValue({
+        getOfflineSignerAuto: vi.fn().mockResolvedValue(offlineSigner),
+        experimentalSuggestChain: vi.fn().mockResolvedValue(undefined),
+        enable: vi.fn().mockResolvedValue(undefined)
+      });
+      const wallet = fakeWallet();
+      await authenticateKeplr(wallet, fakeNetwork());
+      const args = baseWalletCtor.mock.calls[0];
+      expect(args[0]).toEqual({ kind: "comet" });
+    });
+  });
+});

--- a/src/networks/cosm/accountParser.test.ts
+++ b/src/networks/cosm/accountParser.test.ts
@@ -131,8 +131,6 @@ describe("accountFromAny", () => {
   it("throws when a wrapped account is missing its inner baseAccount", () => {
     // ModuleAccount without baseAccount trips the assert() call
     const bytes = ModuleAccount.encode(ModuleAccount.fromPartial({ name: "empty" })).finish();
-    expect(() =>
-      accountFromAny({ typeUrl: "/cosmos.auth.v1beta1.ModuleAccount", value: bytes })
-    ).toThrow();
+    expect(() => accountFromAny({ typeUrl: "/cosmos.auth.v1beta1.ModuleAccount", value: bytes })).toThrow();
   });
 });

--- a/src/networks/cosm/accountParser.test.ts
+++ b/src/networks/cosm/accountParser.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { toBase64 } from "@cosmjs/encoding";
+import { BaseAccount, ModuleAccount } from "cosmjs-types/cosmos/auth/v1beta1/auth";
+import {
+  BaseVestingAccount,
+  ContinuousVestingAccount,
+  DelayedVestingAccount,
+  PeriodicVestingAccount
+} from "cosmjs-types/cosmos/vesting/v1beta1/vesting";
+import { Any } from "cosmjs-types/google/protobuf/any";
+import { accountFromAny } from "./accountParser";
+import { encodePubkey } from "./encode";
+
+const ADDRESS = "nolus1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmjy3kzc";
+const SECP_KEY = new Uint8Array(33);
+SECP_KEY[0] = 0x03;
+for (let i = 1; i < 33; i++) SECP_KEY[i] = i;
+
+function encodedSecpPubkeyAny(): Any {
+  return encodePubkey({ type: "tendermint/PubKeySecp256k1", value: toBase64(SECP_KEY) });
+}
+
+function makeBaseAccountBytes(seq = 42n, num = 100n, withPubKey = true): Uint8Array {
+  return BaseAccount.encode(
+    BaseAccount.fromPartial({
+      address: ADDRESS,
+      pubKey: withPubKey ? encodedSecpPubkeyAny() : undefined,
+      accountNumber: num,
+      sequence: seq
+    })
+  ).finish();
+}
+
+describe("accountFromAny", () => {
+  it("parses a plain BaseAccount", () => {
+    const parsed = accountFromAny({
+      typeUrl: "/cosmos.auth.v1beta1.BaseAccount",
+      value: makeBaseAccountBytes()
+    });
+    expect(parsed.address).toBe(ADDRESS);
+    expect(parsed.accountNumber).toBe(100);
+    expect(parsed.sequence).toBe(42);
+    expect(parsed.pubkey).not.toBeNull();
+  });
+
+  it("parses a BaseAccount without a pubkey (returns null pubkey)", () => {
+    const parsed = accountFromAny({
+      typeUrl: "/cosmos.auth.v1beta1.BaseAccount",
+      value: makeBaseAccountBytes(0n, 1n, false)
+    });
+    expect(parsed.pubkey).toBeNull();
+  });
+
+  it("parses a ModuleAccount (unwraps inner base)", () => {
+    const bytes = ModuleAccount.encode(
+      ModuleAccount.fromPartial({
+        baseAccount: BaseAccount.fromPartial({
+          address: ADDRESS,
+          accountNumber: 7n,
+          sequence: 3n
+        }),
+        name: "fee_collector"
+      })
+    ).finish();
+    const parsed = accountFromAny({ typeUrl: "/cosmos.auth.v1beta1.ModuleAccount", value: bytes });
+    expect(parsed.address).toBe(ADDRESS);
+    expect(parsed.accountNumber).toBe(7);
+    expect(parsed.sequence).toBe(3);
+  });
+
+  it("parses a BaseVestingAccount (unwraps baseAccount)", () => {
+    const bytes = BaseVestingAccount.encode(
+      BaseVestingAccount.fromPartial({
+        baseAccount: BaseAccount.fromPartial({ address: ADDRESS, accountNumber: 1n, sequence: 9n })
+      })
+    ).finish();
+    const parsed = accountFromAny({ typeUrl: "/cosmos.vesting.v1beta1.BaseVestingAccount", value: bytes });
+    expect(parsed.address).toBe(ADDRESS);
+    expect(parsed.sequence).toBe(9);
+  });
+
+  it("parses a ContinuousVestingAccount", () => {
+    const bytes = ContinuousVestingAccount.encode(
+      ContinuousVestingAccount.fromPartial({
+        baseVestingAccount: BaseVestingAccount.fromPartial({
+          baseAccount: BaseAccount.fromPartial({ address: ADDRESS, accountNumber: 2n, sequence: 0n })
+        })
+      })
+    ).finish();
+    const parsed = accountFromAny({
+      typeUrl: "/cosmos.vesting.v1beta1.ContinuousVestingAccount",
+      value: bytes
+    });
+    expect(parsed.address).toBe(ADDRESS);
+    expect(parsed.accountNumber).toBe(2);
+  });
+
+  it("parses a DelayedVestingAccount", () => {
+    const bytes = DelayedVestingAccount.encode(
+      DelayedVestingAccount.fromPartial({
+        baseVestingAccount: BaseVestingAccount.fromPartial({
+          baseAccount: BaseAccount.fromPartial({ address: ADDRESS, accountNumber: 3n, sequence: 0n })
+        })
+      })
+    ).finish();
+    const parsed = accountFromAny({ typeUrl: "/cosmos.vesting.v1beta1.DelayedVestingAccount", value: bytes });
+    expect(parsed.accountNumber).toBe(3);
+  });
+
+  it("parses a PeriodicVestingAccount", () => {
+    const bytes = PeriodicVestingAccount.encode(
+      PeriodicVestingAccount.fromPartial({
+        baseVestingAccount: BaseVestingAccount.fromPartial({
+          baseAccount: BaseAccount.fromPartial({ address: ADDRESS, accountNumber: 4n, sequence: 5n })
+        })
+      })
+    ).finish();
+    const parsed = accountFromAny({
+      typeUrl: "/cosmos.vesting.v1beta1.PeriodicVestingAccount",
+      value: bytes
+    });
+    expect(parsed.sequence).toBe(5);
+  });
+
+  it("throws on unsupported typeUrl", () => {
+    expect(() =>
+      accountFromAny({ typeUrl: "/cosmos.auth.v1beta1.SomeUnknownAccount", value: new Uint8Array() })
+    ).toThrow(/Unsupported type/);
+  });
+
+  it("throws when a wrapped account is missing its inner baseAccount", () => {
+    // ModuleAccount without baseAccount trips the assert() call
+    const bytes = ModuleAccount.encode(ModuleAccount.fromPartial({ name: "empty" })).finish();
+    expect(() =>
+      accountFromAny({ typeUrl: "/cosmos.auth.v1beta1.ModuleAccount", value: bytes })
+    ).toThrow();
+  });
+});

--- a/src/networks/cosm/encode.test.ts
+++ b/src/networks/cosm/encode.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { toBase64 } from "@cosmjs/encoding";
+import { Any } from "cosmjs-types/google/protobuf/any";
+import type { Pubkey } from "@cosmjs/amino";
+import { encodePubkey, decodePubkey } from "./encode";
+
+// secp256k1 pubkeys must be exactly 33 bytes (compressed).
+// ed25519 pubkeys must be exactly 32 bytes.
+const SECP_KEY = new Uint8Array(33);
+SECP_KEY[0] = 0x02; // compressed pubkey prefix
+for (let i = 1; i < 33; i++) SECP_KEY[i] = i;
+const SECP_KEY_B64 = toBase64(SECP_KEY);
+
+const ED_KEY = new Uint8Array(32);
+for (let i = 0; i < 32; i++) ED_KEY[i] = i + 1;
+const ED_KEY_B64 = toBase64(ED_KEY);
+
+describe("encodePubkey", () => {
+  it("encodes a secp256k1 pubkey to /cosmos.crypto.secp256k1.PubKey Any", () => {
+    const pubkey: Pubkey = { type: "tendermint/PubKeySecp256k1", value: SECP_KEY_B64 };
+    const any = encodePubkey(pubkey);
+    expect(any.typeUrl).toBe("/cosmos.crypto.secp256k1.PubKey");
+    expect(any.value).toBeInstanceOf(Uint8Array);
+    expect(any.value.length).toBeGreaterThan(0);
+  });
+
+  it("encodes an ed25519 pubkey to /cosmos.crypto.ed25519.PubKey Any", () => {
+    const pubkey: Pubkey = { type: "tendermint/PubKeyEd25519", value: ED_KEY_B64 };
+    const any = encodePubkey(pubkey);
+    expect(any.typeUrl).toBe("/cosmos.crypto.ed25519.PubKey");
+    expect(any.value).toBeInstanceOf(Uint8Array);
+    expect(any.value.length).toBeGreaterThan(0);
+  });
+
+  it("encodes a multisig threshold pubkey recursively", () => {
+    const pubkey: Pubkey = {
+      type: "tendermint/PubKeyMultisigThreshold",
+      value: {
+        threshold: "2",
+        pubkeys: [
+          { type: "tendermint/PubKeySecp256k1", value: SECP_KEY_B64 },
+          { type: "tendermint/PubKeySecp256k1", value: SECP_KEY_B64 }
+        ]
+      }
+    };
+    const any = encodePubkey(pubkey);
+    expect(any.typeUrl).toBe("/cosmos.crypto.multisig.LegacyAminoPubKey");
+    expect(any.value).toBeInstanceOf(Uint8Array);
+  });
+
+  it("throws for an unrecognized pubkey type", () => {
+    const pubkey = { type: "tendermint/Unknown", value: "AAAA" } as unknown as Pubkey;
+    expect(() => encodePubkey(pubkey)).toThrow(/not recognized/);
+  });
+
+  it("is a lossless round-trip for secp256k1", () => {
+    const pubkey: Pubkey = { type: "tendermint/PubKeySecp256k1", value: SECP_KEY_B64 };
+    const decoded = decodePubkey(encodePubkey(pubkey));
+    expect(decoded).toEqual(pubkey);
+  });
+});
+
+describe("decodePubkey", () => {
+  it("returns null when pubkey is undefined", () => {
+    expect(decodePubkey(undefined)).toBeNull();
+  });
+
+  it("returns null when pubkey is null", () => {
+    expect(decodePubkey(null)).toBeNull();
+  });
+
+  it("returns null when pubkey.value is falsy (undefined on Any shape)", () => {
+    // The production guard is `!pubkey.value`; Any's default from fromPartial gives a Uint8Array,
+    // but an object crafted with an undefined `value` field triggers the null branch.
+    const any = { typeUrl: "/cosmos.crypto.secp256k1.PubKey", value: undefined as unknown as Uint8Array };
+    expect(decodePubkey(any as unknown as Any)).toBeNull();
+  });
+
+  it("decodes an ed25519 Any back to an amino pubkey", () => {
+    const pubkey: Pubkey = { type: "tendermint/PubKeyEd25519", value: ED_KEY_B64 };
+    const decoded = decodePubkey(encodePubkey(pubkey));
+    expect(decoded).toEqual(pubkey);
+  });
+
+  it("decodes a multisig Any back to an amino multisig pubkey", () => {
+    const pubkey: Pubkey = {
+      type: "tendermint/PubKeyMultisigThreshold",
+      value: {
+        threshold: "2",
+        pubkeys: [
+          { type: "tendermint/PubKeySecp256k1", value: SECP_KEY_B64 },
+          { type: "tendermint/PubKeyEd25519", value: ED_KEY_B64 }
+        ]
+      }
+    };
+    const decoded = decodePubkey(encodePubkey(pubkey));
+    expect(decoded).toEqual(pubkey);
+  });
+
+  it("throws for an unrecognized typeUrl", () => {
+    const any = Any.fromPartial({ typeUrl: "/some.unknown.PubKey", value: new Uint8Array([1, 2, 3]) });
+    expect(() => decodePubkey(any)).toThrow(/not recognized/);
+  });
+});

--- a/src/networks/evm/sign.test.ts
+++ b/src/networks/evm/sign.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from "vitest";
+import { AuthInfo, SignerInfo, ModeInfo, Fee } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
+import { ensureEip191AuthInfoBytes, personalSignJSON } from "./sign";
+
+function singleSignerAuthInfo(mode: SignMode): AuthInfo {
+  return AuthInfo.fromPartial({
+    fee: Fee.fromPartial({ amount: [{ amount: "100", denom: "unls" }], gasLimit: 200000n }),
+    signerInfos: [
+      SignerInfo.fromPartial({
+        publicKey: { typeUrl: "/cosmos.crypto.secp256k1.PubKey", value: new Uint8Array([1, 2, 3]) },
+        sequence: 5n,
+        modeInfo: ModeInfo.fromPartial({ single: { mode } })
+      })
+    ]
+  });
+}
+
+describe("ensureEip191AuthInfoBytes", () => {
+  it("returns AuthInfo.encode unchanged when signer already uses SIGN_MODE_EIP_191", () => {
+    const authInfo = singleSignerAuthInfo(SignMode.SIGN_MODE_EIP_191);
+    const out = ensureEip191AuthInfoBytes(authInfo);
+    const expected = AuthInfo.encode(authInfo).finish();
+    expect(out).toEqual(expected);
+  });
+
+  it("patches a DIRECT-signed AuthInfo to EIP-191 mode, preserving sequence and pubkey", () => {
+    const authInfo = singleSignerAuthInfo(SignMode.SIGN_MODE_DIRECT);
+    const out = ensureEip191AuthInfoBytes(authInfo);
+
+    const decoded = AuthInfo.decode(out);
+    expect(decoded.signerInfos).toHaveLength(1);
+    expect(decoded.signerInfos[0].modeInfo?.single?.mode).toBe(SignMode.SIGN_MODE_EIP_191);
+    expect(decoded.signerInfos[0].sequence).toBe(5n);
+    expect(decoded.signerInfos[0].publicKey?.typeUrl).toBe("/cosmos.crypto.secp256k1.PubKey");
+  });
+
+  it("patches AMINO-JSON to EIP-191", () => {
+    const authInfo = singleSignerAuthInfo(SignMode.SIGN_MODE_LEGACY_AMINO_JSON);
+    const decoded = AuthInfo.decode(ensureEip191AuthInfoBytes(authInfo));
+    expect(decoded.signerInfos[0].modeInfo?.single?.mode).toBe(SignMode.SIGN_MODE_EIP_191);
+  });
+
+  it("preserves the original fee when patching", () => {
+    const authInfo = singleSignerAuthInfo(SignMode.SIGN_MODE_DIRECT);
+    const decoded = AuthInfo.decode(ensureEip191AuthInfoBytes(authInfo));
+    expect(decoded.fee?.gasLimit).toBe(200000n);
+    expect(decoded.fee?.amount).toEqual([{ amount: "100", denom: "unls" }]);
+  });
+
+  it("handles an empty signerInfos by still producing a valid encoded AuthInfo", () => {
+    const authInfo = AuthInfo.fromPartial({
+      fee: Fee.fromPartial({ gasLimit: 1n }),
+      signerInfos: []
+    });
+    const out = ensureEip191AuthInfoBytes(authInfo);
+    const decoded = AuthInfo.decode(out);
+    // Empty signerInfos means the `already` check is false, and the patched
+    // signerInfos has one entry with empty pubkey/sequence.
+    expect(decoded.signerInfos).toHaveLength(1);
+    expect(decoded.signerInfos[0].modeInfo?.single?.mode).toBe(SignMode.SIGN_MODE_EIP_191);
+  });
+});
+
+describe("personalSignJSON", () => {
+  const ETH_ADDR = "0x0000000000000000000000000000000000000001";
+
+  it("sends a 0x-hex encoded JSON string to personal_sign and strips the v byte", async () => {
+    // r (32 bytes) + s (32 bytes) + v (1 byte) = 65 bytes hex = 130 chars + "0x"
+    const sigHex = "0x" + "aa".repeat(32) + "bb".repeat(32) + "1c";
+    const request = vi.fn().mockResolvedValue(sigHex);
+    const provider = { request } as unknown as Parameters<typeof personalSignJSON>[1];
+
+    const rsBytes = await personalSignJSON({ foo: "bar" }, provider, ETH_ADDR);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const call = request.mock.calls[0][0];
+    expect(call.method).toBe("personal_sign");
+    expect(call.params[1]).toBe(ETH_ADDR);
+    expect(call.params[0]).toMatch(/^0x[0-9a-fA-F]+$/);
+
+    // r + s only — v byte stripped
+    expect(rsBytes).toBeInstanceOf(Uint8Array);
+    expect(rsBytes.length).toBe(64);
+    expect(rsBytes[0]).toBe(0xaa);
+    expect(rsBytes[31]).toBe(0xaa);
+    expect(rsBytes[32]).toBe(0xbb);
+    expect(rsBytes[63]).toBe(0xbb);
+  });
+
+  it("pretty-prints (4-space) the JSON passed to the signer", async () => {
+    const sigHex = "0x" + "00".repeat(65);
+    const request = vi.fn().mockResolvedValue(sigHex);
+    const provider = { request } as unknown as Parameters<typeof personalSignJSON>[1];
+
+    await personalSignJSON({ a: 1 }, provider, ETH_ADDR);
+    const hexParam: string = request.mock.calls[0][0].params[0];
+    // Decode back
+    const body = hexParam.slice(2);
+    const bytes = new Uint8Array(body.length / 2);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = parseInt(body.slice(i * 2, i * 2 + 2), 16);
+    const text = new TextDecoder().decode(bytes);
+    expect(text).toBe(JSON.stringify({ a: 1 }, null, 4));
+  });
+
+  it("propagates provider errors", async () => {
+    const provider = {
+      request: vi.fn().mockRejectedValue(new Error("user rejected"))
+    } as unknown as Parameters<typeof personalSignJSON>[1];
+
+    await expect(personalSignJSON({}, provider, ETH_ADDR)).rejects.toThrow(/user rejected/);
+  });
+
+  it("throws on hex strings with odd length (from malformed provider)", async () => {
+    // 131-char (odd) — triggers the "Hex string must have an even length" branch
+    const sigHex = "0x" + "a".repeat(131);
+    const provider = {
+      request: vi.fn().mockResolvedValue(sigHex)
+    } as unknown as Parameters<typeof personalSignJSON>[1];
+    await expect(personalSignJSON({}, provider, ETH_ADDR)).rejects.toThrow(/even length/);
+  });
+});

--- a/src/networks/evm/wallet.test.ts
+++ b/src/networks/evm/wallet.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SigningKey, Wallet as EthersWallet, hashMessage, hexlify, toUtf8Bytes } from "ethers";
+
+const stargateConnectMock = vi.fn();
+vi.mock("@cosmjs/stargate", () => ({
+  StargateClient: {
+    connect: (...args: unknown[]) => stargateConnectMock(...args)
+  }
+}));
+
+vi.mock("@nolus/nolusjs", () => ({
+  ChainConstants: { CHAIN_KEY: "nolus" },
+  NolusClient: {
+    setInstance: vi.fn(),
+    getInstance: vi.fn(() => ({ getChainId: vi.fn().mockResolvedValue("nolus-1") }))
+  }
+}));
+
+vi.mock("@/common/utils/EndpointService", () => ({
+  fetchEndpoints: vi.fn(async () => ({ rpc: "rpc", api: "api" }))
+}));
+
+vi.mock("@/common/utils", () => ({
+  EnvNetworkUtils: { getStoredNetworkName: vi.fn(() => "mainnet") },
+  WalletManager: {
+    getWalletConnectMechanism: vi.fn(() => undefined)
+  }
+}));
+
+vi.mock("@/config/global", () => ({
+  KeplrEmbedChainInfo: vi.fn(() => ({
+    bech32Config: { bech32PrefixAccAddr: "nolus" }
+  }))
+}));
+
+import { MetaMaskWallet } from "./wallet";
+import type { NetworkData, API } from "@/common/types";
+import type { Window as MMWindow } from "../window";
+
+// Use a fixed private key so we produce real valid secp256k1 signatures
+// without relying on jsdom's crypto entropy source.
+const TEST_PRIV_KEY = "0x4c0883a69102937d6231471b5dbb6204fe5129617082796bb3b72f23cfb3d6f1";
+const testWallet = new EthersWallet(TEST_PRIV_KEY);
+
+function mkProvider() {
+  const ethAddr = testWallet.address;
+  const request = vi.fn(async (args: { method: string; params?: unknown[] }) => {
+    switch (args.method) {
+      case "eth_requestAccounts":
+        return [ethAddr];
+      case "eth_accounts":
+        return [ethAddr];
+      case "personal_sign": {
+        const msgHex: string = (args.params as string[])[0];
+        // Decode hex to string, sign with ethers wallet's signing key
+        const bytes = new Uint8Array(msgHex.slice(2).length / 2);
+        for (let i = 0; i < bytes.length; i++) {
+          bytes[i] = parseInt(msgHex.slice(2 + i * 2, 4 + i * 2), 16);
+        }
+        const text = new TextDecoder().decode(bytes);
+        const sig = await testWallet.signMessage(text);
+        return sig;
+      }
+      default:
+        throw new Error(`Unhandled method ${args.method}`);
+    }
+  });
+  return { request };
+}
+
+function stubEthereum(provider: unknown) {
+  const w = window as unknown as MMWindow;
+  w.ethereum = provider as MMWindow["ethereum"];
+}
+function stubPhantom(provider: unknown) {
+  const w = window as unknown as MMWindow;
+  w.phantom = { ethereum: provider } as MMWindow["phantom"];
+}
+function clearWindow() {
+  const w = window as unknown as MMWindow;
+  delete w.ethereum;
+  delete w.phantom;
+}
+
+function networkStub(): NetworkData {
+  return {
+    embedChainInfo: () => ({ bech32Config: { bech32PrefixAccAddr: "nolus" } })
+  } as unknown as NetworkData;
+}
+
+describe("MetaMaskWallet", () => {
+  beforeEach(() => {
+    stargateConnectMock.mockReset();
+    stargateConnectMock.mockResolvedValue({ getChainId: vi.fn().mockResolvedValue("nolus-1") });
+  });
+
+  afterEach(() => {
+    clearWindow();
+    vi.restoreAllMocks();
+  });
+
+  it("connectCustom derives bech32 nolus address and secp256k1 compressed pubkey from signed challenge", async () => {
+    const provider = mkProvider();
+    stubEthereum(provider);
+
+    const mm = new MetaMaskWallet();
+    const { bech32Addr, ethAddress, pubkeyAny } = await mm.connectCustom(
+      { rpc: "r", api: "a" } as API,
+      networkStub()
+    );
+    expect(bech32Addr).toMatch(/^nolus1[a-z0-9]+$/);
+    expect(ethAddress).toBe(testWallet.address);
+    expect(pubkeyAny).toBeInstanceOf(Uint8Array);
+    expect(mm.chainId).toBe("nolus-1");
+    expect(mm.type).toBe("evm");
+    expect(mm.algo).toBe("secp256k1");
+    expect(mm.pubKey).toBeInstanceOf(Uint8Array);
+    // Compressed secp256k1 pubkey is 33 bytes, first byte 0x02 or 0x03
+    expect(mm.pubKey!.length).toBe(33);
+    expect([0x02, 0x03]).toContain(mm.pubKey![0]);
+  });
+
+  it("connect uses NolusClient + KeplrEmbedChainInfo and populates chainId/address", async () => {
+    const provider = mkProvider();
+    stubEthereum(provider);
+    const mm = new MetaMaskWallet();
+    await mm.connect("metamask");
+    expect(mm.chainId).toBe("nolus-1");
+    expect(mm.address).toMatch(/^nolus1/);
+  });
+
+  it("getChainId returns cached chainId", async () => {
+    const provider = mkProvider();
+    stubEthereum(provider);
+    const mm = new MetaMaskWallet();
+    await mm.connectCustom({ rpc: "r", api: "a" } as API, networkStub());
+    await expect(mm.getChainId()).resolves.toBe("nolus-1");
+  });
+
+  it("picks the last provider in ethereum.providers[] when present", async () => {
+    const primary = mkProvider();
+    const fallback = mkProvider();
+    const w = window as unknown as MMWindow;
+    w.ethereum = { providers: [fallback, primary] } as MMWindow["ethereum"];
+    const mm = new MetaMaskWallet();
+    await mm.connectCustom({ rpc: "r", api: "a" } as API, networkStub());
+    // Last provider is `primary`
+    expect(primary.request).toHaveBeenCalled();
+  });
+
+  it("uses phantom.ethereum when WalletConnectMechanism is EVM_PHANTOM", async () => {
+    const phantomProv = mkProvider();
+    const ethProv = mkProvider();
+    stubPhantom(phantomProv);
+    stubEthereum(ethProv);
+    const utilsMock = (await import("@/common/utils")) as unknown as {
+      WalletManager: { getWalletConnectMechanism: ReturnType<typeof vi.fn> };
+    };
+    utilsMock.WalletManager.getWalletConnectMechanism.mockReturnValueOnce("evm_phantom");
+
+    const mm = new MetaMaskWallet();
+    await mm.connectCustom({ rpc: "r", api: "a" } as API, networkStub());
+    expect(phantomProv.request).toHaveBeenCalled();
+  });
+
+  it("makeWCOfflineSigner.getAccounts returns a single account with the bech32 address", async () => {
+    const provider = mkProvider();
+    stubEthereum(provider);
+    const mm = new MetaMaskWallet();
+    await mm.connectCustom({ rpc: "r", api: "a" } as API, networkStub());
+    const signer = mm.makeWCOfflineSigner();
+    const accounts = await signer.getAccounts();
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].address).toBe(mm.address);
+    expect(accounts[0].algo).toBe("secp256k1");
+    expect(accounts[0].pubkey).toEqual(mm.pubKey);
+    expect(signer.type).toBe("evm");
+    expect(signer.chainId).toBe("nolus-1");
+  });
+
+  it("makeWCOfflineSigner.signDirect forwards a personal_sign call and returns a valid signature envelope", async () => {
+    const provider = mkProvider();
+    stubEthereum(provider);
+    const mm = new MetaMaskWallet();
+    await mm.connectCustom({ rpc: "r", api: "a" } as API, networkStub());
+
+    const signer = mm.makeWCOfflineSigner();
+    const { TxBody, AuthInfo, Fee, SignerInfo } = await import("cosmjs-types/cosmos/tx/v1beta1/tx");
+    const { SignMode } = await import("cosmjs-types/cosmos/tx/signing/v1beta1/signing");
+
+    const txBody = TxBody.fromPartial({ memo: "m", messages: [] });
+    const bodyBytes = TxBody.encode(txBody).finish();
+    const authInfo = AuthInfo.fromPartial({
+      fee: Fee.fromPartial({ amount: [{ amount: "1", denom: "unls" }], gasLimit: 100n }),
+      signerInfos: [
+        SignerInfo.fromPartial({
+          publicKey: { typeUrl: "/cosmos.crypto.secp256k1.PubKey", value: new Uint8Array([1]) },
+          sequence: 0n,
+          modeInfo: { single: { mode: SignMode.SIGN_MODE_DIRECT } }
+        })
+      ]
+    });
+    const authInfoBytes = AuthInfo.encode(authInfo).finish();
+
+    const res = await signer.signDirect("ignored", {
+      bodyBytes,
+      authInfoBytes,
+      chainId: "nolus-1",
+      accountNumber: 1n
+    });
+    expect(res.signature.pub_key.type).toBe("/cosmos.crypto.secp256k1.PubKey");
+    expect(typeof res.signature.signature).toBe("string");
+    expect(res.signed.chainId).toBe("nolus-1");
+    expect(res.signed.accountNumber).toBe(1n);
+    expect(res.signed.bodyBytes).toEqual(bodyBytes);
+    expect(res.signed.authInfoBytes).toBeInstanceOf(Uint8Array);
+    // authInfoBytes should now have EIP-191 mode set by ensureEip191AuthInfoBytes
+    const decoded = AuthInfo.decode(res.signed.authInfoBytes);
+    expect(decoded.signerInfos[0].modeInfo?.single?.mode).toBe(SignMode.SIGN_MODE_EIP_191);
+  });
+
+  it("produces a recoverable secp256k1 pubkey that matches the ethers signer", async () => {
+    const provider = mkProvider();
+    stubEthereum(provider);
+    const mm = new MetaMaskWallet();
+    await mm.connectCustom({ rpc: "r", api: "a" } as API, networkStub());
+
+    // Derive expected compressed pubkey from the same challenge "Generate address"
+    const expectedSig = await testWallet.signMessage("Generate address");
+    const fullPubkey = SigningKey.recoverPublicKey(hashMessage("Generate address"), expectedSig);
+    const expectedUncompressed = Buffer.from(fullPubkey.slice(2), "hex");
+    const x = expectedUncompressed.slice(1, 33);
+    const y = expectedUncompressed.slice(33);
+    const expectedCompressed = Buffer.concat([Buffer.from([y[y.length - 1] % 2 ? 0x03 : 0x02]), x]);
+    expect(Buffer.from(mm.pubKey!)).toEqual(expectedCompressed);
+  });
+
+  it("bech32 prefix comes from the ChainInfo returned by embedChainInfo (e.g. osmo)", async () => {
+    const provider = mkProvider();
+    stubEthereum(provider);
+    const osmoNet = {
+      embedChainInfo: () => ({ bech32Config: { bech32PrefixAccAddr: "osmo" } })
+    } as unknown as NetworkData;
+    const mm = new MetaMaskWallet();
+    const { bech32Addr } = await mm.connectCustom({ rpc: "r", api: "a" } as API, osmoNet);
+    expect(bech32Addr).toMatch(/^osmo1/);
+  });
+
+  it("personal_sign is called with 0x-hex of the challenge text", async () => {
+    const provider = mkProvider();
+    stubEthereum(provider);
+    const mm = new MetaMaskWallet();
+    await mm.connectCustom({ rpc: "r", api: "a" } as API, networkStub());
+    const personalSignCalls = provider.request.mock.calls.filter((c) => c[0].method === "personal_sign");
+    expect(personalSignCalls.length).toBeGreaterThan(0);
+    const firstChallenge = personalSignCalls[0][0].params[0];
+    expect(firstChallenge).toBe(hexlify(toUtf8Bytes("Generate address")));
+  });
+
+  it("throws when eth_requestAccounts rejects (user denies)", async () => {
+    const provider = {
+      request: vi.fn(async (args: { method: string }) => {
+        if (args.method === "eth_requestAccounts") throw new Error("user denied");
+        return [];
+      })
+    };
+    stubEthereum(provider);
+    const mm = new MetaMaskWallet();
+    await expect(mm.connectCustom({ rpc: "r", api: "a" } as API, networkStub())).rejects.toThrow(/user denied/);
+  });
+
+  it("ethAddress getter returns the address from eth_accounts", async () => {
+    const provider = mkProvider();
+    stubEthereum(provider);
+    const mm = new MetaMaskWallet();
+    await mm.connectCustom({ rpc: "r", api: "a" } as API, networkStub());
+    expect(mm.ethAddress).toBe(testWallet.address);
+  });
+});

--- a/src/networks/evm/wallet.test.ts
+++ b/src/networks/evm/wallet.test.ts
@@ -104,10 +104,7 @@ describe("MetaMaskWallet", () => {
     stubEthereum(provider);
 
     const mm = new MetaMaskWallet();
-    const { bech32Addr, ethAddress, pubkeyAny } = await mm.connectCustom(
-      { rpc: "r", api: "a" } as API,
-      networkStub()
-    );
+    const { bech32Addr, ethAddress, pubkeyAny } = await mm.connectCustom({ rpc: "r", api: "a" } as API, networkStub());
     expect(bech32Addr).toMatch(/^nolus1[a-z0-9]+$/);
     expect(ethAddress).toBe(testWallet.address);
     expect(pubkeyAny).toBeInstanceOf(Uint8Array);

--- a/src/networks/sol/wallet.test.ts
+++ b/src/networks/sol/wallet.test.ts
@@ -125,10 +125,7 @@ describe("SolanaWallet", () => {
     stubSolflare(provider);
     const sol = new SolanaWallet();
     await expect(
-      sol.connectCustom(
-        { rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0],
-        networkStub()
-      )
+      sol.connectCustom({ rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0], networkStub())
     ).rejects.toThrow(/Connection failed/);
   });
 
@@ -137,10 +134,7 @@ describe("SolanaWallet", () => {
     stubSolflare(provider);
     const sol = new SolanaWallet();
     await expect(
-      sol.connectCustom(
-        { rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0],
-        networkStub()
-      )
+      sol.connectCustom({ rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0], networkStub())
     ).rejects.toThrow(/Connection failed/);
   });
 

--- a/src/networks/sol/wallet.test.ts
+++ b/src/networks/sol/wallet.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const stargateConnectMock = vi.fn();
+vi.mock("@cosmjs/stargate", () => ({
+  StargateClient: {
+    connect: (...args: unknown[]) => stargateConnectMock(...args)
+  }
+}));
+
+vi.mock("@nolus/nolusjs", () => ({
+  ChainConstants: { CHAIN_KEY: "nolus" },
+  NolusClient: {
+    setInstance: vi.fn(),
+    getInstance: vi.fn(() => ({ getChainId: vi.fn().mockResolvedValue("nolus-1") }))
+  }
+}));
+
+vi.mock("@/common/utils/EndpointService", () => ({
+  fetchEndpoints: vi.fn(async () => ({ rpc: "rpc", api: "api" }))
+}));
+
+vi.mock("@/common/utils", () => ({
+  EnvNetworkUtils: {
+    getStoredNetworkName: vi.fn(() => "mainnet")
+  }
+}));
+
+vi.mock("@/config/global", () => ({
+  KeplrEmbedChainInfo: vi.fn(() => ({
+    bech32Config: { bech32PrefixAccAddr: "nolus" }
+  }))
+}));
+
+import { SolanaWallet } from "./wallet";
+import type { NetworkData } from "@/common/types";
+import type { Window } from "../window";
+
+const ED_PUBKEY_BYTES = new Uint8Array(32);
+for (let i = 0; i < 32; i++) ED_PUBKEY_BYTES[i] = i + 1;
+
+function makeProvider(overrides: Partial<Record<string, unknown>> = {}) {
+  const publicKey = {
+    toBytes: vi.fn(() => ED_PUBKEY_BYTES),
+    toBase58: vi.fn(() => "SolAddrBase58")
+  };
+  return {
+    connect: vi.fn().mockResolvedValue(true),
+    publicKey,
+    signMessage: vi.fn().mockResolvedValue({ signature: new Uint8Array(64) }),
+    ...overrides
+  };
+}
+
+function stubSolflare(provider: unknown) {
+  const w = window as unknown as Window & { solflare?: unknown };
+  w.solflare = provider as Window["solflare"];
+}
+
+function clearSolflare() {
+  const w = window as unknown as Window & { solflare?: unknown };
+  delete w.solflare;
+}
+
+function networkStub(): NetworkData {
+  return {
+    embedChainInfo: () => ({ bech32Config: { bech32PrefixAccAddr: "nolus" } })
+  } as unknown as NetworkData;
+}
+
+describe("SolanaWallet", () => {
+  beforeEach(() => {
+    stargateConnectMock.mockReset();
+    stargateConnectMock.mockResolvedValue({ getChainId: vi.fn().mockResolvedValue("nolus-1") });
+  });
+
+  afterEach(() => {
+    clearSolflare();
+    vi.restoreAllMocks();
+  });
+
+  it("connectCustom: derives bech32 nolus address from ed25519 pubkey and sets chainId", async () => {
+    const provider = makeProvider();
+    stubSolflare(provider);
+
+    const sol = new SolanaWallet();
+    const { solAddress, bech32Addr, pubkeyAny } = await sol.connectCustom(
+      { rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0],
+      networkStub()
+    );
+
+    expect(solAddress).toBe("SolAddrBase58");
+    expect(bech32Addr).toMatch(/^nolus1[a-z0-9]+$/);
+    expect(pubkeyAny).toBeInstanceOf(Uint8Array);
+    expect(pubkeyAny.length).toBeGreaterThan(0);
+    expect(sol.chainId).toBe("nolus-1");
+    expect(sol.type).toBe("svm");
+    expect(sol.algo).toBe("ed25519");
+    expect(sol.address).toBe(bech32Addr);
+    expect(sol.solAddress).toBe("SolAddrBase58");
+  });
+
+  it("connect: uses NolusClient + KeplrEmbedChainInfo path", async () => {
+    const provider = makeProvider();
+    stubSolflare(provider);
+
+    const sol = new SolanaWallet();
+    const { bech32Addr } = await sol.connect();
+    expect(bech32Addr).toMatch(/^nolus1/);
+    expect(sol.chainId).toBe("nolus-1");
+  });
+
+  it("getChainId returns the cached chainId", async () => {
+    const provider = makeProvider();
+    stubSolflare(provider);
+    const sol = new SolanaWallet();
+    await sol.connectCustom(
+      { rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0],
+      networkStub()
+    );
+    await expect(sol.getChainId()).resolves.toBe("nolus-1");
+  });
+
+  it("throws when provider.connect resolves false", async () => {
+    const provider = makeProvider({ connect: vi.fn().mockResolvedValue(false) });
+    stubSolflare(provider);
+    const sol = new SolanaWallet();
+    await expect(
+      sol.connectCustom(
+        { rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0],
+        networkStub()
+      )
+    ).rejects.toThrow(/Connection failed/);
+  });
+
+  it("throws when provider.publicKey is missing (user rejected)", async () => {
+    const provider = { connect: vi.fn().mockResolvedValue(true), publicKey: undefined };
+    stubSolflare(provider);
+    const sol = new SolanaWallet();
+    await expect(
+      sol.connectCustom(
+        { rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0],
+        networkStub()
+      )
+    ).rejects.toThrow(/Connection failed/);
+  });
+
+  it("makeWCOfflineSigner.getAccounts returns the derived account", async () => {
+    const provider = makeProvider();
+    stubSolflare(provider);
+    const sol = new SolanaWallet();
+    await sol.connectCustom(
+      { rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0],
+      networkStub()
+    );
+    const signer = sol.makeWCOfflineSigner();
+    const accounts = await signer.getAccounts();
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].address).toBe(sol.address);
+    expect(accounts[0].algo).toBe("ed25519");
+  });
+
+  it("makeWCOfflineSigner.signDirect throws 'not supported'", async () => {
+    const provider = makeProvider();
+    stubSolflare(provider);
+    const sol = new SolanaWallet();
+    await sol.connectCustom(
+      { rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0],
+      networkStub()
+    );
+    const signer = sol.makeWCOfflineSigner();
+    // signDirect does `throw "not supported"` (string literal), not an Error
+    await expect(signer.signDirect("", {} as never)).rejects.toBe("not supported");
+  });
+
+  it("makeWCOfflineSigner.simulateMultiTx signs via provider.signMessage and returns txHash/txBytes/usedFee", async () => {
+    const provider = makeProvider();
+    stubSolflare(provider);
+    const sol = new SolanaWallet();
+    await sol.connectCustom(
+      { rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0],
+      networkStub()
+    );
+    const signer = sol.makeWCOfflineSigner();
+
+    // Attach the host dependencies simulateMultiTx expects (via `this.`) —
+    // these are populated by NolusWallet when the signer is plugged in.
+    const bound = Object.assign(signer, {
+      registry: {
+        encodeAsAny: vi.fn((m: unknown) => ({ encoded: m }))
+      },
+      getSequence: vi.fn().mockResolvedValue({ accountNumber: 1n, sequence: 0n }),
+      getGasInfo: vi.fn().mockResolvedValue({
+        gasInfo: { gasUsed: 100000 },
+        gas: 150000,
+        usedFee: { amount: [{ denom: "unls", amount: "1" }], gas: "150000" }
+      })
+    });
+
+    const res = await bound.simulateMultiTx!(
+      [{ msg: { fromAddress: "a", toAddress: "b" }, msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend" }],
+      ""
+    );
+    expect(provider.signMessage).toHaveBeenCalledTimes(1);
+    expect(res).toHaveProperty("txHash");
+    expect(res).toHaveProperty("txBytes");
+    expect(res).toHaveProperty("usedFee");
+  });
+
+  it("makeWCOfflineSigner.simulateTx delegates to simulateMultiTx with a single-message list", async () => {
+    const provider = makeProvider();
+    stubSolflare(provider);
+    const sol = new SolanaWallet();
+    await sol.connectCustom(
+      { rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0],
+      networkStub()
+    );
+    const signer = sol.makeWCOfflineSigner();
+    const bound = Object.assign(signer, {
+      simulateMultiTx: vi.fn().mockResolvedValue({ txHash: "deadbeef", txBytes: new Uint8Array(), usedFee: {} })
+    });
+    await bound.simulateTx!({ x: 1 } as never, "/cosmos.bank.v1beta1.MsgSend", "memo");
+    expect(bound.simulateMultiTx).toHaveBeenCalledWith(
+      [{ msg: { x: 1 }, msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend" }],
+      "memo"
+    );
+  });
+
+  it("signer has type=svm and correct chainId", async () => {
+    const provider = makeProvider();
+    stubSolflare(provider);
+    const sol = new SolanaWallet();
+    await sol.connectCustom(
+      { rpc: "r", api: "a" } as unknown as Parameters<typeof sol.connectCustom>[0],
+      networkStub()
+    );
+    const signer = sol.makeWCOfflineSigner();
+    expect(signer.type).toBe("svm");
+    expect(signer.chainId).toBe("nolus-1");
+  });
+});

--- a/src/networks/utilities.test.ts
+++ b/src/networks/utilities.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "vitest";
+import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
+import { MsgDelegate, MsgUndelegate, MsgBeginRedelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
+import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
+import { MsgVote } from "cosmjs-types/cosmos/gov/v1beta1/tx";
+import { MsgTransfer as IbcMsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
+import { MsgExecuteContract } from "cosmjs-types/cosmwasm/wasm/v1/tx";
+import { reorderCoinsDeep, anyToLegacy } from "./utilities";
+
+describe("reorderCoinsDeep", () => {
+  it("returns primitives unchanged", () => {
+    expect(reorderCoinsDeep("x")).toBe("x");
+    expect(reorderCoinsDeep(42)).toBe(42);
+    expect(reorderCoinsDeep(null)).toBeNull();
+    expect(reorderCoinsDeep(undefined)).toBeUndefined();
+  });
+
+  it("reorders {denom, amount} → {amount, denom} for a coin-shaped object", () => {
+    const out = reorderCoinsDeep({ denom: "unls", amount: "1000" }) as Record<string, unknown>;
+    expect(Object.keys(out)).toEqual(["amount", "denom"]);
+    expect(out).toEqual({ amount: "1000", denom: "unls" });
+  });
+
+  it("leaves non-coin objects untouched (key order preserved)", () => {
+    const input = { foo: 1, bar: 2 };
+    const out = reorderCoinsDeep(input) as Record<string, unknown>;
+    expect(Object.keys(out)).toEqual(["foo", "bar"]);
+  });
+
+  it("recurses into arrays, reordering nested coins", () => {
+    const out = reorderCoinsDeep([
+      { denom: "a", amount: "1" },
+      { denom: "b", amount: "2" }
+    ]);
+    expect(out).toEqual([
+      { amount: "1", denom: "a" },
+      { amount: "2", denom: "b" }
+    ]);
+  });
+
+  it("recurses into nested objects, reordering coins inside", () => {
+    const out = reorderCoinsDeep({
+      wrapper: { denom: "u", amount: "7" }
+    }) as Record<string, unknown>;
+    expect(out).toEqual({ wrapper: { amount: "7", denom: "u" } });
+  });
+
+  it("coerces missing amount/denom fields to defaults when reordering", () => {
+    const out = reorderCoinsDeep({ denom: "x", amount: undefined }) as Record<string, unknown>;
+    expect(out).toEqual({ amount: "0", denom: "x" });
+  });
+
+  it("does not treat 3-key objects with denom+amount as coins", () => {
+    const out = reorderCoinsDeep({ denom: "u", amount: "1", extra: true }) as Record<string, unknown>;
+    expect(Object.keys(out)).toEqual(["denom", "amount", "extra"]);
+  });
+});
+
+describe("anyToLegacy", () => {
+  it("throws for an unregistered typeUrl", () => {
+    expect(() => anyToLegacy({ typeUrl: "/some.unknown.Msg", value: new Uint8Array() })).toThrow(
+      /Unregistered typeUrl/
+    );
+  });
+
+  it("converts a MsgSend to amino form with reordered coin amounts", () => {
+    const m = MsgSend.fromPartial({
+      fromAddress: "nolus1from",
+      toAddress: "nolus1to",
+      amount: [{ denom: "unls", amount: "1000" }]
+    });
+    const bytes = MsgSend.encode(m).finish();
+    const out = anyToLegacy({ typeUrl: "/cosmos.bank.v1beta1.MsgSend", value: bytes });
+    expect(out.type).toBe("cosmos-sdk/MsgSend");
+    const v = out.value as { amount: unknown[]; from_address: string; to_address: string };
+    expect(v.from_address).toBe("nolus1from");
+    expect(v.to_address).toBe("nolus1to");
+    expect(v.amount).toEqual([{ amount: "1000", denom: "unls" }]);
+  });
+
+  it("converts MsgDelegate to cosmos-sdk/MsgDelegate", () => {
+    const m = MsgDelegate.fromPartial({
+      delegatorAddress: "nolus1d",
+      validatorAddress: "nolusvaloper1v",
+      amount: { denom: "unls", amount: "500" }
+    });
+    const bytes = MsgDelegate.encode(m).finish();
+    const out = anyToLegacy({ typeUrl: "/cosmos.staking.v1beta1.MsgDelegate", value: bytes });
+    expect(out.type).toBe("cosmos-sdk/MsgDelegate");
+    const v = out.value as { delegator_address: string; validator_address: string; amount: unknown };
+    expect(v.delegator_address).toBe("nolus1d");
+    expect(v.validator_address).toBe("nolusvaloper1v");
+    expect(v.amount).toEqual({ amount: "500", denom: "unls" });
+  });
+
+  it("converts MsgUndelegate to cosmos-sdk/MsgUndelegate", () => {
+    const m = MsgUndelegate.fromPartial({
+      delegatorAddress: "nolus1d",
+      validatorAddress: "nolusvaloper1v",
+      amount: { denom: "unls", amount: "500" }
+    });
+    const bytes = MsgUndelegate.encode(m).finish();
+    const out = anyToLegacy({ typeUrl: "/cosmos.staking.v1beta1.MsgUndelegate", value: bytes });
+    expect(out.type).toBe("cosmos-sdk/MsgUndelegate");
+  });
+
+  it("converts MsgBeginRedelegate including src/dst validator", () => {
+    const m = MsgBeginRedelegate.fromPartial({
+      delegatorAddress: "nolus1d",
+      validatorSrcAddress: "nolusvaloper1src",
+      validatorDstAddress: "nolusvaloper1dst",
+      amount: { denom: "unls", amount: "500" }
+    });
+    const bytes = MsgBeginRedelegate.encode(m).finish();
+    const out = anyToLegacy({ typeUrl: "/cosmos.staking.v1beta1.MsgBeginRedelegate", value: bytes });
+    expect(out.type).toBe("cosmos-sdk/MsgBeginRedelegate");
+    const v = out.value as { validator_src_address: string; validator_dst_address: string };
+    expect(v.validator_src_address).toBe("nolusvaloper1src");
+    expect(v.validator_dst_address).toBe("nolusvaloper1dst");
+  });
+
+  it("converts MsgWithdrawDelegatorReward to cosmos-sdk/MsgWithdrawDelegationReward", () => {
+    const m = MsgWithdrawDelegatorReward.fromPartial({
+      delegatorAddress: "nolus1d",
+      validatorAddress: "nolusvaloper1v"
+    });
+    const bytes = MsgWithdrawDelegatorReward.encode(m).finish();
+    const out = anyToLegacy({
+      typeUrl: "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
+      value: bytes
+    });
+    expect(out.type).toBe("cosmos-sdk/MsgWithdrawDelegationReward");
+  });
+
+  it("converts MsgVote and stringifies the proposal id", () => {
+    const m = MsgVote.fromPartial({
+      proposalId: 7n,
+      voter: "nolus1voter",
+      option: 1
+    });
+    const bytes = MsgVote.encode(m).finish();
+    const out = anyToLegacy({ typeUrl: "/cosmos.gov.v1beta1.MsgVote", value: bytes });
+    expect(out.type).toBe("cosmos-sdk/MsgVote");
+    const v = out.value as { proposal_id: string; voter: string; option: unknown };
+    expect(v.proposal_id).toBe("7");
+    expect(v.voter).toBe("nolus1voter");
+  });
+
+  it("converts IBC MsgTransfer with timeoutHeight populated (revision_* keys)", () => {
+    const m = IbcMsgTransfer.fromPartial({
+      sourcePort: "transfer",
+      sourceChannel: "channel-0",
+      sender: "nolus1s",
+      receiver: "osmo1r",
+      token: { denom: "unls", amount: "1" },
+      timeoutHeight: { revisionNumber: 1n, revisionHeight: 5n },
+      timeoutTimestamp: 0n,
+      memo: "hi"
+    });
+    const bytes = IbcMsgTransfer.encode(m).finish();
+    const out = anyToLegacy({ typeUrl: "/ibc.applications.transfer.v1.MsgTransfer", value: bytes });
+    expect(out.type).toBe("cosmos-sdk/MsgTransfer");
+    const v = out.value as { timeout_height: Record<string, string>; memo: string };
+    expect(v.timeout_height).toEqual({ revision_number: "1", revision_height: "5" });
+    expect(v.memo).toBe("hi");
+  });
+
+  it("converts IBC MsgTransfer with zero timeoutHeight to an empty object", () => {
+    const m = IbcMsgTransfer.fromPartial({
+      sourcePort: "transfer",
+      sourceChannel: "channel-0",
+      sender: "nolus1s",
+      receiver: "osmo1r",
+      token: { denom: "unls", amount: "1" },
+      timeoutHeight: { revisionNumber: 0n, revisionHeight: 0n },
+      timeoutTimestamp: 123n
+    });
+    const bytes = IbcMsgTransfer.encode(m).finish();
+    const out = anyToLegacy({ typeUrl: "/ibc.applications.transfer.v1.MsgTransfer", value: bytes });
+    const v = out.value as { timeout_height: Record<string, string>; timeout_timestamp: string };
+    expect(v.timeout_height).toEqual({});
+    expect(v.timeout_timestamp).toBe("123");
+  });
+
+  it("MsgTransfer default memo is empty string when unset", () => {
+    const m = IbcMsgTransfer.fromPartial({
+      sourcePort: "transfer",
+      sourceChannel: "channel-0",
+      sender: "a",
+      receiver: "b",
+      token: { denom: "u", amount: "1" },
+      timeoutTimestamp: 1n
+    });
+    const bytes = IbcMsgTransfer.encode(m).finish();
+    const out = anyToLegacy({ typeUrl: "/ibc.applications.transfer.v1.MsgTransfer", value: bytes });
+    const v = out.value as { memo: string };
+    expect(v.memo).toBe("");
+  });
+
+  it("converts MsgExecuteContract — msg decoded from UTF-8 JSON", () => {
+    const innerMsg = { swap: { amount: "10" } };
+    const bytes = MsgExecuteContract.encode(
+      MsgExecuteContract.fromPartial({
+        sender: "nolus1s",
+        contract: "nolus1c",
+        msg: new TextEncoder().encode(JSON.stringify(innerMsg)),
+        funds: [{ denom: "unls", amount: "100" }]
+      })
+    ).finish();
+    const out = anyToLegacy({ typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract", value: bytes });
+    expect(out.type).toBe("wasm/MsgExecuteContract");
+    const v = out.value as { contract: string; sender: string; msg: unknown; funds: unknown[] };
+    expect(v.contract).toBe("nolus1c");
+    expect(v.sender).toBe("nolus1s");
+    expect(v.msg).toEqual(innerMsg);
+    expect(v.funds).toEqual([{ amount: "100", denom: "unls" }]);
+  });
+
+  it("MsgExecuteContract with malformed msg bytes yields an empty object (silently)", () => {
+    const bytes = MsgExecuteContract.encode(
+      MsgExecuteContract.fromPartial({
+        sender: "s",
+        contract: "c",
+        msg: new TextEncoder().encode("not-json"),
+        funds: []
+      })
+    ).finish();
+    const out = anyToLegacy({ typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract", value: bytes });
+    const v = out.value as { msg: unknown };
+    expect(v.msg).toEqual({});
+  });
+
+  it("MsgExecuteContract with empty msg bytes yields an empty object", () => {
+    const bytes = MsgExecuteContract.encode(
+      MsgExecuteContract.fromPartial({
+        sender: "s",
+        contract: "c",
+        msg: new Uint8Array(),
+        funds: []
+      })
+    ).finish();
+    const out = anyToLegacy({ typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract", value: bytes });
+    const v = out.value as { msg: unknown };
+    expect(v.msg).toEqual({});
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,13 +25,13 @@ export default mergeConfig(
           "src/config/global/**"
         ],
         thresholds: {
-          // Phase 3 global floors — set just below current actuals (15.71% / 89.84% / 64.21% / 15.71%)
-          // to catch regressions without fighting routine changes. Phases 4+ ratchet these up
-          // as more source surface gets covered.
-          lines: 14,
+          // Phase 4 global floors — actuals now ~20.95/89.8/71.71/20.95 after
+          // wallet + signing tests landed. Keep floors just below actuals to
+          // catch regressions; ratchet up as more surface is covered.
+          lines: 20,
           branches: 88,
-          functions: 63,
-          statements: 14,
+          functions: 70,
+          statements: 20,
           // Per-file floors for Phase 1 target files (utils + api)
           "src/common/utils/LeaseCalculator.ts": {
             lines: 85,
@@ -143,6 +143,82 @@ export default mergeConfig(
             branches: 70,
             functions: 55,
             statements: 70
+          },
+          // Per-file floors for Phase 4 wallet + signing target files.
+          // Pure logic files — very high bar.
+          "src/networks/cosm/encode.ts": {
+            lines: 95,
+            branches: 90,
+            functions: 100,
+            statements: 95
+          },
+          "src/networks/cosm/accountParser.ts": {
+            lines: 100,
+            branches: 100,
+            functions: 100,
+            statements: 100
+          },
+          "src/networks/utilities.ts": {
+            lines: 95,
+            branches: 75,
+            functions: 100,
+            statements: 95
+          },
+          "src/networks/evm/sign.ts": {
+            lines: 100,
+            branches: 90,
+            functions: 100,
+            statements: 100
+          },
+          "src/common/composables/useAsyncOperation.ts": {
+            lines: 95,
+            branches: 85,
+            functions: 100,
+            statements: 95
+          },
+          // Wallet classes — high bar.
+          "src/networks/cosm/Wallet.ts": {
+            lines: 95,
+            branches: 85,
+            functions: 95,
+            statements: 95
+          },
+          "src/networks/cosm/NolusWalletOverride.ts": {
+            lines: 95,
+            branches: 85,
+            functions: 95,
+            statements: 95
+          },
+          "src/networks/sol/wallet.ts": {
+            lines: 95,
+            branches: 85,
+            functions: 95,
+            statements: 95
+          },
+          "src/networks/evm/wallet.ts": {
+            lines: 95,
+            branches: 75,
+            functions: 95,
+            statements: 95
+          },
+          "src/networks/cosm/WalletFactory.ts": {
+            lines: 95,
+            branches: 90,
+            functions: 95,
+            statements: 95
+          },
+          // BaseWallet — complex, inherits from SigningCosmWasmClient.
+          "src/networks/cosm/BaseWallet.ts": {
+            lines: 70,
+            branches: 60,
+            functions: 85,
+            statements: 70
+          },
+          "src/common/utils/SkipRoute.ts": {
+            lines: 75,
+            branches: 85,
+            functions: 65,
+            statements: 75
           }
         }
       }


### PR DESCRIPTION
## Summary

Phase 4 of 6. Wallet and signing infrastructure — components that directly handle user funds, previously 0% tested. Stacks on #121.

## Stats

| | Before | After |
|---|---|---|
| Frontend tests | 483 | **630** (+147) |
| Frontend line coverage | 15.71% | **20.95%** |
| Frontend function coverage | 63% | **71.71%** |

## What's covered

**CosmJS signing (cosm/):**
- `encode.test.ts` (11) — Any pubkey encoding, secp256k1 legacy aliasing, multisig, empty/invalid pubkey paths
- `accountParser.test.ts` (9) — 100%
- `Wallet.test.ts` (9) — 100%
- `NolusWalletOverride.test.ts` (13) — 100% lines
- `WalletFactory.test.ts` (12)
- `BaseWallet.test.ts` (20) — simulate/sign/broadcast via hand-rolled `SigningCosmWasmClient` stub; `simulateSendIbcTokensTx` deterministic with `vi.setSystemTime`

**EVM (evm/):**
- `sign.test.ts` (9) — ethers v6 idioms
- `wallet.test.ts` (12) — MetaMask flow with real `ethers.Wallet` + fixed private key (for recoverable signatures — `createRandom()` fails under jsdom crypto surface)

**Solana (sol/):**
- `wallet.test.ts` (10) — documents the `throw \"not supported\"` string-literal behavior in `signDirect`

**Cross-chain utilities:**
- `utilities.test.ts` (20) — `reorderCoinsDeep` + `anyToLegacy` codec; documents silent `\"0\"` amount auto-heal
- `useAsyncOperation.test.ts` (8) — ApiError discrimination + toast invocation

**SkipRoute (extended from Phase 0's 9 → 23):**
- **Critical**: asserts `route.revert === true` is ALWAYS enforced after `getRoute`, even when backend returns `revert: false`. Per project CLAUDE.md: \"always set to true — do not change without thorough swap direction testing.\"
- `submitRoute` / `transaction()` paths
- `MsgTransfer` / `MsgSend` / `MsgExecuteContract` construction (incl. C1 regression from Phase 0)
- Per-chain wallet dispatch

## Real defects found in production code (NOT fixed — logged for future review)

Per test-only scope. All reachable code but low-severity / latent:

1. `src/networks/cosm/encode.ts:48` — `!pubkey.value` guard does NOT trip for `new Uint8Array()` (empty, but truthy); flows into `CosmosCryptoSecp256k1Pubkey.decode(empty)` which throws. Comment intent wrong.
2. `src/networks/utilities.ts:25` — `reorderCoinsDeep` silently coerces missing amount to `\"0\"`, auto-healing malformed backend responses into valid-looking coins.
3. `src/networks/cosm/BaseWallet.ts:114` — `simulateTx` has `gasMultiplier` / `gasPrice` parameters that are shadowed by `this.gasMultiplier` / `this.gasPriceData` (always set in constructor). Callers passing custom values are silently ignored.
4. `src/networks/sol/wallet.ts:224` — `throw \"not supported\"` (string literal, not `Error`). Downstream stack trace loses context.
5. `src/networks/evm/wallet.ts:100` — bare `!` non-null assertion on pubkey parity byte (`y[y.length - 1]!`).

## Coverage thresholds added

Per-file entries in `vitest.config.ts` for all 12 target files. Global floors bumped: lines 14→20, functions 63→70, statements 14→20 (branches unchanged at 88). `BaseWallet.ts` per-file floors are intentionally lower (70/60/85/70) due to inherited `SigningCosmWasmClient` complexity.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 32 files / 630 tests pass
- [x] `npm run test:coverage` — all per-file + global thresholds pass
- [x] `npm run build` clean (husky pre-commit)
- [x] No new dependencies added
- [x] SkipRoute `revert: true` override locked by regression tests

## Next

- Phase 5: end-to-end HTTP + WS (backend)
- Phase 6: component & view integration