### PR TITLE
fix(auth): force Select Wallet modal to size to content on desktop

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -56,3 +56,17 @@ svg {
 .intercom-lightweight-app {
   z-index: 1 !important;
 }
+
+// The shared Dialog component (web-components lib) pins md:h-[800px] on its
+// outer container. The Select Wallet modal only shows ~340px of content, so
+// it ends up with ~460px of empty space below "Learn more". Override here
+// because the Dialog's class-list prop pathway through motion-v's
+// inheritAttrs:false setup doesn't reliably forward the class to the
+// rendered DOM. The :has() selector targets any [role="dialog"] that
+// contains a .select-wallet-content child — which only AuthComponent emits.
+@media (min-width: 768px) {
+  [role="dialog"]:has(.select-wallet-content) {
+    height: auto !important;
+    max-height: 90dvh !important;
+  }
+}

--- a/src/common/components/auth/AuthComponent.vue
+++ b/src/common/components/auth/AuthComponent.vue
@@ -1,6 +1,6 @@
 <template>
   <TermsDialog ref="terms" />
-  <div class="flex flex-col gap-4 px-6 pb-6">
+  <div class="select-wallet-content flex flex-col gap-4 px-6 pb-6">
     <div class="text-[14px] text-neutral-400">
       {{ $t("message.policy") }}
       <button

--- a/src/common/components/dialogs/AuthDialog.vue
+++ b/src/common/components/dialogs/AuthDialog.vue
@@ -11,7 +11,6 @@
     ref="dialog"
     show-close
     :title="$t('message.select-wallet')"
-    class-list="md:!h-auto md:!max-h-[90dvh]"
   >
     <template v-slot:content>
       <AuthComponent />


### PR DESCRIPTION
## Summary

The modal trim from #140 didn't visibly take effect on staging — the modal still rendered with the lib's pinned `md:h-[800px]`, leaving ~460px of empty space below the wallet list. Override via global CSS keyed on a sentinel class so the fix doesn't depend on the Vue prop pathway through `web-components`/`motion-v`.

## Why the previous approach didn't work

`#140` passed `class-list="md:!h-auto md:!max-h-[90dvh]"` to the shared Dialog. Both rules generated correctly in the production CSS (both inside `@layer utilities`, both with `!important`). The classes are present in the bundle and the Dialog component does spread `__props.classList` into its outer wrapper's class array via `normalizeClass([...])`. But that wrapper is the `Motion` component from `motion-v`, which uses `inheritAttrs:false` and forwards `class` through `useAttrs()` → `getAttrs()` → `h(asTag, allAttrs)`. Somewhere in that pathway the class isn't landing on the rendered DOM in the deployed bundle. Source-tracing didn't pin down the exact step, so the next attempt should not depend on it.

## Changes

- `src/common/components/auth/AuthComponent.vue` — add a `select-wallet-content` sentinel class to the outer wrapper.
- `src/assets/styles/global.scss` — add `@media (min-width: 768px) { [role='dialog']:has(.select-wallet-content) { height: auto !important; max-height: 90dvh !important; } }`. The selector targets the modal's outer `[role="dialog"]` element only when our slot content is present, so no leak to other dialogs.
- `src/common/components/dialogs/AuthDialog.vue` — drop the `class-list` prop now that the global rule does the work.

Mobile keeps `h-[100dvh]` (full-screen) — the override is gated on the `md` breakpoint.

## Verification

- `tsc --noEmit`, `prettier --check`, `eslint --max-warnings=0`, `vitest run` (740/740) all clean.
- `npm run build` clean. Confirmed Tailwind generates the expected utilities in the output CSS, and the new SCSS rule appears verbatim in the compiled stylesheet.
- Visual confirmation pending on staging — the modal should now collapse to ~360px on desktop.

## Browser support

`:has()` selector — supported in Chrome 105+, Safari 15.4+, Firefox 121+ (since Dec 2023). No fallback needed; if a user hits an older browser, the modal renders at the lib's default 800px which is the current pre-fix behavior, so no regression.

## Out of scope

Investigating the underlying motion-v / Vue inheritAttrs prop-class issue. Worth filing upstream if it bites again, but not blocking on it for the v3.2.3 cut.