### PR TITLE
fix(ci): stop backend before rclone sync to avoid ETXTBSY

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -65,6 +65,11 @@ jobs:
             fi
           REMOTE
 
+      - name: Stop backend service (release binary lock)
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }} "\
+            sudo systemctl stop $SERVICE"
+
       - name: Deploy bundle via rclone
         run: |
           rclone sync deploy-bundle/ :sftp,host=${{ vars.DEPLOY_HOST }},user=${{ vars.DEPLOY_USER }},key_file=~/.ssh/id_ed25519:$DEPLOY_DIR/ \
@@ -75,11 +80,11 @@ jobs:
             --filter "- dist.bak/**" \
             --verbose
 
-      - name: Restart backend + mark binary executable
+      - name: Start backend + mark binary executable
         run: |
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }} "\
             chmod +x $DEPLOY_DIR/nolus-backend && \
-            sudo systemctl restart $SERVICE"
+            sudo systemctl start $SERVICE"
 
       - name: Health probe
         run: |

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -65,6 +65,11 @@ jobs:
             fi
           REMOTE
 
+      - name: Stop backend service (release binary lock)
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }} "\
+            sudo systemctl stop $SERVICE"
+
       - name: Deploy bundle via rclone
         run: |
           rclone sync deploy-bundle/ :sftp,host=${{ vars.DEPLOY_HOST }},user=${{ vars.DEPLOY_USER }},key_file=~/.ssh/id_ed25519:$DEPLOY_DIR/ \
@@ -75,11 +80,11 @@ jobs:
             --filter "- dist.bak/**" \
             --verbose
 
-      - name: Restart backend + mark binary executable
+      - name: Start backend + mark binary executable
         run: |
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no ${{ vars.DEPLOY_USER }}@${{ vars.DEPLOY_HOST }} "\
             chmod +x $DEPLOY_DIR/nolus-backend && \
-            sudo systemctl restart $SERVICE"
+            sudo systemctl start $SERVICE"
 
       - name: Health probe
         run: |


### PR DESCRIPTION
## Problem

Recent deploys to staging (and any prod deploy involving a backend-binary change) fail at the rclone step with:

\`\`\`
ERROR : nolus-backend: Failed to copy: Update Create failed: sftp: \"Failure\" (SSH_FX_FAILURE)
\`\`\`

Root cause: Linux returns \`ETXTBSY\` (\"Text file busy\") when you try to open a running executable for writing. \`rclone sync\` via SFTP uses truncate-and-write, which hits this error. The rollback step runs correctly and keeps the service healthy at the pre-merge state — so nothing is ever broken, but nothing ever deploys either.

## Fix

Stop the backend service before rclone sync, start it after. The binary is no longer held as a live image → rclone can overwrite. Trade-off: ~10-30s service downtime per deploy (vs. ~1s restart previously). Acceptable for staging and prod — deploys are infrequent and the health probe + rollback step still catch bad binaries.

Applied identically to \`deploy-dev.yaml\` and \`deploy-prod.yaml\`.

## Why this wasn't caught before

Previous deploys likely happened when the backend binary content didn't actually change (only frontend dist changed). rclone's sync detects no-op by checksum and skips the write. With the Phase 2 source fixes pending, the binary WILL change on upcoming deploys, so this needs to land first.

## Test plan

- [x] YAML parses
- [ ] Merge → triggers a deploy → verify staging comes up cleanly (health probe passes)
- [ ] Subsequent Phase 2 merge verifies binary overwrite now succeeds