### PR TITLE
chore: bump version to 3.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nolus-wallet",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nolus-wallet",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "0.38.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nolus-wallet",
   "author": "Nolus",
   "license": "Apache-2.0",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Bump to 3.2.5 ahead of cutting the production tag.

The 3.2.4 tag was already used for an earlier hotfix (#145) and shipped to production this morning, so we move to 3.2.5 rather than reusing or moving the existing tag.

## Changes shipped vs. the production 3.2.4 build

- #146 — `fix(backend): raise chain-query concurrency cap, make configurable`. Default `ChainClient` semaphore raised from 32 to 256 with `CHAIN_MAX_CONCURRENT_QUERIES` env override. Resolves user-visible slowness ("backend at 0% CPU but every chain-touching handler queues") observed when concurrent REST clients overlapped a normal user session.

## Verification

- Validated on staging (`app-dev.nolus.io`) — wallet connect and dashboard load are responsive, no degradation observed.
- Pre-commit hook (lint + frontend build) passed.