### PR TITLE
fix(health): correct probe paths for /api/health/detailed

### DIFF
--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -265,7 +265,7 @@ async fn check_etl_health(state: &AppState, timeout_duration: Duration) -> Servi
         return ServiceStatus::not_configured();
     }
 
-    let check_url = format!("{}/pools", url);
+    let check_url = format!("{}/api/pools", url);
     debug!("Health check: ETL API at {}", check_url);
 
     let start = std::time::Instant::now();
@@ -398,7 +398,11 @@ async fn check_referral_health(state: &AppState, timeout_duration: Duration) -> 
         return ServiceStatus::not_configured();
     }
 
-    // Try to validate a dummy code (will return 404 but confirms connectivity)
+    // Try to validate a dummy code. The Referral API auth-walls every path,
+    // so an unauthenticated probe returns 401 when the service is reachable.
+    // Accept 200/401/404 all as "reachable" — the health check is only verifying
+    // connectivity, not authentication. Real requests from handlers go through
+    // ReferralClient which adds the Bearer token.
     let check_url = format!("{}/api/referrals/validate/HEALTH_CHECK", url);
     debug!("Health check: Referral API at {}", check_url);
 
@@ -411,12 +415,16 @@ async fn check_referral_health(state: &AppState, timeout_duration: Duration) -> 
     {
         Ok(Ok(response)) => {
             let latency = start.elapsed().as_millis() as u64;
-            // 404 is expected for invalid code, 200 means API is working
-            if response.status().is_success() || response.status() == reqwest::StatusCode::NOT_FOUND
+            let status = response.status();
+            // 200 = working, 404 = invalid code (expected for dummy), 401 = needs
+            // auth (API is reachable). All three confirm connectivity.
+            if status.is_success()
+                || status == reqwest::StatusCode::NOT_FOUND
+                || status == reqwest::StatusCode::UNAUTHORIZED
             {
                 ServiceStatus::healthy(latency)
             } else {
-                ServiceStatus::unhealthy(format!("HTTP {}", response.status()))
+                ServiceStatus::unhealthy(format!("HTTP {}", status))
             }
         }
         Ok(Err(e)) => {


### PR DESCRIPTION
\`/api/health/detailed\` reported \`etl_api\` and \`referral_api\` as degraded even though both services were healthy. Root cause: probe miscalibration.

### Bugs fixed

| Service | Old probe | Problem | Fix |
|---|---|---|---|
| \`etl_api\` | GET \`/pools\` | ETL service returns 404 on \`/pools\`; real endpoint is \`/api/pools\` | Use \`/api/pools\` |
| \`referral_api\` | GET \`/api/referrals/validate/HEALTH_CHECK\` | Returns 401 because the API auth-walls every path; the probe sent no Bearer token. Old code accepted only 200/404 as healthy | Accept 401 as well (matches existing \`check_zero_interest_health\` pattern) |

### Verification on staging

\`\`\`
$ curl -o /dev/null -w \"%{http_code}\" https://etl-internal.nolus.network/api/pools
200
$ curl -o /dev/null -w \"%{http_code}\" https://referral.nolus.io/api/referrals/validate/HEALTH_CHECK
401
\`\`\`

Both paths confirm the services are reachable. The real production clients (\`EtlClient\`, \`ReferralClient\`) already use the correct paths and send the Bearer token where needed — this PR only affects the admin-gated \`/api/health/detailed\` endpoint probe logic.

### Left unchanged: \`zero_interest_api\`

That one genuinely times out because its staging URL (\`http://192.168.4.74:3631\`) is unreachable from the webapp-dev host. Not a probe bug. Tracked separately for ops/infra triage.

### Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test --all-targets\` — 451/451 pass (no test required the old paths; the change is path-only)
- [ ] Post-merge: verify \`/api/health/detailed\` on staging reports etl_api + referral_api as healthy