### PR TITLE
fix(leases): short swap-fee routes target the stable, not the shorted asset

### DIFF
--- a/src/modules/leases/components/new-lease/ShortLeaseDetails.vue
+++ b/src/modules/leases/components/new-lease/ShortLeaseDetails.vue
@@ -344,47 +344,55 @@ function getTotalAmount() {
 
 const setSwapFee = async () => {
   clearTimeout(time!);
-  if (props.lease) {
-    time = setTimeout(async () => {
-      const currency = downPaymentAsset.value;
-      const [_, p] = asset.value.key.split("@");
+  if (!props.lease) return;
+  time = setTimeout(async () => {
+    const currency = downPaymentAsset.value;
+    const [_, p] = asset.value.key.split("@");
 
-      const microAmount = CurrencyUtils.convertDenomToMinimalDenom(
-        props.downpaymenAmount,
-        currency.ibcData,
-        currency.decimal_digits
-      ).amount.toString();
+    // For a Short position the on-chain flow swaps both the down payment and
+    // the borrowed LPN to the stable the position settles in (lease.total.ticker,
+    // e.g. USDC_NOBLE) — NOT to asset.value (the borrowed/shorted asset, which
+    // on a Short protocol is the same as the LPN). Routing source→source is a
+    // no-op and Skip returns a zero fee, so the UI showed 0.00 BTC.
+    const stableTicker = props.lease!.total?.ticker;
+    const stable = stableTicker ? configStore.currenciesData?.[`${stableTicker}@${p}`] : null;
+    if (!stable) return;
 
-      const lpn = getLpnByProtocol(p);
-      let amountIn = 0;
-      let amountOut = 0;
-      await Promise.all([
-        SkipRouter.getRoute(currency.ibcData, asset.value.ibcData, microAmount).then((data) => {
-          amountIn += Number(data.usd_amount_in ?? 0);
-          amountOut += Number(data.usd_amount_out ?? 0);
+    const microAmount = CurrencyUtils.convertDenomToMinimalDenom(
+      props.downpaymenAmount,
+      currency.ibcData,
+      currency.decimal_digits
+    ).amount.toString();
 
-          return Number(data?.swap_price_impact_percent ?? 0);
-        }),
-        SkipRouter.getRoute(lpn.ibcData, asset.value.ibcData, props.lease!.borrow.amount).then((data) => {
-          amountIn += Number(data.usd_amount_in ?? 0);
-          amountOut += Number(data.usd_amount_out ?? 0);
+    const lpn = getLpnByProtocol(p);
+    let amountIn = 0;
+    let amountOut = 0;
+    await Promise.all([
+      SkipRouter.getRoute(currency.ibcData, stable.ibcData, microAmount).then((data) => {
+        amountIn += Number(data.usd_amount_in ?? 0);
+        amountOut += Number(data.usd_amount_out ?? 0);
 
-          return Number(data?.swap_price_impact_percent ?? 0);
-        })
-      ]);
-      const out_a = Math.max(amountOut, amountIn);
-      const in_a = Math.min(amountOut, amountIn);
+        return Number(data?.swap_price_impact_percent ?? 0);
+      }),
+      SkipRouter.getRoute(lpn.ibcData, stable.ibcData, props.lease!.borrow.amount).then((data) => {
+        amountIn += Number(data.usd_amount_in ?? 0);
+        amountOut += Number(data.usd_amount_out ?? 0);
 
-      const diff = out_a - in_a;
-      swapStableFee.value = diff;
-      let fee = 0;
+        return Number(data?.swap_price_impact_percent ?? 0);
+      })
+    ]);
+    const out_a = Math.max(amountOut, amountIn);
+    const in_a = Math.min(amountOut, amountIn);
 
-      if (in_a > 0) {
-        fee = diff / in_a;
-      }
-      swapFee.value = fee;
-    }, timeOut);
-  }
+    const diff = out_a - in_a;
+    swapStableFee.value = diff;
+    let fee = 0;
+
+    if (in_a > 0) {
+      fee = diff / in_a;
+    }
+    swapFee.value = fee;
+  }, timeOut);
 };
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
## Summary

On a Short position the on-chain flow swaps both the down payment and the borrowed LPN into the stable currency the position settles in (`lease.total.ticker`, e.g. `USDC_NOBLE`) — not into `asset.value`, which on a Short protocol is the borrowed/shorted asset itself and is identical to the LPN.

`ShortLeaseDetails.setSwapFee` passed `asset.value.ibcData` as the destination for both `SkipRouter.getRoute` calls, producing source→source no-op routes. Skip returned a zero fee, so the UI reported `0.00 BTC / $0.00` for Swap Fees on any Short position.

Fix: resolve the stable via the protocol-scoped currency lookup (`{stableTicker}@{protocol}` in `currenciesData`) and route both Skip calls to that IBC denom. Guard for the transient state where `lease.total.ticker` hasn't landed yet.

## Test plan

- [x] `tsc --noEmit`
- [x] `prettier --check`
- [x] `eslint --max-warnings=0`
- [x] `vitest` — 741/741 pass
- [x] Manual on app-dev: open a Short with BTC collateral, verify the Swap Fees row shows a non-zero BTC and USD value matching the route impact