### PR TITLE
fix(frontend): recover from stale chunk loads; guard empty validators

### DIFF
--- a/backend/config/locales/en.json
+++ b/backend/config/locales/en.json
@@ -273,6 +273,7 @@
     "deposit-assets": "Deposit assets to begin using Nolus",
     "vote-successful": "Vote successfully on {proposal} proposal",
     "delegate-successful": "Assets delegated successfully",
+    "delegate-no-validators": "No validators are currently available for delegation. Please try again later.",
     "undelegate-successful": "Assets undelegation now in progress",
     "rewards-claimed-successful": "Rewards claimed successfully",
     "validator-distribution-tooltip": "Distribution of stake across validators. As long as the validator remains active, you earn rewards and maintain voting power",

--- a/src/modules/stake/components/DelegateForm.test.ts
+++ b/src/modules/stake/components/DelegateForm.test.ts
@@ -161,13 +161,11 @@ import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import DelegateForm from "./DelegateForm.vue";
 
-function factory() {
+function factory(onShowToast: ReturnType<typeof vi.fn> = vi.fn()) {
   return mount(DelegateForm, {
     global: {
       mocks: { $t: (k: string) => k },
-      provide: {
-        onShowToast: vi.fn()
-      }
+      provide: { onShowToast }
     }
   });
 }
@@ -264,5 +262,66 @@ describe("DelegateForm.vue", () => {
     expect(hoisted.loadActivities).toHaveBeenCalled();
     expect(hoisted.routerPush).toHaveBeenCalledWith("/stake");
     wrapper.unmount();
+  });
+
+  describe("empty validators guard", () => {
+    beforeEach(() => {
+      hoisted.loadDelegatorValidators.mockResolvedValue([]);
+      hoisted.loadValidators.mockResolvedValue([]);
+    });
+
+    it("does not crash when both delegator and chain validators are empty", async () => {
+      const wrapper = factory();
+      await wrapper.find('[data-test="amount"]').setValue("100");
+      await wrapper.find('[data-test="submit"]').trigger("click");
+      await new Promise((r) => setTimeout(r, 0));
+      await nextTick();
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Form should still be mounted and button re-enabled
+      expect(wrapper.find('[data-test="submit"]').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it("does not call simulateDelegateTx or broadcastTx when no validators are available", async () => {
+      const wrapper = factory();
+      await wrapper.find('[data-test="amount"]').setValue("100");
+      await wrapper.find('[data-test="submit"]').trigger("click");
+      await new Promise((r) => setTimeout(r, 0));
+      await nextTick();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(hoisted.simulateDelegateTx).not.toHaveBeenCalled();
+      expect(hoisted.broadcastTx).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+
+    it("surfaces an error toast to the user when no validators are available", async () => {
+      const toast = vi.fn();
+      const wrapper = factory(toast);
+      await wrapper.find('[data-test="amount"]').setValue("100");
+      await wrapper.find('[data-test="submit"]').trigger("click");
+      await new Promise((r) => setTimeout(r, 0));
+      await nextTick();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(toast).toHaveBeenCalledExactlyOnceWith({
+        type: "error",
+        message: "message.delegate-no-validators"
+      });
+      wrapper.unmount();
+    });
+
+    it("does not navigate away when no validators are available", async () => {
+      const wrapper = factory();
+      await wrapper.find('[data-test="amount"]').setValue("100");
+      await wrapper.find('[data-test="submit"]').trigger("click");
+      await new Promise((r) => setTimeout(r, 0));
+      await nextTick();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(hoisted.routerPush).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
   });
 });

--- a/src/modules/stake/components/DelegateForm.vue
+++ b/src/modules/stake/components/DelegateForm.vue
@@ -162,12 +162,17 @@ function validateInputs() {
 async function delegate() {
   if (!wallet.wallet || validationError.value.length > 0) return;
 
-  let validators = await getValidators();
-  let division = STAKING.VALIDATORS_NUMBER;
+  let validators = (await getValidators())?.filter((v) => v?.operator_address) ?? [];
 
-  if (validators?.length > 0) {
-    division = validators?.length;
+  if (validators.length === 0) {
+    onShowToast({
+      type: ToastType.error,
+      message: i18n.t("message.delegate-no-validators")
+    });
+    return;
   }
+
+  const division = validators.length;
 
   const data = CurrencyUtils.convertNolusToUNolus(input.value);
   const amount = Number(data.amount.toString());

--- a/src/router/index.test.ts
+++ b/src/router/index.test.ts
@@ -109,3 +109,118 @@ describe("router/index.ts", () => {
     await expect(mod.router.push("/some/nonexistent/path")).resolves.not.toThrow();
   });
 });
+
+describe("handleChunkLoadError", () => {
+  const key = "nolus-chunk-reload-at";
+
+  function makeStorage(initial: Record<string, string> = {}): Storage {
+    const store: Record<string, string> = { ...initial };
+    return {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+      clear: () => {
+        for (const k of Object.keys(store)) delete store[k];
+      },
+      key: (i: number) => Object.keys(store)[i] ?? null,
+      get length() {
+        return Object.keys(store).length;
+      }
+    };
+  }
+
+  it("reloads on 'Failed to fetch dynamically imported module' error", async () => {
+    const { handleChunkLoadError } = await import("./index");
+    const reload = vi.fn();
+    const storage = makeStorage();
+
+    handleChunkLoadError(
+      new Error("Failed to fetch dynamically imported module: https://x/assets/SingleLease-abc.js"),
+      "/leases/nolus1abc",
+      storage,
+      1_000_000,
+      reload
+    );
+
+    expect(reload).toHaveBeenCalledExactlyOnceWith("/leases/nolus1abc");
+    expect(storage.getItem(key)).toBe("1000000");
+  });
+
+  it("reloads on 'Loading chunk X failed' error", async () => {
+    const { handleChunkLoadError } = await import("./index");
+    const reload = vi.fn();
+    handleChunkLoadError(new Error("Loading chunk 42 failed."), "/dashboard", makeStorage(), 1_000_000, reload);
+    expect(reload).toHaveBeenCalledExactlyOnceWith("/dashboard");
+  });
+
+  it("reloads on 'Importing a module script failed' (Safari)", async () => {
+    const { handleChunkLoadError } = await import("./index");
+    const reload = vi.fn();
+    handleChunkLoadError(new Error("Importing a module script failed."), "/earn", makeStorage(), 1_000_000, reload);
+    expect(reload).toHaveBeenCalledExactlyOnceWith("/earn");
+  });
+
+  it("does not reload for unrelated errors", async () => {
+    const { handleChunkLoadError } = await import("./index");
+    const reload = vi.fn();
+    handleChunkLoadError(new Error("Network disconnected"), "/leases", makeStorage(), 1_000_000, reload);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("does not reload when a reload happened within the last 10 seconds (loop guard)", async () => {
+    const { handleChunkLoadError } = await import("./index");
+    const reload = vi.fn();
+    const storage = makeStorage({ [key]: "995000" }); // 5s ago
+
+    handleChunkLoadError(
+      new Error("Failed to fetch dynamically imported module: x"),
+      "/leases",
+      storage,
+      1_000_000,
+      reload
+    );
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("reloads again once the 10s loop-guard window has elapsed", async () => {
+    const { handleChunkLoadError } = await import("./index");
+    const reload = vi.fn();
+    const storage = makeStorage({ [key]: "989000" }); // 11s ago
+
+    handleChunkLoadError(
+      new Error("Failed to fetch dynamically imported module: x"),
+      "/leases",
+      storage,
+      1_000_000,
+      reload
+    );
+
+    expect(reload).toHaveBeenCalledExactlyOnceWith("/leases");
+  });
+
+  it("falls back to current pathname when no target path is given", async () => {
+    const { handleChunkLoadError } = await import("./index");
+    const reload = vi.fn();
+    handleChunkLoadError(
+      new Error("Failed to fetch dynamically imported module: x"),
+      undefined,
+      makeStorage(),
+      1_000_000,
+      reload
+    );
+    expect(reload).toHaveBeenCalledExactlyOnceWith(window.location.pathname);
+  });
+
+  it("tolerates non-Error values (string / null)", async () => {
+    const { handleChunkLoadError } = await import("./index");
+    const reload = vi.fn();
+    handleChunkLoadError(null, "/leases", makeStorage(), 1_000_000, reload);
+    handleChunkLoadError("plain string", "/leases", makeStorage(), 1_000_000, reload);
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -63,6 +63,40 @@ router.beforeEach((to, from, next) => {
   next();
 });
 
+// After a deploy, already-open tabs still reference the old hashed JS chunks.
+// Lazy-route imports for those old chunks 404, the navigation silently completes
+// with no component mounted, and the user sees a blank main content area.
+// Force a fresh document load so the new index.html + new chunk hashes are picked up.
+const CHUNK_RELOAD_KEY = "nolus-chunk-reload-at";
+const CHUNK_RELOAD_COOLDOWN_MS = 10_000;
+const CHUNK_LOAD_ERROR_PATTERNS = [
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /Importing a module script failed/i,
+  /Loading chunk \S+ failed/i
+];
+
+export function handleChunkLoadError(
+  error: unknown,
+  toPath: string | undefined,
+  storage: Storage,
+  now: number,
+  reload: (path: string) => void
+): void {
+  if (!(error instanceof Error)) return;
+  if (!CHUNK_LOAD_ERROR_PATTERNS.some((re) => re.test(error.message))) return;
+
+  const last = Number(storage.getItem(CHUNK_RELOAD_KEY) ?? "0");
+  if (now - last < CHUNK_RELOAD_COOLDOWN_MS) return;
+  storage.setItem(CHUNK_RELOAD_KEY, String(now));
+
+  reload(toPath ?? window.location.pathname);
+}
+
+router.onError((error, to) => {
+  handleChunkLoadError(error, to?.fullPath, window.sessionStorage, Date.now(), (path) => window.location.assign(path));
+});
+
 router
   .isReady()
   .then(() => {
@@ -74,7 +108,9 @@ const preloadAllRoutes = () => {
   router.getRoutes().forEach((route) => {
     const preload = route.components?.default;
     if (typeof preload === "function") {
-      preload();
+      // Stale chunks after a deploy will reject here; don't pollute console —
+      // the real navigation will trigger router.onError with the same error.
+      Promise.resolve(preload()).catch(() => {});
     }
   });
 };


### PR DESCRIPTION
## Summary

Two pre-prod defensive fixes uncovered while smoke-testing today's build on staging.

### 1. Router chunk-load recovery (`src/router/index.ts`)

**Symptom:** After every deploy, the *first* user action that triggers a lazy route (e.g. opening the first lease → `/leases/<addr>`) renders a totally blank main content area. Subsequent actions work normally. Only once per deploy.

**Root cause:** Already-open tabs still reference old hashed JS chunks (e.g. `SingleLease-abc123.js`). After a deploy, those filenames 404 — the dynamic `import()` inside `LeasesRouter` rejects, the router navigation silently completes with no component mounted, and the user sees a blank page. A hard reload pulls a fresh `index.html` with new chunk hashes, so it only happens once.

**Fix:** `router.onError` handler that detects chunk-load failures across Chrome/Firefox/Safari message variants and hard-reloads to the target path. 10s `sessionStorage` cooldown prevents reload loops if the deploy is genuinely broken. Detection logic extracted as pure `handleChunkLoadError` for testability (8 tests).

Also added `.catch(() => {})` to `preloadAllRoutes()` — old chunks would reject on background preload too, polluting the console with the same error; the real navigation still triggers `onError`.

### 2. DelegateForm empty-validators guard

**Symptom:** If `getValidators()` returns an empty array (network hiccup, all validators jailed, etc.), `amounts[0].value += remainder` throws `TypeError` on `undefined`. The `onNextClick` try/catch swallows it — user clicks Delegate, nothing happens, no feedback.

**Fix:** Check for empty validators after the fetch + filter, show an error toast, return early. Filter also rejects entries missing `operator_address` (defensive against the `Utils.getRandomInt` + `.splice` pattern in `getValidators` that can push `undefined` when the eligible pool is smaller than `VALIDATORS_NUMBER`).

Added translation key `delegate-no-validators`.

## Test plan

- [x] `npx vue-tsc --noEmit` — passes
- [x] `npx prettier --check` — passes
- [x] `npx eslint --max-warnings=0` — passes
- [x] `npx vitest run` — 692/692 pass (12 new tests across router + DelegateForm)
- [x] `cargo test` (backend) — 451/451 pass
- [x] `cargo clippy -- -D warnings` — passes
- [x] `npm run build` — succeeds
- [ ] Post-merge: verify no blank-page on first navigation after staging deploy
- [ ] Post-merge: empty-validators path — covered by unit test; manual repro impractical
