### PR TITLE
chore: bump version to 3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nolus-wallet",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nolus-wallet",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "0.38.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nolus-wallet",
   "author": "Nolus",
   "license": "Apache-2.0",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Cuts the 3.2.2 release tag containing:

- #135 — short open uses protocol stable as lease ticker
- #136 — raise setSwapFee debounce to avoid /swap/route rate limit
- #137 — short swap-fee routes target the stable, not the shorted asset