### PR TITLE
revert(auth): drop Select Wallet modal height-shrink attempts

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -56,30 +56,3 @@ svg {
 .intercom-lightweight-app {
   z-index: 1 !important;
 }
-
-// The shared Dialog component (web-components lib) pins md:h-[800px] on its
-// outer container, plus h-[calc(100%-80px)] on the inner overflow body.
-// AuthComponent only renders ~340px of content, so the modal otherwise has
-// ~460px of empty space below "Learn more". Override on desktop only —
-// mobile keeps h-[100dvh] full-screen.
-//
-// Both selectors used because the Dialog's outer class array sits behind a
-// motion-v Motion wrapper with inheritAttrs:false; the class-list prop
-// pathway didn't reliably forward to the rendered DOM in the deployed
-// bundle, so target via descendant content instead. The aria-label fallback
-// covers locales where the i18n title may differ in length but the role +
-// label pair is stable per the Dialog component.
-@media (min-width: 768px) {
-  [role="dialog"]:has(.select-wallet-content),
-  [role="dialog"][aria-label="Select Wallet"] {
-    height: auto !important;
-    max-height: 90dvh !important;
-  }
-  // Inner overflow body's h-[calc(100%-80px)] resolves circularly when the
-  // parent goes auto; force it explicitly so the modal sizes to the wallet
-  // list rather than expanding to fill viewport.
-  [role="dialog"]:has(.select-wallet-content) > .overflow-y-auto,
-  [role="dialog"][aria-label="Select Wallet"] > .overflow-y-auto {
-    height: auto !important;
-  }
-}

--- a/src/common/components/auth/AuthComponent.vue
+++ b/src/common/components/auth/AuthComponent.vue
@@ -1,6 +1,6 @@
 <template>
   <TermsDialog ref="terms" />
-  <div class="select-wallet-content flex flex-col gap-4 px-6 pb-6">
+  <div class="flex flex-col gap-4 px-6 pb-6">
     <div class="text-[14px] text-neutral-400">
       {{ $t("message.policy") }}
       <button


### PR DESCRIPTION
## Summary

Three iterations (#140 modal-trim portion, #141, #142) failed to visibly shrink the Select Wallet modal on desktop, despite the override CSS landing correctly in the served stylesheet. The 800px modal is acceptable as-is; reverting the failed attempts so we don't ship dead code.

## What's reverted

- `src/common/components/auth/AuthComponent.vue` — drop the `select-wallet-content` sentinel class (only existed to anchor the global CSS rule).
- `src/assets/styles/global.scss` — drop the override block.

## What stays

- The Ledger UI hide from #140 — that landed correctly and the picker now offers Keplr only.
- The Leap removal from #139.
- The Ledger reconnect path remains intact for existing sessions.

## Why we couldn't make it work

Production CSS contained both `[role="dialog"]:has(.select-wallet-content)` and `[role="dialog"][aria-label="Select Wallet"]` selectors with `height: auto !important; max-height: 90dvh !important`, plus an inner `.overflow-y-auto > height: auto !important` to break the calc-against-auto-parent dependency. DevTools on the live modal showed the inner overflow body still computing to ~1014px — neither rule was winning. Likely an interaction with motion-v's animation wrapper or its inheritAttrs:false flag on the Motion root, but isolating it would need deeper changes to the upstream `web-components` Dialog component. Not worth the extra rounds for a cosmetic improvement.