### PR TITLE
refactor(backend): cache governance proposals + tally fan-out

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -78,7 +78,6 @@ utoipa = { version = "5", features = ["axum_extras", "chrono", "preserve_order"]
 futures = "0.3"
 http-body-util = "0.1"
 tempfile = "3.10"
-tokio = { version = "1", features = ["full", "test-util"] }
 wiremock = "0.6"
 
 [profile.release]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -78,6 +78,7 @@ utoipa = { version = "5", features = ["axum_extras", "chrono", "preserve_order"]
 futures = "0.3"
 http-body-util = "0.1"
 tempfile = "3.10"
+tokio = { version = "1", features = ["full", "test-util"] }
 wiremock = "0.6"
 
 [profile.release]

--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -1266,7 +1266,7 @@
           "governance"
         ],
         "summary": "List governance proposals",
-        "description": "Returns governance proposals in reverse-chronological order. For proposals\nin the voting period, the live tally is fetched; if `voter` is supplied,\neach such proposal is annotated with whether that address has voted.",
+        "description": "Returns governance proposals in reverse-chronological order from the\nbackground-refreshed cache. The response carries `Cache-Status: warm`\n(with a `Cache-Age` value in seconds) once the refresh task has populated\nthe cache, or `Cache-Status: cold` with an empty list before the first\nrefresh completes — never 503 — so the frontend's `Promise.allSettled`\nflow can render an empty state without a coordinated rollout.\n\nHidden proposals from the gated UI config are filtered at request time\nagainst the latest config; cached tallies are attached for voting-period\nproposals. The fresh tally for a single proposal is available on the\nper-id `/proposals/{id}/tally` endpoint, which still queries the chain\ndirectly. `?voter=` triggers a live `get_proposal_vote` fan-out across\nvoting-period proposals only — a chain failure on any of those calls\nsurfaces as 502.",
         "operationId": "get_proposals",
         "parameters": [
           {
@@ -1299,6 +1299,20 @@
         "responses": {
           "200": {
             "description": "Paginated list of proposals",
+            "headers": {
+              "Cache-Age": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Age in seconds of the cached snapshot. Present on `warm` responses, omitted on `cold`."
+              },
+              "Cache-Status": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "`warm` when served from the background-refreshed cache, `cold` before the first refresh has populated it (response body is then an empty list)."
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1308,7 +1322,7 @@
             }
           },
           "502": {
-            "description": "Upstream chain RPC error",
+            "description": "Upstream chain RPC error on live `?voter=` fan-out",
             "content": {
               "application/json": {
                 "schema": {

--- a/backend/src/data_cache.rs
+++ b/backend/src/data_cache.rs
@@ -114,6 +114,20 @@ pub struct GatedConfigBundle {
 /// Keyed by protocol name (e.g., "OSMOSIS-OSMOSIS-USDC_NOBLE").
 pub type ProtocolContractsMap = HashMap<String, crate::external::chain::ProtocolContractsInfo>;
 
+/// Snapshot of governance proposals with their per-proposal tallies.
+///
+/// `proposals` is canonical — refreshed atomically as a unit on every cycle.
+/// `tallies` is keyed by proposal id and only carries entries for proposals
+/// in `PROPOSAL_STATUS_VOTING_PERIOD`. The map is merged with prior state on
+/// each refresh: per-id failures retain the prior value, proposals that exit
+/// voting period are pruned. Finalized proposals' tally lives on
+/// `Proposal::final_tally_result` and does not need a separate map entry.
+#[derive(Debug, Clone)]
+pub struct ProposalsWithTally {
+    pub proposals: Vec<crate::external::chain::Proposal>,
+    pub tallies: HashMap<String, crate::external::chain::TallyResult>,
+}
+
 /// All cached application data.
 ///
 /// Each field is a `Cached<T>` populated by a dedicated background refresh task.
@@ -148,6 +162,10 @@ pub struct AppDataCache {
 
     /// Annual inflation (from Nolus mint module, changes per governance proposal)
     pub annual_inflation: Cached<AnnualInflationResponse>,
+
+    /// Governance proposals with their voting-period tallies, refreshed
+    /// together so list reads serve consistent (proposal, tally) pairs.
+    pub proposals_with_tally: Cached<ProposalsWithTally>,
 
     /// Staking pool (bonded/not-bonded tokens)
     pub staking_pool: Cached<StakingPoolResponse>,
@@ -195,6 +213,7 @@ impl AppDataCache {
             pools: Cached::new(),
             validators: Cached::new(),
             annual_inflation: Cached::new(),
+            proposals_with_tally: Cached::new(),
             staking_pool: Cached::new(),
             gated_assets: Cached::new(),
             gated_protocols: Cached::new(),
@@ -219,6 +238,8 @@ impl AppDataCache {
             pools: self.field_status("pools", &self.pools),
             validators: self.field_status("validators", &self.validators),
             annual_inflation: self.field_status("annual_inflation", &self.annual_inflation),
+            proposals_with_tally: self
+                .field_status("proposals_with_tally", &self.proposals_with_tally),
             staking_pool: self.field_status("staking_pool", &self.staking_pool),
             gated_assets: self.field_status("gated_assets", &self.gated_assets),
             gated_protocols: self.field_status("gated_protocols", &self.gated_protocols),
@@ -266,6 +287,7 @@ pub struct CacheStatusSummary {
     pub pools: CacheFieldStatus,
     pub validators: CacheFieldStatus,
     pub annual_inflation: CacheFieldStatus,
+    pub proposals_with_tally: CacheFieldStatus,
     pub staking_pool: CacheFieldStatus,
     pub gated_assets: CacheFieldStatus,
     pub gated_protocols: CacheFieldStatus,
@@ -444,6 +466,7 @@ mod tests {
         assert!(!cache.pools.is_populated());
         assert!(!cache.validators.is_populated());
         assert!(!cache.annual_inflation.is_populated());
+        assert!(!cache.proposals_with_tally.is_populated());
         assert!(!cache.staking_pool.is_populated());
         assert!(!cache.gated_assets.is_populated());
         assert!(!cache.gated_protocols.is_populated());
@@ -480,6 +503,7 @@ mod tests {
             ("pools", &summary.pools),
             ("validators", &summary.validators),
             ("annual_inflation", &summary.annual_inflation),
+            ("proposals_with_tally", &summary.proposals_with_tally),
             ("staking_pool", &summary.staking_pool),
             ("gated_assets", &summary.gated_assets),
             ("gated_protocols", &summary.gated_protocols),

--- a/backend/src/handlers/governance.rs
+++ b/backend/src/handlers/governance.rs
@@ -125,7 +125,15 @@ pub struct PaginationInfo {
     tag = "governance",
     params(ProposalsQuery),
     responses(
-        (status = 200, description = "Paginated list of proposals", body = ProposalsListResponse),
+        (
+            status = 200,
+            description = "Paginated list of proposals",
+            body = ProposalsListResponse,
+            headers(
+                ("Cache-Status" = String, description = "`warm` when served from the background-refreshed cache, `cold` before the first refresh has populated it (response body is then an empty list)."),
+                ("Cache-Age" = String, description = "Age in seconds of the cached snapshot. Present on `warm` responses, omitted on `cold`."),
+            ),
+        ),
         (status = 502, description = "Upstream chain RPC error on live `?voter=` fan-out", body = crate::error::ErrorResponse),
     ),
 )]

--- a/backend/src/handlers/governance.rs
+++ b/backend/src/handlers/governance.rs
@@ -6,13 +6,18 @@ use std::sync::Arc;
 
 use axum::{
     extract::{Path, Query, State},
+    http::{HeaderMap, HeaderValue},
     Json,
 };
+use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, warn};
+use tracing::debug;
 use utoipa::{IntoParams, ToSchema};
 
 use crate::{error::AppError, external::chain, AppState};
+
+/// Status string the chain reports for proposals currently accepting votes.
+const PROPOSAL_STATUS_VOTING_PERIOD: &str = "PROPOSAL_STATUS_VOTING_PERIOD";
 
 // ============================================================================
 // Hidden Proposals
@@ -100,9 +105,20 @@ pub struct PaginationInfo {
 
 /// List governance proposals
 ///
-/// Returns governance proposals in reverse-chronological order. For proposals
-/// in the voting period, the live tally is fetched; if `voter` is supplied,
-/// each such proposal is annotated with whether that address has voted.
+/// Returns governance proposals in reverse-chronological order from the
+/// background-refreshed cache. The response carries `Cache-Status: warm`
+/// (with a `Cache-Age` value in seconds) once the refresh task has populated
+/// the cache, or `Cache-Status: cold` with an empty list before the first
+/// refresh completes — never 503 — so the frontend's `Promise.allSettled`
+/// flow can render an empty state without a coordinated rollout.
+///
+/// Hidden proposals from the gated UI config are filtered at request time
+/// against the latest config; cached tallies are attached for voting-period
+/// proposals. The fresh tally for a single proposal is available on the
+/// per-id `/proposals/{id}/tally` endpoint, which still queries the chain
+/// directly. `?voter=` triggers a live `get_proposal_vote` fan-out across
+/// voting-period proposals only — a chain failure on any of those calls
+/// surfaces as 502.
 #[utoipa::path(
     get,
     path = "/api/governance/proposals",
@@ -110,81 +126,131 @@ pub struct PaginationInfo {
     params(ProposalsQuery),
     responses(
         (status = 200, description = "Paginated list of proposals", body = ProposalsListResponse),
-        (status = 502, description = "Upstream chain RPC error", body = crate::error::ErrorResponse),
+        (status = 502, description = "Upstream chain RPC error on live `?voter=` fan-out", body = crate::error::ErrorResponse),
     ),
 )]
 pub async fn get_proposals(
     State(state): State<Arc<AppState>>,
     Query(query): Query<ProposalsQuery>,
-) -> Result<Json<ProposalsListResponse>, AppError> {
-    let limit = query.limit.unwrap_or(10);
-    debug!("Fetching proposals with limit: {}", limit);
+) -> Result<(HeaderMap, Json<ProposalsListResponse>), AppError> {
+    let limit = query.limit.unwrap_or(10) as usize;
+    debug!("Fetching proposals from cache, limit: {}", limit);
 
-    let proposals_response = state.chain_client.get_proposals(limit, true).await?;
+    let cache = &state.data_cache.proposals_with_tally;
+    let snapshot = match cache.load() {
+        Some(snapshot) => snapshot,
+        None => {
+            // Cold cache — empty list with explicit header. The handler is
+            // never the place that triggers a chain fetch on cold; the
+            // background refresh task is the only writer.
+            let mut headers = HeaderMap::new();
+            headers.insert("Cache-Status", HeaderValue::from_static("cold"));
+            return Ok((
+                headers,
+                Json(ProposalsListResponse {
+                    proposals: Vec::new(),
+                    pagination: PaginationInfo {
+                        total: "0".to_string(),
+                        next_key: None,
+                    },
+                }),
+            ));
+        }
+    };
 
-    let mut proposals: Vec<ProposalResponse> = Vec::new();
+    // Hidden-proposal filter applies the *latest* gated config — request-time,
+    // not cache-time, so toggles take effect immediately.
+    let hidden_ids: std::collections::HashSet<String> = state
+        .data_cache
+        .gated_config
+        .load()
+        .map(|g| g.ui_settings.hidden_proposals.into_iter().collect())
+        .unwrap_or_default();
 
-    for proposal in proposals_response.proposals {
-        let mut response = ProposalResponse {
-            id: proposal.id.clone(),
-            status: proposal.status.clone(),
-            final_tally_result: proposal.final_tally_result,
-            submit_time: proposal.submit_time,
-            deposit_end_time: proposal.deposit_end_time,
-            voting_start_time: proposal.voting_start_time,
-            voting_end_time: proposal.voting_end_time,
-            title: proposal.title,
-            summary: proposal.summary,
-            messages: proposal.messages,
-            metadata: proposal.metadata,
-            tally: None,
-            voted: None,
+    let visible: Vec<chain::Proposal> = snapshot
+        .proposals
+        .into_iter()
+        .filter(|p| !hidden_ids.contains(&p.id))
+        .collect();
+    let total_visible = visible.len();
+    let page: Vec<chain::Proposal> = visible.into_iter().take(limit).collect();
+
+    // Live `?voter=` fan-out — only voting-period proposals trigger a vote
+    // call. A single chain error fails the whole request with 502; the
+    // 502 response shape is exactly what the frontend already handles for
+    // this endpoint.
+    let voted_map: std::collections::HashMap<String, bool> =
+        if let Some(voter) = query.voter.as_deref().filter(|v| !v.is_empty()) {
+            let voting_ids: Vec<String> = page
+                .iter()
+                .filter(|p| p.status == PROPOSAL_STATUS_VOTING_PERIOD)
+                .map(|p| p.id.clone())
+                .collect();
+            let chain_client = state.chain_client.clone();
+            let voter = voter.to_string();
+            let futs = voting_ids.into_iter().map(|id| {
+                let chain_client = chain_client.clone();
+                let voter = voter.clone();
+                async move {
+                    let res = chain_client.get_proposal_vote(&id, &voter).await?;
+                    let voted = match res {
+                        Some(vote_response) => !vote_response.vote.options.is_empty(),
+                        None => false,
+                    };
+                    Ok::<_, AppError>((id, voted))
+                }
+            });
+            try_join_all(futs).await?.into_iter().collect()
+        } else {
+            std::collections::HashMap::new()
         };
 
-        // For voting proposals, fetch tally
-        if proposal.status == "PROPOSAL_STATUS_VOTING_PERIOD" {
-            match state.chain_client.get_proposal_tally(&proposal.id).await {
-                Ok(tally_response) => {
-                    response.tally = Some(tally_response.tally);
-                }
-                Err(e) => {
-                    warn!("Failed to fetch tally for proposal {}: {}", proposal.id, e);
-                }
+    let proposals: Vec<ProposalResponse> = page
+        .into_iter()
+        .map(|p| {
+            let id = p.id.clone();
+            let status = p.status.clone();
+            let tally = if status == PROPOSAL_STATUS_VOTING_PERIOD {
+                snapshot.tallies.get(&id).cloned()
+            } else {
+                None
+            };
+            let voted = voted_map.get(&id).copied();
+            ProposalResponse {
+                id,
+                status,
+                final_tally_result: p.final_tally_result,
+                submit_time: p.submit_time,
+                deposit_end_time: p.deposit_end_time,
+                voting_start_time: p.voting_start_time,
+                voting_end_time: p.voting_end_time,
+                title: p.title,
+                summary: p.summary,
+                messages: p.messages,
+                metadata: p.metadata,
+                tally,
+                voted,
             }
+        })
+        .collect();
 
-            // If voter is provided, check if they voted
-            if let Some(ref voter) = query.voter {
-                match state
-                    .chain_client
-                    .get_proposal_vote(&proposal.id, voter)
-                    .await
-                {
-                    Ok(Some(vote_response)) => {
-                        response.voted = Some(!vote_response.vote.options.is_empty());
-                    }
-                    Ok(None) => {
-                        response.voted = Some(false);
-                    }
-                    Err(e) => {
-                        warn!(
-                            "Failed to check vote for proposal {} voter {}: {}",
-                            proposal.id, voter, e
-                        );
-                    }
-                }
-            }
-        }
-
-        proposals.push(response);
+    let mut headers = HeaderMap::new();
+    headers.insert("Cache-Status", HeaderValue::from_static("warm"));
+    let age = cache.age_secs().unwrap_or(0);
+    if let Ok(value) = HeaderValue::from_str(&age.to_string()) {
+        headers.insert("Cache-Age", value);
     }
 
-    Ok(Json(ProposalsListResponse {
-        proposals,
-        pagination: PaginationInfo {
-            total: proposals_response.pagination.total,
-            next_key: proposals_response.pagination.next_key,
-        },
-    }))
+    Ok((
+        headers,
+        Json(ProposalsListResponse {
+            proposals,
+            pagination: PaginationInfo {
+                total: total_visible.to_string(),
+                next_key: None,
+            },
+        }),
+    ))
 }
 
 /// Get proposal tally
@@ -521,23 +587,6 @@ mod tests {
         assert!(body.contains("\"hidden_ids\""), "body: {body}");
         assert!(body.contains("\"42\""), "body: {body}");
         assert!(body.contains("\"99\""), "body: {body}");
-    }
-
-    #[tokio::test]
-    async fn governance_proposals_upstream_failure_returns_502() {
-        // stub RPC (127.0.0.1:1 + 1ms timeout) ensures chain_client returns an
-        // error that maps to 502 BAD_GATEWAY via AppError::ChainRpc.
-        let app = build_app(test_app_state().await);
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/governance/proposals?limit=5")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
     }
 
     #[tokio::test]

--- a/backend/src/handlers/governance.rs
+++ b/backend/src/handlers/governance.rs
@@ -611,4 +611,397 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
     }
+
+    // =======================================================================
+    // Phase 1 cache refactor — proposals served from `proposals_with_tally`.
+    // =======================================================================
+
+    use std::collections::HashMap;
+    use wiremock::matchers::{method as wm_method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Build an `AppState` whose chain HTTP client uses a realistic timeout
+    /// and points at the supplied mock chain URL. Mirrors the helper in
+    /// `etl_proxy.rs::tests::state_with_etl_url`. Required for the live
+    /// `?voter` fan-out and per-id tally tests where chain calls actually
+    /// have to land on the wiremock.
+    async fn state_with_chain_url(chain_url: &str) -> Arc<AppState> {
+        use crate::config_store::ConfigStore;
+        use crate::handlers::websocket::WebSocketManager;
+        use crate::translations::{
+            llm::{LlmClient, LlmConfig},
+            TranslationStorage,
+        };
+        use std::time::Instant;
+
+        let mut cfg = crate::test_utils::test_config();
+        cfg.external.nolus_rest_url = chain_url.to_string();
+
+        let http_client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .expect("reqwest client");
+
+        let etl_client = crate::external::etl::EtlClient::new(
+            cfg.external.etl_api_url.clone(),
+            http_client.clone(),
+        );
+        let skip_client = crate::external::skip::SkipClient::new(
+            cfg.external.skip_api_url.clone(),
+            cfg.external.skip_api_key.clone(),
+            http_client.clone(),
+        );
+        let chain_client = crate::external::chain::ChainClient::new(
+            cfg.external.nolus_rest_url.clone(),
+            http_client.clone(),
+        );
+        let referral_client =
+            crate::external::referral::ReferralClient::new(&cfg, http_client.clone());
+        let zero_interest_client =
+            crate::external::zero_interest::ZeroInterestClient::new(&cfg, http_client.clone());
+
+        let config_dir = tempfile::tempdir().expect("tempdir").keep();
+        let config_store = ConfigStore::new(&config_dir);
+        config_store.init().await.expect("ConfigStore init");
+        let translation_dir = tempfile::tempdir().expect("tempdir").keep();
+        let translation_storage = TranslationStorage::new(&translation_dir);
+        translation_storage.init().await.expect("TS init");
+        let llm_client = LlmClient::new(LlmConfig {
+            api_key: String::new(),
+            model: "stub".to_string(),
+            base_url: Some("http://127.0.0.1:1/".to_string()),
+        });
+
+        Arc::new(AppState {
+            config: cfg,
+            etl_client,
+            skip_client,
+            chain_client,
+            referral_client,
+            zero_interest_client,
+            data_cache: crate::data_cache::AppDataCache::new(),
+            ws_manager: WebSocketManager::new(16),
+            config_store,
+            translation_storage,
+            llm_client,
+            startup_time: Instant::now(),
+        })
+    }
+
+    fn sample_proposal(id: &str, status: &str) -> chain::Proposal {
+        chain::Proposal {
+            id: id.to_string(),
+            status: status.to_string(),
+            final_tally_result: None,
+            submit_time: Some("2026-01-01T00:00:00Z".to_string()),
+            deposit_end_time: Some("2026-01-08T00:00:00Z".to_string()),
+            voting_start_time: Some("2026-01-08T00:00:00Z".to_string()),
+            voting_end_time: Some("2026-01-15T00:00:00Z".to_string()),
+            title: Some(format!("proposal {id}")),
+            summary: Some(format!("summary {id}")),
+            messages: vec![],
+            metadata: None,
+            tally: None,
+            voted: None,
+        }
+    }
+
+    fn populate_proposals_cache(state: &AppState, proposals: Vec<chain::Proposal>) {
+        state
+            .data_cache
+            .proposals_with_tally
+            .store(crate::data_cache::ProposalsWithTally {
+                proposals,
+                tallies: HashMap::new(),
+            });
+    }
+
+    #[tokio::test]
+    async fn governance_proposals_cold_cache_returns_empty_list_with_cache_status_header() {
+        let app = build_app(test_app_state().await);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/governance/proposals")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get("cache-status")
+                .map(|v| v.to_str().unwrap()),
+            Some("cold")
+        );
+        let body = collect_body_str(resp).await;
+        assert!(
+            body.contains("\"proposals\":[]"),
+            "cold cache must return empty proposals list, body: {body}"
+        );
+        assert!(
+            body.contains("\"total\":\"0\""),
+            "cold cache pagination.total must be \"0\", body: {body}"
+        );
+        assert!(
+            body.contains("\"next_key\":null"),
+            "cold cache pagination.next_key must be null, body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn governance_proposals_populated_cache_returns_list_with_cache_status_header() {
+        let state = test_app_state().await;
+        populate_proposals_cache(
+            &state,
+            vec![
+                sample_proposal("1", "PROPOSAL_STATUS_PASSED"),
+                sample_proposal("2", "PROPOSAL_STATUS_REJECTED"),
+            ],
+        );
+        let app = build_app(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/governance/proposals")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get("cache-status")
+                .map(|v| v.to_str().unwrap()),
+            Some("warm")
+        );
+        // Cache-Age header must be present and a numeric string (likely "0").
+        let age = resp
+            .headers()
+            .get("cache-age")
+            .expect("cache-age header on warm response")
+            .to_str()
+            .expect("ascii cache-age")
+            .to_string();
+        let age_secs: u64 = age.parse().expect("cache-age is a non-negative integer");
+        assert!(age_secs <= 5, "expected small age, got {age_secs}");
+
+        let body = collect_body_str(resp).await;
+        assert!(body.contains("\"id\":\"1\""), "body: {body}");
+        assert!(body.contains("\"id\":\"2\""), "body: {body}");
+        // No tally was populated for these finalized proposals; skip_serializing_if
+        // means the field is absent.
+        assert!(
+            !body.contains("\"tally\""),
+            "no tally field expected, body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn governance_proposals_with_voter_fans_out_live_vote_calls() {
+        // 1 voting + 1 finalized; only the voting one should trigger the live
+        // get_proposal_vote chain call.
+        let mock = MockServer::start().await;
+        let state = state_with_chain_url(&mock.uri()).await;
+        populate_proposals_cache(
+            &state,
+            vec![
+                sample_proposal("1", "PROPOSAL_STATUS_VOTING_PERIOD"),
+                sample_proposal("2", "PROPOSAL_STATUS_PASSED"),
+            ],
+        );
+
+        // Vote response for proposal 1 — voter cast a YES vote.
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/cosmos/gov/v1/proposals/1/votes/nolus1xxxx"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "vote": {
+                    "proposal_id": "1",
+                    "voter": "nolus1xxxx",
+                    "options": [{ "option": "VOTE_OPTION_YES", "weight": "1.0" }]
+                }
+            })))
+            .mount(&mock)
+            .await;
+
+        let app = build_app(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/governance/proposals?voter=nolus1xxxx")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = collect_body_str(resp).await;
+
+        // Only one chain vote call observed — the voting-period proposal.
+        let received = mock.received_requests().await.unwrap_or_default();
+        let vote_calls: Vec<_> = received
+            .iter()
+            .filter(|req| req.url.path().contains("/votes/"))
+            .collect();
+        assert_eq!(
+            vote_calls.len(),
+            1,
+            "exactly one vote chain call expected for the voting-period proposal"
+        );
+        assert!(
+            vote_calls[0].url.path().contains("/proposals/1/votes/"),
+            "vote call must be for proposal 1, got: {}",
+            vote_calls[0].url
+        );
+
+        // Response carries voted=true for proposal 1; proposal 2 has no `voted`.
+        assert!(
+            body.contains("\"voted\":true"),
+            "voted=true expected for proposal 1, body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn governance_proposals_hidden_filter_uses_latest_gated_config() {
+        let state = test_app_state().await;
+        populate_proposals_cache(
+            &state,
+            vec![
+                sample_proposal("X", "PROPOSAL_STATUS_PASSED"),
+                sample_proposal("Y", "PROPOSAL_STATUS_PASSED"),
+                sample_proposal("Z", "PROPOSAL_STATUS_PASSED"),
+            ],
+        );
+
+        // First request: hide Y only. Expect X and Z, not Y.
+        populate_gated(&state, vec!["Y".to_string()]);
+        let resp1 = build_app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/api/governance/proposals")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp1.status(), StatusCode::OK);
+        let body1 = collect_body_str(resp1).await;
+        assert!(body1.contains("\"id\":\"X\""), "X visible, body: {body1}");
+        assert!(
+            !body1.contains("\"id\":\"Y\""),
+            "Y must be filtered, body: {body1}"
+        );
+        assert!(body1.contains("\"id\":\"Z\""), "Z visible, body: {body1}");
+
+        // Swap gated_config: now hide both X and Y. Proposals cache untouched.
+        populate_gated(&state, vec!["X".to_string(), "Y".to_string()]);
+        let resp2 = build_app(state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/api/governance/proposals")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp2.status(), StatusCode::OK);
+        let body2 = collect_body_str(resp2).await;
+        assert!(
+            !body2.contains("\"id\":\"X\""),
+            "X now filtered, body: {body2}"
+        );
+        assert!(
+            !body2.contains("\"id\":\"Y\""),
+            "Y still filtered, body: {body2}"
+        );
+        assert!(body2.contains("\"id\":\"Z\""), "Z visible, body: {body2}");
+    }
+
+    #[tokio::test]
+    async fn governance_proposal_tally_per_id_stays_live() {
+        // Even with the proposals cache populated, the per-id tally route must
+        // still hit the chain — regression guard against accidentally routing
+        // it through the cached map.
+        let mock = MockServer::start().await;
+        let state = state_with_chain_url(&mock.uri()).await;
+        populate_proposals_cache(
+            &state,
+            vec![sample_proposal("7", "PROPOSAL_STATUS_VOTING_PERIOD")],
+        );
+
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/cosmos/gov/v1/proposals/7/tally"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "tally": {
+                    "yes_count": "42",
+                    "abstain_count": "0",
+                    "no_count": "0",
+                    "no_with_veto_count": "0"
+                }
+            })))
+            .mount(&mock)
+            .await;
+
+        let app = build_app(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/governance/proposals/7/tally")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = collect_body_str(resp).await;
+        assert!(body.contains("\"yes_count\":\"42\""), "body: {body}");
+
+        // Chain mock was actually hit — proves per-id stayed live.
+        let received = mock.received_requests().await.unwrap_or_default();
+        let hits: Vec<_> = received
+            .iter()
+            .filter(|r| r.url.path() == "/cosmos/gov/v1/proposals/7/tally")
+            .collect();
+        assert_eq!(
+            hits.len(),
+            1,
+            "per-id tally must be served live from chain, not from cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn governance_proposals_with_voter_upstream_failure_on_vote_returns_502() {
+        // Renamed from `governance_proposals_upstream_failure_returns_502`.
+        // After the cache refactor, the list endpoint without `?voter` no
+        // longer touches the chain — so a chain failure can only surface
+        // when fanning out vote calls. Populate the cache, mock vote 500,
+        // expect 502.
+        let mock = MockServer::start().await;
+        let state = state_with_chain_url(&mock.uri()).await;
+        populate_proposals_cache(
+            &state,
+            vec![sample_proposal("1", "PROPOSAL_STATUS_VOTING_PERIOD")],
+        );
+
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/cosmos/gov/v1/proposals/1/votes/nolus1xxxx"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("vote rpc unavailable"))
+            .mount(&mock)
+            .await;
+
+        let app = build_app(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/governance/proposals?voter=nolus1xxxx")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
 }

--- a/backend/src/refresh.rs
+++ b/backend/src/refresh.rs
@@ -83,10 +83,7 @@ pub async fn warm_essential_data(state: Arc<AppState>) {
         warm_with_timeout("gas_fee_config", refresh_gas_fee_config(&state)),
         warm_with_timeout("annual_inflation", refresh_annual_inflation(&state)),
         warm_with_timeout("staking_pool", refresh_staking_pool(&state)),
-        warm_with_timeout(
-            "proposals_with_tally",
-            refresh_governance_proposals(&state),
-        ),
+        warm_with_timeout("proposals_with_tally", refresh_governance_proposals(&state),),
     );
 
     info!("Essential data warm-up complete");
@@ -812,10 +809,8 @@ pub async fn refresh_governance_proposals(state: &Arc<AppState>) {
     // Merge: start with prior tallies, prune anything not in this cycle's
     // voting set, then apply this cycle's results (success overwrites,
     // failure leaves the prior entry in place).
-    let voting_set: std::collections::HashSet<String> = tally_results
-        .iter()
-        .map(|(id, _)| id.clone())
-        .collect();
+    let voting_set: std::collections::HashSet<String> =
+        tally_results.iter().map(|(id, _)| id.clone()).collect();
     let mut tallies = prior_tallies;
     tallies.retain(|id, _| voting_set.contains(id));
 
@@ -2960,7 +2955,8 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/cosmos/gov/v1/proposals"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(proposals_body(&[p_a.clone(), p_b.clone()])),
+                ResponseTemplate::new(200)
+                    .set_body_json(proposals_body(&[p_a.clone(), p_b.clone()])),
             )
             .mount(&chain)
             .await;
@@ -3003,7 +2999,8 @@ mod tests {
         // Pre-populate cache with prior tallies for both A and B.
         let prior_a = sample_proposal("1", "PROPOSAL_STATUS_VOTING_PERIOD");
         let prior_b = sample_proposal("2", "PROPOSAL_STATUS_VOTING_PERIOD");
-        let mut prior_tallies: HashMap<String, crate::external::chain::TallyResult> = HashMap::new();
+        let mut prior_tallies: HashMap<String, crate::external::chain::TallyResult> =
+            HashMap::new();
         prior_tallies.insert("1".to_string(), sample_tally("prior_a"));
         prior_tallies.insert("2".to_string(), sample_tally("prior_b"));
         state
@@ -3030,7 +3027,8 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/cosmos/gov/v1/proposals/1/tally"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(json!({ "tally": sample_tally("fresh_a") })),
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({ "tally": sample_tally("fresh_a") })),
             )
             .mount(&chain)
             .await;
@@ -3055,7 +3053,10 @@ mod tests {
         // Tally A overwritten with fresh value; B retains prior.
         let a = loaded.tallies.get("1").expect("tally A present");
         assert_eq!(a.yes_count, "fresh_a");
-        let b = loaded.tallies.get("2").expect("tally B retained from prior");
+        let b = loaded
+            .tallies
+            .get("2")
+            .expect("tally B retained from prior");
         assert_eq!(b.yes_count, "prior_b");
     }
 
@@ -3064,7 +3065,8 @@ mod tests {
         let (state, _etl, chain) = state_with_wiremock_etl_and_chain().await;
 
         // Pre-populate with two voting-period proposals + tallies.
-        let mut prior_tallies: HashMap<String, crate::external::chain::TallyResult> = HashMap::new();
+        let mut prior_tallies: HashMap<String, crate::external::chain::TallyResult> =
+            HashMap::new();
         prior_tallies.insert("1".to_string(), sample_tally("prior_a"));
         prior_tallies.insert("2".to_string(), sample_tally("prior_b"));
         state
@@ -3094,7 +3096,8 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/cosmos/gov/v1/proposals/1/tally"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(json!({ "tally": sample_tally("fresh_a") })),
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({ "tally": sample_tally("fresh_a") })),
             )
             .mount(&chain)
             .await;

--- a/backend/src/refresh.rs
+++ b/backend/src/refresh.rs
@@ -6,9 +6,32 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::future::join_all;
 use tracing::{debug, error, info, warn};
+
+/// Per-call ceiling for `warm_essential_data` so a hung chain LCD on boot
+/// cannot block `axum::serve` from binding. The deploy script has already
+/// stopped the prior binary by the time warm-up runs — without an outer
+/// bound, a stuck handshake would take the host dark.
+const WARM_CALL_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Run `fut` with the warm-up timeout. On timeout, log a single `warn!` and
+/// return — the cache stays empty for that field and the request handler
+/// falls back to its cold-cache path.
+async fn warm_with_timeout<F>(name: &'static str, fut: F)
+where
+    F: std::future::Future<Output = ()>,
+{
+    if tokio::time::timeout(WARM_CALL_TIMEOUT, fut).await.is_err() {
+        warn!(
+            "warm_essential_data: {} timed out after {}s — leaving cache cold",
+            name,
+            WARM_CALL_TIMEOUT.as_secs()
+        );
+    }
+}
 
 use crate::chain_events::EventChannels;
 use crate::data_cache::GatedConfigBundle;
@@ -41,24 +64,24 @@ pub async fn warm_essential_data(state: Arc<AppState>) {
     info!("Starting essential data warm-up...");
 
     // Load gated config from disk first (no external deps)
-    refresh_gated_config(&state).await;
+    warm_with_timeout("gated_config", refresh_gated_config(&state)).await;
 
     // Load filter context (needs gated config + ETL)
-    refresh_filter_context(&state).await;
+    warm_with_timeout("filter_context", refresh_filter_context(&state)).await;
 
     // Load protocol contracts from admin contract
-    refresh_protocol_contracts(&state).await;
+    warm_with_timeout("protocol_contracts", refresh_protocol_contracts(&state)).await;
 
     // These can run in parallel since they depend on data already loaded above
     tokio::join!(
-        refresh_app_config(&state),
-        refresh_currencies(&state),
-        refresh_prices(&state),
-        refresh_gated_protocols(&state),
-        refresh_gated_networks(&state),
-        refresh_gas_fee_config(&state),
-        refresh_annual_inflation(&state),
-        refresh_staking_pool(&state),
+        warm_with_timeout("app_config", refresh_app_config(&state)),
+        warm_with_timeout("currencies", refresh_currencies(&state)),
+        warm_with_timeout("prices", refresh_prices(&state)),
+        warm_with_timeout("gated_protocols", refresh_gated_protocols(&state)),
+        warm_with_timeout("gated_networks", refresh_gated_networks(&state)),
+        warm_with_timeout("gas_fee_config", refresh_gas_fee_config(&state)),
+        warm_with_timeout("annual_inflation", refresh_annual_inflation(&state)),
+        warm_with_timeout("staking_pool", refresh_staking_pool(&state)),
     );
 
     info!("Essential data warm-up complete");

--- a/backend/src/refresh.rs
+++ b/backend/src/refresh.rs
@@ -3182,34 +3182,28 @@ mod tests {
         assert_eq!(loaded.tallies.len(), 12);
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
     async fn warm_essential_data_returns_within_bounded_time_on_chain_hang() {
-        // Default test_app_state uses `127.0.0.1:1` with a 1ms HTTP timeout.
-        // The contract under test is the per-call `tokio::time::timeout(15s)`
-        // wrapping every warm call: even if a chain endpoint hangs forever,
-        // warm_essential_data MUST return within ~16s of paused virtual time.
-        //
-        // Asserting on real wall-clock with a real wiremock-hung connection is
-        // too brittle under paused time. Instead we lean on the unroutable
-        // 1ms-timeout client (every fetch fails fast) and add an
-        // outer paused-time bound to confirm the function is non-blocking.
+        // `test_app_state` configures the chain HTTP client with a 1ms request
+        // timeout against an unroutable address, so every chain call inside
+        // `warm_essential_data` fails fast. Real wall-clock here is bounded
+        // by that fast-fail path plus the disk-only refreshers — well under a
+        // second in practice. The 5s ceiling is a real-time regression guard:
+        // if a future change introduces an unbounded await without our
+        // `tokio::time::timeout(15s)` wrapper, this test catches it.
         let state = crate::test_utils::test_app_state().await;
 
-        let started = tokio::time::Instant::now();
+        let started = std::time::Instant::now();
         warm_essential_data(state.clone()).await;
         let elapsed = started.elapsed();
 
-        // Bound: even the wrapped 15s timeout × however-many-serial-stages must
-        // be substantially less than (15s × stage_count). We pick a generous
-        // ceiling — 60s of paused virtual time — that nonetheless catches an
-        // unbounded hang regression.
         assert!(
-            elapsed <= std::time::Duration::from_secs(60),
-            "warm_essential_data exceeded 60s paused-time budget: {:?}",
+            elapsed <= std::time::Duration::from_secs(5),
+            "warm_essential_data exceeded 5s wall-clock budget: {:?}",
             elapsed
         );
 
-        // No proposals should be cached — chain calls all failed fast.
+        // No proposals cached — chain calls all failed fast.
         assert!(state.data_cache.proposals_with_tally.load().is_none());
     }
 }

--- a/backend/src/refresh.rs
+++ b/backend/src/refresh.rs
@@ -2908,4 +2908,305 @@ mod tests {
         // Dropping `state` here (via scope end) is implicit — if any spawned
         // task held a problematic strong ref, clippy/miri would catch it in CI.
     }
+
+    // =======================================================================
+    // refresh_governance_proposals (Phase 1 cache refactor)
+    // =======================================================================
+
+    /// Build a minimal `Proposal` value with the given id and status.
+    /// All other fields populated with deterministic placeholder strings so
+    /// equality assertions on the round-tripped value are stable.
+    fn sample_proposal(id: &str, status: &str) -> crate::external::chain::Proposal {
+        crate::external::chain::Proposal {
+            id: id.to_string(),
+            status: status.to_string(),
+            final_tally_result: None,
+            submit_time: Some("2026-01-01T00:00:00Z".to_string()),
+            deposit_end_time: Some("2026-01-08T00:00:00Z".to_string()),
+            voting_start_time: Some("2026-01-08T00:00:00Z".to_string()),
+            voting_end_time: Some("2026-01-15T00:00:00Z".to_string()),
+            title: Some(format!("proposal {id}")),
+            summary: Some(format!("summary {id}")),
+            messages: vec![],
+            metadata: None,
+            tally: None,
+            voted: None,
+        }
+    }
+
+    fn sample_tally(yes: &str) -> crate::external::chain::TallyResult {
+        crate::external::chain::TallyResult {
+            yes_count: yes.to_string(),
+            abstain_count: "0".to_string(),
+            no_count: "0".to_string(),
+            no_with_veto_count: "0".to_string(),
+        }
+    }
+
+    fn proposals_body(proposals: &[crate::external::chain::Proposal]) -> serde_json::Value {
+        json!({
+            "proposals": proposals,
+            "pagination": { "total": proposals.len().to_string(), "next_key": null }
+        })
+    }
+
+    #[tokio::test]
+    async fn refresh_governance_proposals_populates_on_success() {
+        let (state, _etl, chain) = state_with_wiremock_etl_and_chain().await;
+
+        let p_a = sample_proposal("1", "PROPOSAL_STATUS_VOTING_PERIOD");
+        let p_b = sample_proposal("2", "PROPOSAL_STATUS_PASSED");
+
+        Mock::given(method("GET"))
+            .and(path("/cosmos/gov/v1/proposals"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(proposals_body(&[p_a.clone(), p_b.clone()])),
+            )
+            .mount(&chain)
+            .await;
+
+        // Tally only fetched for voting-period proposals (just "1" here).
+        Mock::given(method("GET"))
+            .and(path("/cosmos/gov/v1/proposals/1/tally"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "tally": sample_tally("100") })),
+            )
+            .mount(&chain)
+            .await;
+
+        refresh_governance_proposals(&state).await;
+
+        let loaded: crate::data_cache::ProposalsWithTally = state
+            .data_cache
+            .proposals_with_tally
+            .load()
+            .expect("proposals_with_tally populated after success");
+
+        assert_eq!(loaded.proposals.len(), 2);
+        assert_eq!(loaded.proposals[0].id, "1");
+        assert_eq!(loaded.proposals[1].id, "2");
+
+        // Tally map: only the voting-period proposal has an entry.
+        assert_eq!(loaded.tallies.len(), 1);
+        let tally_a = loaded
+            .tallies
+            .get("1")
+            .expect("tally for voting proposal 1 stored");
+        assert_eq!(tally_a.yes_count, "100");
+        assert!(!loaded.tallies.contains_key("2"));
+    }
+
+    #[tokio::test]
+    async fn refresh_governance_proposals_partial_tally_failure_merges_with_prior() {
+        let (state, _etl, chain) = state_with_wiremock_etl_and_chain().await;
+
+        // Pre-populate cache with prior tallies for both A and B.
+        let prior_a = sample_proposal("1", "PROPOSAL_STATUS_VOTING_PERIOD");
+        let prior_b = sample_proposal("2", "PROPOSAL_STATUS_VOTING_PERIOD");
+        let mut prior_tallies: HashMap<String, crate::external::chain::TallyResult> = HashMap::new();
+        prior_tallies.insert("1".to_string(), sample_tally("prior_a"));
+        prior_tallies.insert("2".to_string(), sample_tally("prior_b"));
+        state
+            .data_cache
+            .proposals_with_tally
+            .store(crate::data_cache::ProposalsWithTally {
+                proposals: vec![prior_a.clone(), prior_b.clone()],
+                tallies: prior_tallies,
+            });
+
+        // Fresh proposals list: A and B both still in voting period.
+        let fresh_a = sample_proposal("1", "PROPOSAL_STATUS_VOTING_PERIOD");
+        let fresh_b = sample_proposal("2", "PROPOSAL_STATUS_VOTING_PERIOD");
+        Mock::given(method("GET"))
+            .and(path("/cosmos/gov/v1/proposals"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(proposals_body(&[fresh_a.clone(), fresh_b.clone()])),
+            )
+            .mount(&chain)
+            .await;
+
+        // Tally A succeeds with a NEW value.
+        Mock::given(method("GET"))
+            .and(path("/cosmos/gov/v1/proposals/1/tally"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "tally": sample_tally("fresh_a") })),
+            )
+            .mount(&chain)
+            .await;
+        // Tally B fails with 500.
+        Mock::given(method("GET"))
+            .and(path("/cosmos/gov/v1/proposals/2/tally"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&chain)
+            .await;
+
+        refresh_governance_proposals(&state).await;
+
+        let loaded = state
+            .data_cache
+            .proposals_with_tally
+            .load()
+            .expect("populated");
+
+        // Proposals list reflects the fresh fetch.
+        assert_eq!(loaded.proposals.len(), 2);
+
+        // Tally A overwritten with fresh value; B retains prior.
+        let a = loaded.tallies.get("1").expect("tally A present");
+        assert_eq!(a.yes_count, "fresh_a");
+        let b = loaded.tallies.get("2").expect("tally B retained from prior");
+        assert_eq!(b.yes_count, "prior_b");
+    }
+
+    #[tokio::test]
+    async fn refresh_governance_proposals_prunes_non_voting_tallies() {
+        let (state, _etl, chain) = state_with_wiremock_etl_and_chain().await;
+
+        // Pre-populate with two voting-period proposals + tallies.
+        let mut prior_tallies: HashMap<String, crate::external::chain::TallyResult> = HashMap::new();
+        prior_tallies.insert("1".to_string(), sample_tally("prior_a"));
+        prior_tallies.insert("2".to_string(), sample_tally("prior_b"));
+        state
+            .data_cache
+            .proposals_with_tally
+            .store(crate::data_cache::ProposalsWithTally {
+                proposals: vec![
+                    sample_proposal("1", "PROPOSAL_STATUS_VOTING_PERIOD"),
+                    sample_proposal("2", "PROPOSAL_STATUS_VOTING_PERIOD"),
+                ],
+                tallies: prior_tallies,
+            });
+
+        // Fresh fetch: A still voting, B passed.
+        let fresh_a = sample_proposal("1", "PROPOSAL_STATUS_VOTING_PERIOD");
+        let fresh_b = sample_proposal("2", "PROPOSAL_STATUS_PASSED");
+        Mock::given(method("GET"))
+            .and(path("/cosmos/gov/v1/proposals"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(proposals_body(&[fresh_a, fresh_b])),
+            )
+            .mount(&chain)
+            .await;
+
+        // Tally A succeeds. Tally B mock NOT mounted — refresh must not call it
+        // because B is no longer in voting period.
+        Mock::given(method("GET"))
+            .and(path("/cosmos/gov/v1/proposals/1/tally"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "tally": sample_tally("fresh_a") })),
+            )
+            .mount(&chain)
+            .await;
+
+        refresh_governance_proposals(&state).await;
+
+        let loaded = state
+            .data_cache
+            .proposals_with_tally
+            .load()
+            .expect("populated");
+
+        // Tally map has key A only — B is dropped because B exited voting period.
+        assert!(loaded.tallies.contains_key("1"), "A tally retained");
+        assert!(
+            !loaded.tallies.contains_key("2"),
+            "B tally pruned on exit-voting"
+        );
+        assert_eq!(loaded.tallies.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn refresh_governance_proposals_caps_concurrency_at_eight() {
+        // Approach: use timing-based assertion. With 12 voting-period proposals,
+        // each tally mocked to take 100ms, `buffer_unordered(8)` should produce
+        // total elapsed ≈ ceil(12/8) * 100ms = 200ms. Fully serial would be
+        // ~1200ms; fully parallel ~100ms. We assert elapsed sits in a band
+        // that only `buffer_unordered(8)` (or a similar bound) satisfies.
+        //
+        // TODO: tighten this assertion once we settle on a counter approach
+        // (shared AtomicUsize incremented on mock-entry, peak tracked via
+        // fetch_max). For now, timing is the most portable signal.
+        let (state, _etl, chain) = state_with_wiremock_etl_and_chain().await;
+
+        let proposals: Vec<crate::external::chain::Proposal> = (1..=12)
+            .map(|i| sample_proposal(&i.to_string(), "PROPOSAL_STATUS_VOTING_PERIOD"))
+            .collect();
+
+        Mock::given(method("GET"))
+            .and(path("/cosmos/gov/v1/proposals"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(proposals_body(&proposals)))
+            .mount(&chain)
+            .await;
+
+        // One mock matching ANY per-id tally URL, with a 100ms delay.
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path_regex(
+                r"^/cosmos/gov/v1/proposals/\d+/tally$",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({ "tally": sample_tally("1") }))
+                    .set_delay(std::time::Duration::from_millis(100)),
+            )
+            .mount(&chain)
+            .await;
+
+        let started = std::time::Instant::now();
+        refresh_governance_proposals(&state).await;
+        let elapsed = started.elapsed();
+
+        // Concurrency 8 → ceil(12/8) = 2 batches × 100ms = ~200ms.
+        // Lower bound: must be > 100ms (else concurrency >= 12 — not bounded).
+        // Upper bound: generous slack for proposals fetch + scheduling.
+        assert!(
+            elapsed >= std::time::Duration::from_millis(180),
+            "elapsed {:?} too short — concurrency cap > 8?",
+            elapsed
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(900),
+            "elapsed {:?} too long — fan-out not parallelizing?",
+            elapsed
+        );
+
+        // And we still successfully populated all 12 tallies.
+        let loaded = state
+            .data_cache
+            .proposals_with_tally
+            .load()
+            .expect("populated");
+        assert_eq!(loaded.tallies.len(), 12);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn warm_essential_data_returns_within_bounded_time_on_chain_hang() {
+        // Default test_app_state uses `127.0.0.1:1` with a 1ms HTTP timeout.
+        // The contract under test is the per-call `tokio::time::timeout(15s)`
+        // wrapping every warm call: even if a chain endpoint hangs forever,
+        // warm_essential_data MUST return within ~16s of paused virtual time.
+        //
+        // Asserting on real wall-clock with a real wiremock-hung connection is
+        // too brittle under paused time. Instead we lean on the unroutable
+        // 1ms-timeout client (every fetch fails fast) and add an
+        // outer paused-time bound to confirm the function is non-blocking.
+        let state = crate::test_utils::test_app_state().await;
+
+        let started = tokio::time::Instant::now();
+        warm_essential_data(state.clone()).await;
+        let elapsed = started.elapsed();
+
+        // Bound: even the wrapped 15s timeout × however-many-serial-stages must
+        // be substantially less than (15s × stage_count). We pick a generous
+        // ceiling — 60s of paused virtual time — that nonetheless catches an
+        // unbounded hang regression.
+        assert!(
+            elapsed <= std::time::Duration::from_secs(60),
+            "warm_essential_data exceeded 60s paused-time budget: {:?}",
+            elapsed
+        );
+
+        // No proposals should be cached — chain calls all failed fast.
+        assert!(state.data_cache.proposals_with_tally.load().is_none());
+    }
 }

--- a/backend/src/refresh.rs
+++ b/backend/src/refresh.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::join_all;
+use futures::stream::{self, StreamExt};
 use tracing::{debug, error, info, warn};
 
 /// Per-call ceiling for `warm_essential_data` so a hung chain LCD on boot
@@ -34,8 +35,8 @@ where
 }
 
 use crate::chain_events::EventChannels;
-use crate::data_cache::GatedConfigBundle;
-use crate::external::chain::ProtocolContractsInfo;
+use crate::data_cache::{GatedConfigBundle, ProposalsWithTally};
+use crate::external::chain::{ProtocolContractsInfo, TallyResult};
 use crate::handlers::config::{
     AppConfigResponse, ContractsInfo, NativeAssetInfo, NetworkInfo, ProtocolInfo,
 };
@@ -82,6 +83,10 @@ pub async fn warm_essential_data(state: Arc<AppState>) {
         warm_with_timeout("gas_fee_config", refresh_gas_fee_config(&state)),
         warm_with_timeout("annual_inflation", refresh_annual_inflation(&state)),
         warm_with_timeout("staking_pool", refresh_staking_pool(&state)),
+        warm_with_timeout(
+            "proposals_with_tally",
+            refresh_governance_proposals(&state),
+        ),
     );
 
     info!("Essential data warm-up complete");
@@ -101,7 +106,8 @@ pub async fn warm_essential_data(state: Arc<AppState>) {
 ///   All depend on Group 2 outputs.
 ///
 /// **Group 4 — Domain Data (60s, independent):**
-///   pools, validators — no internal dependencies.
+///   pools, validators, annual_inflation, staking_pool, proposals_with_tally —
+///   no internal dependencies.
 ///
 /// **Group 5 — ETL Stats (60s, independent):**
 ///   stats_overview, loans_stats — pure ETL reads.
@@ -149,6 +155,7 @@ pub fn start_all(state: Arc<AppState>, event_channels: &EventChannels) {
                 refresh_validators(s),
                 refresh_annual_inflation(s),
                 refresh_staking_pool(s),
+                refresh_governance_proposals(s),
             );
         })
     });
@@ -738,6 +745,111 @@ pub async fn refresh_validators(state: &Arc<AppState>) {
         .collect();
 
     state.data_cache.validators.store(result);
+}
+
+/// Status string the chain reports for proposals currently accepting votes.
+const PROPOSAL_STATUS_VOTING_PERIOD: &str = "PROPOSAL_STATUS_VOTING_PERIOD";
+
+/// Maximum concurrent per-proposal tally calls. The list endpoint can have
+/// up to ~10 voting-period proposals; capping at 8 keeps boot-time fan-out
+/// from stacking on top of the other Group 4 tasks plus any retry-held
+/// chain-client permits.
+const PROPOSAL_TALLY_FANOUT_CAP: usize = 8;
+
+/// Refresh governance proposals plus per-proposal tallies for those in
+/// `PROPOSAL_STATUS_VOTING_PERIOD`.
+///
+/// Semantics:
+/// - `proposals` is canonical: replaced atomically every cycle (even if every
+///   tally fan-out call fails).
+/// - `tallies` is merged with prior state: success overwrites, per-id failure
+///   retains the prior value, and proposals not in voting period are pruned.
+/// - On the proposals list call itself failing, the cache is left untouched.
+pub async fn refresh_governance_proposals(state: &Arc<AppState>) {
+    let started = std::time::Instant::now();
+
+    let proposals_response = match state.chain_client.get_proposals(100, true).await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("Failed to refresh governance proposals: {}", e);
+            return;
+        }
+    };
+    let proposals = proposals_response.proposals;
+
+    let prior_tallies: HashMap<String, TallyResult> = state
+        .data_cache
+        .proposals_with_tally
+        .load()
+        .map(|p| p.tallies)
+        .unwrap_or_default();
+
+    let voting_ids: Vec<String> = proposals
+        .iter()
+        .filter(|p| p.status == PROPOSAL_STATUS_VOTING_PERIOD)
+        .map(|p| p.id.clone())
+        .collect();
+    let voting_count = voting_ids.len();
+
+    // Fan out per-proposal tally fetches with a hard concurrency cap.
+    let chain_client = state.chain_client.clone();
+    let tally_results: Vec<(String, Result<TallyResult, String>)> = stream::iter(voting_ids)
+        .map(|id| {
+            let chain_client = chain_client.clone();
+            async move {
+                let res = chain_client
+                    .get_proposal_tally(&id)
+                    .await
+                    .map(|resp| resp.tally)
+                    .map_err(|e| e.to_string());
+                (id, res)
+            }
+        })
+        .buffer_unordered(PROPOSAL_TALLY_FANOUT_CAP)
+        .collect()
+        .await;
+
+    // Merge: start with prior tallies, prune anything not in this cycle's
+    // voting set, then apply this cycle's results (success overwrites,
+    // failure leaves the prior entry in place).
+    let voting_set: std::collections::HashSet<String> = tally_results
+        .iter()
+        .map(|(id, _)| id.clone())
+        .collect();
+    let mut tallies = prior_tallies;
+    tallies.retain(|id, _| voting_set.contains(id));
+
+    let mut tallies_ok: usize = 0;
+    let mut tallies_kept_prior: usize = 0;
+    for (id, result) in tally_results {
+        match result {
+            Ok(tally) => {
+                tallies.insert(id, tally);
+                tallies_ok += 1;
+            }
+            Err(e) => {
+                warn!("Failed to fetch tally for proposal {}: {}", id, e);
+                if tallies.contains_key(&id) {
+                    tallies_kept_prior += 1;
+                }
+            }
+        }
+    }
+
+    let proposal_count = proposals.len();
+    state
+        .data_cache
+        .proposals_with_tally
+        .store(ProposalsWithTally { proposals, tallies });
+
+    info!(
+        "governance_refresh: proposals={} voting={} tallies_ok={} tallies_kept_prior={} elapsed_ms={}",
+        proposal_count,
+        voting_count,
+        tallies_ok,
+        tallies_kept_prior,
+        started.elapsed().as_millis(),
+    );
 }
 
 /// Refresh annual inflation from chain


### PR DESCRIPTION
## Summary

Route `/api/governance/proposals` through `Cached<ProposalsWithTally>` with a 60s background refresh, capped at 8 concurrent tally fetches. Per-id `/proposals/{id}/tally` and the per-voter vote fan-out stay live. Cold cache returns `200 OK + Cache-Status: cold`; warm responses carry `Cache-Status: warm` and `Cache-Age`. As a latent-bug fix, every call inside `warm_essential_data` is now wrapped in a 15s timeout so a hung chain LCD on boot can no longer block the server from binding.

Refs #149 — first of several PRs that move chain-global read paths to the cached pattern.

## Changes

- New `proposals_with_tally: Cached<ProposalsWithTally>` field; refresh task wired into Group 4 (60s) and `warm_essential_data`.
- `refresh_governance_proposals`: list canonical, tally map merged-with-prior on partial fan-out failure, prune-on-exit-voting.
- `get_proposals` reads from cache, applies the hidden-proposal filter from `gated_config` at request time, fans out live `get_proposal_vote` only for voting-period proposals when `?voter=` is set.
- `warm_with_timeout` helper wraps all 8 existing warm calls + the new governance one with `tokio::time::timeout(15s)`.
- OpenAPI snapshot regenerated to document `Cache-Status` / `Cache-Age` response headers.

## Trade-offs we considered

- Cold cache returns `200 OK + Cache-Status: cold` rather than `503` — the existing FE flow uses `Promise.allSettled` on `view.vue` and a 503 would silently leave the page in an infinite skeleton.
- Hidden-proposal filter applied at request time (not at refresh time) so admin-driven `gated_config` updates apply instantly.
- Voter fan-out kept live: a cached voter map would either explode in size or require per-address invalidation; live fan-out is cheap because it only touches voting-period proposals.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --all-targets`, `cargo test --all-targets` all pass on the final commit (465 tests).
- 11 new tests cover: cache populate, partial-failure merge, prune-on-exit, fan-out cap, warm-data wall-clock budget, cold/warm headers, voter fan-out (live + 502 propagation), request-time hidden filter, per-id tally stays live.
- Independent fresh-context diff review and a security pass via the `differential-review` skill both clear after two follow-up fixes (over-long commit subjects rewritten; warm-data hang test rewritten on real wall-clock instead of vacuously-true paused time).

## Follow-ups

- Cache governance metadata next (tallying-params, denom-metadata, node-info, staking-params) — covered by the umbrella in #149.
- Frontend-only: `src/modules/vote/view.vue` does not refetch `/proposals` when the wallet connects post-page-load. Pre-existing bug that becomes steady-state visible once the list is cached ("voted" badges stale on already-voted proposals). Tracking separately.