### PR TITLE
chore: bump version to 3.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nolus-wallet",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nolus-wallet",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "0.38.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nolus-wallet",
   "author": "Nolus",
   "license": "Apache-2.0",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Cut v3.2.3 from main for production. Includes the Leap wallet removal and Ledger UI hide that landed since v3.2.2.

## Highlights

- **#139** — Leap wallet integration removed end-to-end (enum, action, factory, util, listener, UI, locale, icon, tests). Includes a self-healing localStorage shim so existing Leap users land in a clean disconnected state on first load post-deploy and reconnect with a supported wallet.
- **#140** — Ledger entry hidden from the Select Wallet picker. Reconnect path retained for existing Ledger sessions; the underlying `connectLedger` / `authenticateLedger` / `@ledgerhq/*` deps stay in place. Full removal needs a coordinated `@nolus/nolusjs` update (tracked separately).
- **#141 / #142 / #143** — three iterations to shrink the now-shorter Select Wallet modal on desktop. Reverted; the modal stays at the lib's default height. Logged for follow-up if we ever want to invest in it.

## Verification

- pr-validate green on every PR shipped this release.
- Staging deploy (`app-dev.nolus.io`) verified after each merge: bundle bytes, locale endpoints, WebMCP grep guard, agent-card commitment, services healthy.
- Server-side locale cleanup applied — orphan `"leap"` keys removed from `/opt/deploy/builds/{app,app-dev}/config/locales/*.json` and services restarted to flush the in-memory translation cache.