### PR TITLE
feat(auth): hide Ledger from wallet picker, right-size modal

### DIFF
--- a/src/common/components/auth/AuthComponent.vue
+++ b/src/common/components/auth/AuthComponent.vue
@@ -45,7 +45,6 @@ import { WalletActions } from "@/common/stores/wallet";
 import WalletBoxes from "./WalletBoxes.vue";
 import TermsDialog from "../dialogs/TermsDialog.vue";
 import KeplrIcon from "@/assets/icons/wallets/keplr.svg?url";
-import LedgerIcon from "@/assets/icons/wallets/ledger.svg?url";
 
 import { IntercomService } from "@/common/utils";
 import type { IObjectKeys } from "@/common/types";
@@ -67,11 +66,6 @@ const connections = computed(
         icon: KeplrIcon,
         label: i18n.t("message.keplr"),
         type: WalletActions.CONNECT_KEPLR
-      },
-      Ledger: {
-        icon: LedgerIcon,
-        label: i18n.t("message.ledger"),
-        type: WalletActions.CONNECT_LEDGER
       }
     };
 

--- a/src/common/components/dialogs/AuthDialog.vue
+++ b/src/common/components/dialogs/AuthDialog.vue
@@ -11,6 +11,7 @@
     ref="dialog"
     show-close
     :title="$t('message.select-wallet')"
+    class-list="md:!h-auto md:!max-h-[90dvh]"
   >
     <template v-slot:content>
       <AuthComponent />


### PR DESCRIPTION
## Summary

Two small UI changes for the Select Wallet modal that land alongside the Leap removal:

- Hide the direct Ledger entry from the wallet picker. Ledger users who already have a session auto-reconnect via the stored mechanism; the underlying `connectLedger` / `authenticateLedger` / `@ledgerhq/*` deps stay in place to support that path. Picker now offers Keplr only.
- Right-size the modal on desktop. The shared Dialog component pins `md:h-[800px]`, leaving ~400px of empty space below the wallet list. Override with `class-list="md:!h-auto md:!max-h-[90dvh]"` so it sizes to content. Mobile stays full-screen (`h-[100dvh]`) — the override is desktop-only.

## Changes

- `src/common/components/auth/AuthComponent.vue` — drop the `Ledger` connection entry and the unused `LedgerIcon` import.
- `src/common/components/dialogs/AuthDialog.vue` — pass `class-list="md:!h-auto md:!max-h-[90dvh]"` to the shared Dialog.

## Why hide-not-remove for Ledger

The `@ledgerhq/hw-transport-web-ble`, `@ledgerhq/hw-transport-webusb`, and `@cosmjs/ledger-amino` packages are imported only by `WalletFactory.ts` and `connectLedger.ts` — they are NOT shared with the Keplr path (Keplr uses its own extension-internal signer). Removing the integration entirely is safe in principle, but doing so in the same release as the Leap removal would leave existing Ledger sessions stuck. Hiding the entry first lets us watch usage, then decide whether to drop the deps in a follow-up.

Users who want a hardware-wallet flow can still connect via Keplr's own Ledger support — Keplr handles that device-side, independent of our `@ledgerhq` imports.

## Verification

- `tsc --noEmit`, `prettier --check`, `eslint --max-warnings=0`, `vitest run` (740/740 — no test changes needed).
- `npm run build` clean. Confirmed Tailwind generated `.md\:\!h-auto{height:auto!important}` and `.md\:\!max-h-\[90dvh\]{max-height:90dvh!important}` in the output CSS.
- Reviewed the Dialog source in `web-components` to confirm the inner `h-[calc(100%-80px)] overflow-y-auto` content body resolves cleanly when the parent height is auto (the percentage on a flex item with auto-height parent resolves to auto, so content sizes to itself rather than collapsing to zero).
- Visual check pending on staging once merged — no automated UI test for modal sizing.

## Out of scope (for a follow-up)

- Removing `@ledgerhq/*` and `@cosmjs/ledger-amino` deps + the `connectLedger` / `authenticateLedger` code paths entirely.
- Any change to `WalletInfo.vue` (the post-connect "you're connected as X" component) — Ledger label still renders correctly there for users with existing Ledger sessions.