### PR TITLE
chore: bump version to 3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nolus-wallet",
-  "version": "2.0.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nolus-wallet",
-      "version": "2.0.0",
+      "version": "3.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "0.38.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nolus-wallet",
   "author": "Nolus",
   "license": "Apache-2.0",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump to match tag v3.2.1 (already cut, prod deploy in flight).

Pairs with the two fixes that shipped:
- #132 — chain_events reconnect watchdog + SHORT position-summary size rounding
- #133 — SHORT size rendering on the positions list

Created post-tag because direct push to `main` is blocked by branch protection; the tag itself went through (rule bypass for tag creation) and is already building on prod.