### PR TITLE
fix(leases): invert SHORT size rendering on positions list

### DIFF
--- a/src/modules/leases/components/Leases.vue
+++ b/src/modules/leases/components/Leases.vue
@@ -104,6 +104,7 @@ import {
 import { RouteNames } from "@/router";
 
 import BigNumber from "@/common/components/BigNumber.vue";
+import { buildLeaseSizeCell } from "./leaseSize";
 import ListHeader from "@/common/components/ListHeader.vue";
 import EmptyState from "@/common/components/EmptyState.vue";
 import SharePnLDialog from "@/modules/leases/components/single-lease/SharePnLDialog.vue";
@@ -122,13 +123,7 @@ import { useBalancesStore } from "@/common/stores/balances";
 import { usePricesStore } from "@/common/stores/prices";
 import { useConfigStore } from "@/common/stores/config";
 import { NATIVE_CURRENCY, UPDATE_LEASES } from "@/config/global";
-import {
-  formatUsd,
-  formatDecAsUsd,
-  formatTokenBalance,
-  formatMobileAmount,
-  formatMobileUsd
-} from "@/common/utils/NumberFormatUtils";
+import { formatUsd, formatMobileAmount, formatMobileUsd } from "@/common/utils/NumberFormatUtils";
 import { useRouter } from "vue-router";
 import type { IAction } from "./single-lease/Action.vue";
 import Action from "./single-lease/Action.vue";
@@ -252,13 +247,21 @@ const leasesData = computed<TableRowItemProps[]>(() => {
         const asset = getAsset(item);
         const amount = displayData.unitAsset;
         const stable = displayData.assetValueUsd;
-        const positionType = i18n.t(`message.${configStore.getPositionType(item.protocol).toLowerCase()}`);
+        const rawPositionType = configStore.getPositionType(item.protocol);
+        const positionType = i18n.t(`message.${rawPositionType.toLowerCase()}`);
+        const isShort = rawPositionType === "Short";
+        const cryptoPriceUsd = isShort
+          ? new Dec(pricesStore.prices[`${item.debt.ticker}@${item.protocol}`]?.price ?? "0")
+          : new Dec(0);
 
-        const value = {
-          subValue: formatDecAsUsd(stable),
-          value: formatTokenBalance(amount),
-          tooltip: `${amount.toString(asset?.decimal_digits ?? 6)}`
-        };
+        const value = buildLeaseSizeCell({
+          positionType: rawPositionType,
+          unitAsset: amount,
+          assetValueUsd: stable,
+          cryptoAsset: asset,
+          cryptoPriceUsd
+        });
+        const cryptoDec = isShort && cryptoPriceUsd.isPositive() ? amount.quo(cryptoPriceUsd) : new Dec(0);
 
         if (hide.value) {
           value.value = "****";
@@ -283,8 +286,8 @@ const leasesData = computed<TableRowItemProps[]>(() => {
                 class: "cursor-pointer"
               },
               {
-                value: hide.value ? "****" : formatMobileAmount(amount),
-                subValue: hide.value ? "****" : formatMobileUsd(stable),
+                value: hide.value ? "****" : isShort ? formatMobileUsd(stable) : formatMobileAmount(amount),
+                subValue: hide.value ? "****" : isShort ? formatMobileAmount(cryptoDec) : formatMobileUsd(stable),
                 variant: "right",
                 click: navigate,
                 class: "cursor-pointer"

--- a/src/modules/leases/components/leaseSize.test.ts
+++ b/src/modules/leases/components/leaseSize.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression tests for the Leases-list Size cell.
+ *
+ * Rule (mirror of PositionSummaryWidget):
+ *   LONG : value = crypto adaptive, subValue = USD 2 dp
+ *   SHORT: value = USD 2 dp,        subValue = crypto adaptive (BTC/etc.)
+ *
+ * The SHORT branch has regressed at least once on the positions list —
+ * when the format was unified with LONG it left USDC being rendered
+ * via `formatTokenBalance` (8 dp) while the sub showed a $-rounded number.
+ * These assertions prevent it from flipping back.
+ */
+import { describe, it, expect } from "vitest";
+import { Dec } from "@keplr-wallet/unit";
+import { buildLeaseSizeCell } from "./leaseSize";
+
+const BTC = { shortName: "BTC", decimal_digits: 8 };
+
+describe("buildLeaseSizeCell", () => {
+  describe("LONG", () => {
+    it("puts crypto adaptive in the big value and $-rounded USD in the sub", () => {
+      const cell = buildLeaseSizeCell({
+        positionType: "Long",
+        unitAsset: new Dec("0.00089801"), // 0.000898 BTC
+        assetValueUsd: new Dec("70"), // $70
+        cryptoAsset: BTC
+      });
+      // Big: adaptive crypto precision, no $. formatTokenBalance uses
+      // first-significant-digit+1 rule for amounts < 1 and trims trailing
+      // zeros, so 0.00089801 renders as "0.00089".
+      expect(cell.value).not.toMatch(/^\$/);
+      expect(cell.value).toBe("0.00089");
+      // Sub: USD 2 dp, $-prefixed
+      expect(cell.subValue).toMatch(/^\$70\.00$/);
+      // Tooltip exposes full crypto decimals for disambiguation
+      expect(cell.tooltip).toBe("0.00089801");
+    });
+
+    it("renders integer-scale crypto amounts without padding trailing zeros past min 2", () => {
+      const cell = buildLeaseSizeCell({
+        positionType: "Long",
+        unitAsset: new Dec("1234.5"),
+        assetValueUsd: new Dec("1234.5"),
+        cryptoAsset: BTC
+      });
+      expect(cell.value).toBe("1,234.50");
+      expect(cell.subValue).toBe("$1,234.50");
+    });
+  });
+
+  describe("SHORT", () => {
+    it("puts $-rounded USD in the big value and crypto adaptive in the sub", () => {
+      // 70 USDC position, BTC = $77,949.36 → 0.00089801 BTC
+      const cell = buildLeaseSizeCell({
+        positionType: "Short",
+        unitAsset: new Dec("70"), // USDC amount (Dec still carries stable magnitude)
+        assetValueUsd: new Dec("69.97"),
+        cryptoAsset: BTC,
+        cryptoPriceUsd: new Dec("77949.36")
+      });
+      // Big is the $-rounded number the user would read as position value
+      expect(cell.value).toMatch(/^\$69\.97$/);
+      // Sub is the crypto-size at adaptive precision, with ticker
+      expect(cell.subValue).toBe("0.00089 BTC");
+      // Tooltip is the full crypto amount at the asset's native decimals
+      expect(cell.tooltip).toMatch(/^0\.00089801/);
+    });
+
+    it("does not crash and shows zero crypto when the price feed is missing", () => {
+      const cell = buildLeaseSizeCell({
+        positionType: "Short",
+        unitAsset: new Dec("70"),
+        assetValueUsd: new Dec("69.97"),
+        cryptoAsset: BTC,
+        cryptoPriceUsd: new Dec("0")
+      });
+      expect(cell.value).toMatch(/^\$69\.97$/);
+      expect(cell.subValue).toBe("0.00 BTC");
+      expect(cell.tooltip).toBe("0.00000000");
+    });
+
+    it("falls back cleanly when cryptoPriceUsd is omitted entirely", () => {
+      const cell = buildLeaseSizeCell({
+        positionType: "Short",
+        unitAsset: new Dec("70"),
+        assetValueUsd: new Dec("69.97"),
+        cryptoAsset: BTC
+      });
+      expect(cell.value).toBe("$69.97");
+      expect(cell.subValue).toBe("0.00 BTC");
+    });
+
+    it("omits the ticker suffix when the crypto asset lookup returned null", () => {
+      const cell = buildLeaseSizeCell({
+        positionType: "Short",
+        unitAsset: new Dec("70"),
+        assetValueUsd: new Dec("69.97"),
+        cryptoAsset: null,
+        cryptoPriceUsd: new Dec("77949.36")
+      });
+      expect(cell.value).toBe("$69.97");
+      expect(cell.subValue).not.toMatch(/BTC/);
+      // Still a numeric sub-value; no trailing whitespace
+      expect(cell.subValue).toMatch(/^\d/);
+    });
+  });
+});

--- a/src/modules/leases/components/leaseSize.ts
+++ b/src/modules/leases/components/leaseSize.ts
@@ -1,0 +1,59 @@
+/**
+ * Size-cell formatter for the Leases list row.
+ *
+ * Size follows the codebase's rounding convention:
+ *   - stable (USD) values     → `formatDecAsUsd` (2 dp, $-prefixed)
+ *   - crypto asset values     → `formatTokenBalance` (adaptive, trimmed)
+ *
+ * LONG:  big = crypto (adaptive),    sub = USD (2 dp)
+ * SHORT: big = USD (2 dp, rounded),  sub = crypto BTC (adaptive)
+ *
+ * For SHORT positions `displayData.unitAsset` is actually denominated in
+ * the stable (USDC) — same Dec in both "is USDC" and "has USD meaning"
+ * senses — so the sub-number needs the stable-to-crypto conversion via
+ * the borrowed asset's oracle price.
+ */
+import { Dec } from "@keplr-wallet/unit";
+import { formatDecAsUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
+
+export interface LeaseSizeInputs {
+  /** `Long` / `Short` — raw value from `configStore.getPositionType`. */
+  positionType: "Long" | "Short" | string;
+  /** `displayData.unitAsset` — for LONG this is crypto, for SHORT it's USDC. */
+  unitAsset: Dec;
+  /** `displayData.assetValueUsd` — USD value of the position. */
+  assetValueUsd: Dec;
+  /** The volatile/crypto asset on both position types (LONG: `amount.ticker`, SHORT: `debt.ticker`). */
+  cryptoAsset?: { shortName?: string; decimal_digits?: number } | null;
+  /**
+   * Oracle price of the crypto asset in USD. Only used for SHORT; required
+   * to convert the stable `unitAsset` into an equivalent crypto amount for
+   * the sub-number. Pass a `Dec(0)` to force the zero fallback.
+   */
+  cryptoPriceUsd?: Dec;
+}
+
+export interface LeaseSizeCell {
+  value: string;
+  subValue: string;
+  tooltip: string;
+}
+
+export function buildLeaseSizeCell(inputs: LeaseSizeInputs): LeaseSizeCell {
+  if (inputs.positionType !== "Short") {
+    return {
+      value: formatTokenBalance(inputs.unitAsset),
+      subValue: formatDecAsUsd(inputs.assetValueUsd),
+      tooltip: inputs.unitAsset.toString(inputs.cryptoAsset?.decimal_digits ?? 6)
+    };
+  }
+
+  const price = inputs.cryptoPriceUsd ?? new Dec(0);
+  const cryptoAmount = price.isPositive() ? inputs.unitAsset.quo(price) : new Dec(0);
+  const suffix = inputs.cryptoAsset?.shortName ? ` ${inputs.cryptoAsset.shortName}` : "";
+  return {
+    value: formatDecAsUsd(inputs.assetValueUsd),
+    subValue: `${formatTokenBalance(cryptoAmount)}${suffix}`,
+    tooltip: cryptoAmount.toString(inputs.cryptoAsset?.decimal_digits ?? 8)
+  };
+}


### PR DESCRIPTION
## Summary

Same rounding regression as PR #132 (the single-position Summary widget), this time on the **Margin list** row on `/leases`.

For SHORT positions, the code read `displayData.unitAsset` (which on a SHORT is denominated in the stable, i.e. USDC) through `formatTokenBalance` — the adaptive-crypto formatter — which produced values like \`69.979522\` with no denom, while the sub-number rendered the USD equivalent as \`\$69.97\`. The user sees a stable-class value rendered like crypto, and a crypto sub-number that's really just the same USD amount repeated.

Fix follows the codebase's rounding convention (now consistent across both the single-position widget and the list):

| | Big | Sub |
|---|---|---|
| LONG | crypto adaptive (e.g. \`0.00089\`) | USD 2 dp (e.g. \`\$69.97\`) |
| SHORT | USD 2 dp (e.g. \`\$69.97\`) | crypto adaptive with ticker (e.g. \`0.00089 BTC\`) |

For SHORT the crypto sub is derived from \`unitAsset / btc_price\` — same approach as the Summary widget, so the two surfaces stay in sync.

## Implementation

- Extract size-cell building into \`src/modules/leases/components/leaseSize.ts\` as a pure helper so the branching is unit-testable.
- Call it from \`Leases.vue\` for both desktop and mobile row shapes.
- Add \`leaseSize.test.ts\` pinning LONG and SHORT shapes + zero-price and missing-asset fallbacks.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] \`npx prettier --check\` clean
- [x] \`npx vitest run\` — 736/736 passing (+6 new for leaseSize)
- [x] \`npx vitest run --coverage\` — branches 83.14% (≥ 80 floor)
- [ ] After merge: staging deploys; confirm /leases list SHORT row shows \`\$XX.XX\` big + \`0.000X BTC\` sub (matches single-position Summary widget).