### PR TITLE
fix(auth): also relax inner overflow body for Select Wallet modal

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -58,15 +58,28 @@ svg {
 }
 
 // The shared Dialog component (web-components lib) pins md:h-[800px] on its
-// outer container. The Select Wallet modal only shows ~340px of content, so
-// it ends up with ~460px of empty space below "Learn more". Override here
-// because the Dialog's class-list prop pathway through motion-v's
-// inheritAttrs:false setup doesn't reliably forward the class to the
-// rendered DOM. The :has() selector targets any [role="dialog"] that
-// contains a .select-wallet-content child — which only AuthComponent emits.
+// outer container, plus h-[calc(100%-80px)] on the inner overflow body.
+// AuthComponent only renders ~340px of content, so the modal otherwise has
+// ~460px of empty space below "Learn more". Override on desktop only —
+// mobile keeps h-[100dvh] full-screen.
+//
+// Both selectors used because the Dialog's outer class array sits behind a
+// motion-v Motion wrapper with inheritAttrs:false; the class-list prop
+// pathway didn't reliably forward to the rendered DOM in the deployed
+// bundle, so target via descendant content instead. The aria-label fallback
+// covers locales where the i18n title may differ in length but the role +
+// label pair is stable per the Dialog component.
 @media (min-width: 768px) {
-  [role="dialog"]:has(.select-wallet-content) {
+  [role="dialog"]:has(.select-wallet-content),
+  [role="dialog"][aria-label="Select Wallet"] {
     height: auto !important;
     max-height: 90dvh !important;
+  }
+  // Inner overflow body's h-[calc(100%-80px)] resolves circularly when the
+  // parent goes auto; force it explicitly so the modal sizes to the wallet
+  // list rather than expanding to fill viewport.
+  [role="dialog"]:has(.select-wallet-content) > .overflow-y-auto,
+  [role="dialog"][aria-label="Select Wallet"] > .overflow-y-auto {
+    height: auto !important;
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #141 — the outer override didn't visibly land in production. DevTools shows the inner overflow body computed to 1014px, which means either the `:has()` selector wasn't matching the live DOM at evaluation time or the inner body's `h-[calc(100%-80px)]` was still pinning against a definite parent.

This adds two reinforcements:

- A second outer-dialog selector keyed on `[aria-label="Select Wallet"]`, so the rule still applies even if `:has(.select-wallet-content)` evaluates against a tree state where the slot content hasn't fully mounted.
- An explicit `height: auto !important` on the inner `> .overflow-y-auto` body, which sidesteps the question of how `calc(100% - 80px)` resolves when the parent flips to auto.

The `aria-label` English string is acceptable here because the modal title isn't translated in any locale today; if that changes we'll move to a stable data attribute.

## Verification

- `tsc --noEmit`, `prettier --check`, `eslint --max-warnings=0`, `vitest run` (740/740) all clean.
- `npm run build` clean. Confirmed the compiled CSS contains both selectors:
  - `[role=dialog]:has(.select-wallet-content),[role=dialog][aria-label="Select Wallet"]{height:auto!important;max-height:90dvh!important}`
  - `[role=dialog]:has(.select-wallet-content)>.overflow-y-auto,[role=dialog][aria-label="Select Wallet"]>.overflow-y-auto{height:auto!important}`
- Visual confirmation pending on staging.