### PR TITLE
fix(backend): raise chain-query concurrency cap, make configurable

### DIFF
--- a/backend/src/external/chain.rs
+++ b/backend/src/external/chain.rs
@@ -15,7 +15,16 @@ use crate::error::AppError;
 
 /// Maximum concurrent LCD/REST requests to the chain node.
 /// Prevents burst overload on cold start and during cache refresh cycles.
-const MAX_CONCURRENT_CHAIN_QUERIES: usize = 32;
+/// Override at runtime with `CHAIN_MAX_CONCURRENT_QUERIES`.
+const DEFAULT_MAX_CONCURRENT_CHAIN_QUERIES: usize = 256;
+
+fn chain_query_concurrency() -> usize {
+    std::env::var("CHAIN_MAX_CONCURRENT_QUERIES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_MAX_CONCURRENT_CHAIN_QUERIES)
+}
 
 /// Maximum retries for transient HTTP errors (429, 503).
 const MAX_RETRIES: u32 = 3;
@@ -77,7 +86,7 @@ impl ChainClient {
         Self {
             rest_url,
             client,
-            query_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_CHAIN_QUERIES)),
+            query_semaphore: Arc::new(Semaphore::new(chain_query_concurrency())),
         }
     }
 


### PR DESCRIPTION
## Summary

Raise the `ChainClient` semaphore default from 32 to 256 and add a `CHAIN_MAX_CONCURRENT_QUERIES` env override so the cap can be tuned per environment without a code change.

## Why

Under modest concurrent load (one user plus a secondary REST client), the existing 32-permit cap saturates and every chain-touching handler queues — `/api/staking/positions`, `/api/governance/*`, `/api/earn/*`, `/api/currencies/balances`, `/api/leases/*`. Symptom is "the app feels slow but the backend is at 0% CPU." `journalctl` showed zero upstream 429/503 retries during the slow window, so the bottleneck is the internal semaphore, not the chain.

With six load-balanced LCD endpoints upstream, the chain can absorb far more than 32 concurrent egress requests. 256 is a safe new default — bounded enough to keep cold-start egress in check, large enough that normal multi-session traffic does not queue. The env override leaves a tuning knob if upstream quota or topology changes.

## Changes

- `backend/src/external/chain.rs`: rename `MAX_CONCURRENT_CHAIN_QUERIES` to `DEFAULT_MAX_CONCURRENT_CHAIN_QUERIES`, raise to 256, route the semaphore initialisation through a new `chain_query_concurrency()` helper that reads `CHAIN_MAX_CONCURRENT_QUERIES` and falls back to the default on missing/empty/zero/non-numeric input.

## Verification

- `cargo build --release` — clean
- `cargo clippy --release --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test --release --all-targets` — 455 passed, 0 failed
- Env parse paths checked for empty / `"0"` / non-numeric / negative inputs — all fall back to the default cleanly
- Pre-commit hook (lint + frontend build + frontend test) passed

## Follow-ups

Worth scoping separately: route chain-global handlers (governance proposals/tally, denom metadata, network status, per-protocol pool stats) through `Cached<T>` background refresh, so user requests for these surfaces are lock-free reads. Per-user state (balances, delegations, lease state) stays live.