### PR TITLE
chore: bump version to 3.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nolus-wallet",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nolus-wallet",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "0.38.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nolus-wallet",
   "author": "Nolus",
   "license": "Apache-2.0",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Bump to 3.2.4 ahead of cutting the production tag.

## Changes shipped since 3.2.3

- #146 — `fix(backend): raise chain-query concurrency cap, make configurable`. Default `ChainClient` semaphore raised from 32 to 256 with `CHAIN_MAX_CONCURRENT_QUERIES` env override. Resolves user-visible slowness ("backend at 0% CPU but every chain-touching handler queues") observed when concurrent REST clients overlapped a normal user session.

## Verification

- Validated on staging (`app-dev.nolus.io`) by the maintainer — wallet connect and dashboard load are now responsive (previously 10s+ hangs under concurrent load).
- Pre-commit hook (lint + frontend build) passed.