### PR TITLE
fix(leases): raise setSwapFee debounce to avoid /swap/route rate limit

### DIFF
--- a/src/modules/leases/components/new-lease/LongLeaseDetails.vue
+++ b/src/modules/leases/components/new-lease/LongLeaseDetails.vue
@@ -141,7 +141,12 @@ import { Dec } from "@keplr-wallet/unit";
 import { CurrencyUtils } from "@nolus/nolusjs";
 import { SkipRouter } from "@/common/utils/SkipRoute";
 
-const timeOut = 200;
+// Debounce window for the two Promise.all'd Skip API calls fired when the
+// lease quote changes. Must stay comfortably above the Leaser contract call
+// latency so rapid slider drags collapse to a single fire — a shorter window
+// let slow contract responses trigger back-to-back setSwapFee runs and hit
+// the backend's /api/swap/route strict rate limit (2 RPS, burst 5).
+const timeOut = 600;
 let time: NodeJS.Timeout;
 
 const props = defineProps<{
@@ -157,10 +162,6 @@ const swapStableFee = ref(0);
 
 onMounted(async () => {
   // Free interest is handled by a 3rd party service
-});
-
-onUnmounted(() => {
-  clearTimeout(time!);
 });
 
 onUnmounted(() => {

--- a/src/modules/leases/components/new-lease/ShortLeaseDetails.vue
+++ b/src/modules/leases/components/new-lease/ShortLeaseDetails.vue
@@ -143,7 +143,12 @@ import { Dec } from "@keplr-wallet/unit";
 import { CurrencyUtils } from "@nolus/nolusjs";
 import { SkipRouter } from "@/common/utils/SkipRoute";
 
-const timeOut = 200;
+// Debounce window for the two Promise.all'd Skip API calls fired when the
+// lease quote changes. Must stay comfortably above the Leaser contract call
+// latency so rapid slider drags collapse to a single fire — a shorter window
+// let slow contract responses trigger back-to-back setSwapFee runs and hit
+// the backend's /api/swap/route strict rate limit (2 RPS, burst 5).
+const timeOut = 600;
 let time: NodeJS.Timeout;
 
 const props = defineProps<{
@@ -159,10 +164,6 @@ const swapStableFee = ref(0);
 
 onMounted(async () => {
   // Free interest is handled by a 3rd party service
-});
-
-onUnmounted(() => {
-  clearTimeout(time!);
 });
 
 onUnmounted(() => {

--- a/src/modules/leases/components/single-lease/CloseDialog.vue
+++ b/src/modules/leases/components/single-lease/CloseDialog.vue
@@ -295,7 +295,12 @@ import { getLeasePositionSpec } from "@/common/utils/LeaseConfigService";
 import type { AmountSpec } from "@/common/api/types/webapp";
 import type { LeaseInfo } from "@/common/api";
 
-const timeOut = 250;
+// Debounce window for the Skip API call fired when inputs change. Must stay
+// comfortably above chain/contract latencies so rapid slider drags collapse
+// to a single fire — a shorter window lets slow responses trigger back-to-back
+// setSwapFee runs and hit the backend's /api/swap/route strict rate limit
+// (2 RPS, burst 5).
+const timeOut = 600;
 let time: NodeJS.Timeout;
 
 const route = useRoute();


### PR DESCRIPTION
## Summary

Moving the Open Position slider 2–3 times reliably produced `429 Too many requests` from `/api/swap/route`. Root cause: `setSwapFee` fires two `Promise.all`'d Skip calls after a 200–250 ms debounce — shorter than the Leaser contract's typical round-trip. Back-to-back slider updates produced 4–6 requests in a tight window, which the backend's strict rate limiter (2 RPS, burst 5) rejected.

- Raise the debounce to 600 ms in `ShortLeaseDetails.vue`, `LongLeaseDetails.vue`, and `CloseDialog.vue` so rapid slider drags collapse to a single Skip fire (matches the existing `SwapForm` value).
- Drop a duplicate `onUnmounted(clearTimeout(time))` block that had been registered twice for the same timer ref in both lease detail components.

## Why 600 ms

- Typical Leaser `leaseQuote` round-trip is ~200–500 ms; a debounce shorter than that lets a stale `leaseApply` fire Skip calls before the next quote arrives, then a second fire triggers once it does — doubling the request count per slider move.
- 600 ms keeps the Size/Swap Fee preview responsive in the common case (one fire per drag) while staying under the strict rate limiter's burst.

## Test plan

- [x] `tsc --noEmit`
- [x] `prettier --check`
- [x] `eslint --max-warnings=0`
- [x] `vitest` — 741/741 pass
- [ ] Manual on app-dev: drag the Size slider rapidly several times, verify no 429 and Swap Fee still updates