### PR TITLE
refactor: drive network filter from connected wallet

### DIFF
--- a/src/common/components/settings/ThemeSettings.vue
+++ b/src/common/components/settings/ThemeSettings.vue
@@ -1,13 +1,6 @@
 <template>
   <div class="flex flex-col gap-6 p-4">
     <Dropdown
-      id="header"
-      :label="$t('message.network')"
-      :options="options"
-      :selected="option"
-      :on-select="onSelect"
-    />
-    <Dropdown
       id="language"
       :label="$t('message.language')"
       :options="languagesOptions"
@@ -47,14 +40,11 @@
 import { h, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { type DropdownOption, Dropdown } from "web-components";
-import { WalletManager } from "@/common/utils";
-import { usePricesStore } from "@/common/stores/prices";
 
 import { setLang } from "@/i18n";
 import { APPEARANCE, languages } from "@/config/global";
 import { setTheme, getTheme, type Theme } from "@/common/utils/ThemeManager";
 import { getLanguage, setLanguage as setLangUtil } from "@/common/utils/LanguageUtils";
-import { useConfigStore } from "@/common/stores/config";
 
 import DarkIcon from "@/assets/icons/theme/dark.svg";
 import LightIcon from "@/assets/icons/theme/light.svg";
@@ -63,8 +53,6 @@ import SyncIcon from "@/assets/icons/theme/sync.svg";
 const i18n = useI18n();
 const lang = getLanguage();
 const themeData = getTheme();
-const configStore = useConfigStore();
-const pricesStore = usePricesStore();
 
 const selectedAppearance = ref({
   label: i18n.t(`message.${themeData}`),
@@ -81,9 +69,6 @@ const ThemeIcons = {
   light: h(LightIcon),
   sync: h(SyncIcon)
 };
-
-const options = configStore.getNetworkFilterOptions();
-const option = options.find((item) => item.value == WalletManager.getProtocolFilter());
 
 const languagesOptions = ref(
   Object.keys(languages).map((key) => {
@@ -130,11 +115,6 @@ async function setLanguage(item: DropdownOption) {
     label: i18n.t(`message.${themeData}`),
     value: themeData
   };
-}
-
-async function onSelect(item: { value: string; label: string; icon: string }) {
-  configStore.setProtocolFilter(item.value);
-  await pricesStore.fetchPrices();
 }
 </script>
 

--- a/src/common/stores/config/index.test.ts
+++ b/src/common/stores/config/index.test.ts
@@ -164,33 +164,11 @@ describe("ConfigStore", () => {
     expect(store.selectedNetwork).toBe("mainnet");
   });
 
-  it("protocolFilter_persisted_to_localStorage_on_set", async () => {
-    const store = useConfigStore();
-    store.setProtocolFilter("OSMOSIS");
-    // watchers are flushed on the next microtask
-    await Promise.resolve();
-    expect(localStorage.getItem("protocol_filter")).toBe("OSMOSIS");
-  });
-
-  it("protocolFilter_cleared_from_localStorage_on_empty", async () => {
-    localStorage.setItem("protocol_filter", "OSMOSIS");
-    const store = useConfigStore();
-    store.clearProtocolFilter();
-    await Promise.resolve();
-    expect(localStorage.getItem("protocol_filter")).toBeNull();
-  });
-
   it("selectedNetwork_persisted_to_localStorage_on_set", async () => {
     const store = useConfigStore();
     store.setSelectedNetwork("testnet");
     await Promise.resolve();
     expect(localStorage.getItem("selected_network")).toBe("testnet");
-  });
-
-  it("protocolFilter_read_from_localStorage_on_store_creation", () => {
-    localStorage.setItem("protocol_filter", "NEUTRON");
-    const store = useConfigStore();
-    expect(store.protocolFilter).toBe("NEUTRON");
   });
 
   // -------------------------------------------------------------------------
@@ -446,16 +424,6 @@ describe("ConfigStore", () => {
     const filters = store.getAvailableNetworkFilters();
     expect(filters).toContain("OSMOSIS");
     expect(filters).toContain("NEUTRON");
-  });
-
-  it("getNetworkFilterOptions_maps_keys_to_labels", async () => {
-    api.getConfig.mockResolvedValueOnce(makeConfig());
-    const store = useConfigStore();
-    await store.fetchConfig();
-    const options = store.getNetworkFilterOptions();
-    const osmosis = options.find((o) => o.value === "OSMOSIS");
-    expect(osmosis?.label).toBe("Osmosis");
-    expect(osmosis?.icon).toBe("/icons/osmosis.svg");
   });
 
   // -------------------------------------------------------------------------

--- a/src/common/stores/config/index.test.ts
+++ b/src/common/stores/config/index.test.ts
@@ -503,4 +503,138 @@ describe("ConfigStore", () => {
     const store = useConfigStore();
     expect(store.getPositionType("DOES_NOT_EXIST")).toBe("Long");
   });
+
+  // -------------------------------------------------------------------------
+  // protocolFilter watcher contract (post-refactor)
+  // -------------------------------------------------------------------------
+  //
+  // After the wallet-driven network refactor, the configStore is the sole
+  // owner of protocolFilter. The watcher must:
+  //   1. Reject filters that are not valid network keys before fetching, so
+  //      a stray "DEFINITELY_NOT_A_NETWORK" doesn't burn a 503 round trip.
+  //   2. Record failed fetches in a "do-not-retry" set so a flapping backend
+  //      doesn't get hammered by repeated setProtocolFilter calls for the
+  //      same network.
+  //   3. Log failures at error level (console.error), not just warn.
+  //   4. Drop stale assets when a switch fails — never leave the previous
+  //      network's assets visible under the new filter.
+
+  /** Helper: prime the store so initialize() is a no-op past the first cycle. */
+  async function primeInitializedStore() {
+    api.getConfig.mockResolvedValueOnce(makeConfig());
+    api.getCurrencies.mockResolvedValueOnce(makeCurrencies());
+    api.getNetworkAssets.mockResolvedValueOnce({ assets: [] });
+    api.getGatedProtocols.mockResolvedValueOnce({ protocols: [] });
+    api.getGasFeeConfig.mockResolvedValueOnce({ gas_prices: {}, gas_multiplier: 1 });
+    const store = useConfigStore();
+    await store.initialize();
+    api.getNetworkAssets.mockClear();
+    return store;
+  }
+
+  it("watcher_rejects_invalid_filter_before_fetching", async () => {
+    const store = await primeInitializedStore();
+
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      store.setProtocolFilter("DEFINITELY_NOT_A_NETWORK");
+      // Let the Vue watcher microtask flush.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(api.getNetworkAssets).not.toHaveBeenCalled();
+      // Either warn or error is acceptable — implementation choice. The
+      // contract is "log it, don't silently swallow".
+      expect(consoleErr.mock.calls.length + consoleWarn.mock.calls.length).toBeGreaterThan(0);
+    } finally {
+      consoleErr.mockRestore();
+      consoleWarn.mockRestore();
+    }
+  });
+
+  it("watcher_failed_fetch_is_recorded_so_it_does_not_retry_storm", async () => {
+    const store = await primeInitializedStore();
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      api.getNetworkAssets.mockRejectedValue(new Error("solana down"));
+
+      store.setProtocolFilter("SOLANA");
+      // Let the watcher run + the rejected promise settle.
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+
+      const callsAfterFirstFail = api.getNetworkAssets.mock.calls.filter((c) => c[0] === "SOLANA").length;
+      expect(callsAfterFirstFail).toBe(1);
+
+      // Bounce away and back. The watcher must not re-fetch SOLANA — it has
+      // been recorded as failed.
+      store.setProtocolFilter("OSMOSIS");
+      await new Promise((r) => setTimeout(r, 0));
+      store.setProtocolFilter("SOLANA");
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+
+      const callsAfterBounce = api.getNetworkAssets.mock.calls.filter((c) => c[0] === "SOLANA").length;
+      expect(callsAfterBounce).toBe(1);
+    } finally {
+      consoleErr.mockRestore();
+    }
+  });
+
+  it("watcher_failed_fetch_logs_at_error_level_with_network_key_and_error", async () => {
+    const store = await primeInitializedStore();
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const cause = new Error("solana down");
+      api.getNetworkAssets.mockRejectedValueOnce(cause);
+
+      store.setProtocolFilter("SOLANA");
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(consoleErr).toHaveBeenCalled();
+      // At least one call must mention SOLANA and carry the error.
+      const matching = consoleErr.mock.calls.find((args) =>
+        args.some((a) => typeof a === "string" && a.includes("SOLANA"))
+      );
+      expect(matching).toBeDefined();
+      expect(matching?.some((a) => a instanceof Error)).toBe(true);
+    } finally {
+      consoleErr.mockRestore();
+    }
+  });
+
+  it("watcher_failed_fetch_clears_stale_assets_assetsResponse_is_null", async () => {
+    // Prime with OSMOSIS having real assets, so when SOLANA fails the
+    // stale OSMOSIS data is what we want to verify is cleared. Contract:
+    // assetsResponse === null after a failed switch — never leave stale
+    // assets visible under the new filter.
+    api.getConfig.mockResolvedValueOnce(makeConfig());
+    api.getCurrencies.mockResolvedValueOnce(makeCurrencies());
+    api.getNetworkAssets.mockResolvedValueOnce({
+      assets: [{ ticker: "OSMO", networks: ["OSMOSIS"], protocols: ["OSMOSIS"], icon: "" }]
+    });
+    api.getGatedProtocols.mockResolvedValueOnce({ protocols: [] });
+    api.getGasFeeConfig.mockResolvedValueOnce({ gas_prices: {}, gas_multiplier: 1 });
+
+    const store = useConfigStore();
+    await store.initialize();
+    expect(store.assets.length).toBe(1);
+
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      api.getNetworkAssets.mockRejectedValueOnce(new Error("solana down"));
+      store.setProtocolFilter("SOLANA");
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(store.assetsResponse).toBeNull();
+    } finally {
+      consoleErr.mockRestore();
+    }
+  });
 });

--- a/src/common/stores/config/index.ts
+++ b/src/common/stores/config/index.ts
@@ -8,8 +8,9 @@
  * - Network selection
  *
  * Browser HTTP cache (Cache-Control: max-age=3600, stale-while-revalidate=1800)
- * handles caching at the network layer. User preferences (protocol filter,
- * selected network) are persisted to localStorage.
+ * handles caching at the network layer. The mainnet/testnet `selectedNetwork`
+ * is persisted to localStorage. The `protocolFilter` (current network) is
+ * wallet-derived and not persisted — see `walletProtocolFilter.ts`.
  */
 
 import { defineStore } from "pinia";
@@ -32,7 +33,6 @@ import {
   type GasFeeConfigResponse
 } from "@/common/api";
 
-const PROTOCOL_FILTER_KEY = "protocol_filter";
 const SELECTED_NETWORK_KEY = "selected_network";
 
 export const useConfigStore = defineStore("config", () => {
@@ -67,17 +67,11 @@ export const useConfigStore = defineStore("config", () => {
   const initialized = ref(false);
 
   // User preferences
-  const protocolFilter = ref<string>(localStorage.getItem(PROTOCOL_FILTER_KEY) || "");
+  // protocolFilter is owned by the connected wallet (see applyWalletProtocolFilter
+  // in src/common/utils/walletProtocolFilter.ts). It is no longer persisted to
+  // localStorage — connect/disconnect actions push the value in directly.
+  const protocolFilter = ref<string>("");
   const selectedNetwork = ref<string>(localStorage.getItem(SELECTED_NETWORK_KEY) || "mainnet");
-
-  // Persist user preferences
-  watch(protocolFilter, (val) => {
-    if (val) {
-      localStorage.setItem(PROTOCOL_FILTER_KEY, val);
-    } else {
-      localStorage.removeItem(PROTOCOL_FILTER_KEY);
-    }
-  });
 
   watch(selectedNetwork, (val) => {
     localStorage.setItem(SELECTED_NETWORK_KEY, val);
@@ -509,19 +503,6 @@ export const useConfigStore = defineStore("config", () => {
     return getAvailableNetworkFilters().includes(filter.toUpperCase());
   }
 
-  /** Get network filter dropdown options (for UI dropdowns) */
-  function getNetworkFilterOptions(): { value: string; label: string; icon: string }[] {
-    const filters = getAvailableNetworkFilters();
-    return filters.map((filterKey) => {
-      const network = networkByKey.value.get(filterKey);
-      return {
-        value: filterKey,
-        label: network?.name ?? filterKey,
-        icon: network?.icon ?? ""
-      };
-    });
-  }
-
   /** Check if a protocol filter (network) is disabled (no active protocols) */
   function isProtocolFilterDisabled(networkFilter: string): boolean {
     const networkProtocols = getActiveProtocolsForNetwork(networkFilter);
@@ -796,33 +777,60 @@ export const useConfigStore = defineStore("config", () => {
       fetchGasFeeConfig()
     ]);
     fetchedNetworks.add(networkToFetch.toUpperCase());
-    ensureDefaultProtocolFilter();
     await prefetchProtocolCurrenciesForNetwork(networkToFetch);
     initialized.value = true;
   }
 
-  // Track which networks have had their assets fetched to avoid redundant API calls
+  // Track which networks have had their assets fetched to avoid redundant API calls.
+  // Failed fetches are recorded here too — a switch that 503s once must NOT retry-storm
+  // the backend on every subsequent toggle back to the same filter within the session.
   const fetchedNetworks = new Set<string>();
 
-  /** Set protocolFilter to the first available network if it's empty or invalid */
-  function ensureDefaultProtocolFilter(): void {
-    const available = getAvailableNetworkFilters();
-    if (available.length > 0 && !available.includes(protocolFilter.value.toUpperCase())) {
-      protocolFilter.value = available[0];
-    }
+  // Networks the wallet-driven mapping in `walletProtocolFilter.ts` can produce.
+  // Even when the backend has no protocol entry for one of these yet (e.g. SOLANA
+  // before the first Solana protocol ships), the watcher must still attempt the
+  // fetch so the failure surfaces loudly via console.error and the user sees an
+  // empty state — not a silently swallowed reject. Keep this set in sync with
+  // `protocolFilterForMechanism` in `src/common/utils/walletProtocolFilter.ts`.
+  const WALLET_PRODUCIBLE_NETWORKS = new Set(["OSMOSIS", "SOLANA"]);
+
+  function isAllowedNetworkFilter(filter: string): boolean {
+    const upper = filter.toUpperCase();
+    return WALLET_PRODUCIBLE_NETWORKS.has(upper) || isValidNetworkFilter(filter);
   }
 
-  // Watch for protocol filter changes and fetch assets for new networks
+  // Watch for protocol filter changes and fetch assets for new networks.
+  //
+  // Contract (post wallet-driven-network refactor):
+  //   1. Empty filter → no-op. Disconnect intentionally clears the filter.
+  //   2. Unknown filter → console.error + return. Filters that are neither in
+  //      the live network list nor in the wallet-producible set are gibberish
+  //      and must not burn a 503 round trip.
+  //   3. Failed fetch → console.error, clear assetsResponse so stale data from
+  //      the previous network does not survive the failed switch, AND record
+  //      the network in fetchedNetworks so we do not retry-storm.
   watch(protocolFilter, async (newFilter) => {
-    if (initialized.value && newFilter) {
-      const upperFilter = newFilter.toUpperCase();
-      if (!fetchedNetworks.has(upperFilter)) {
-        await fetchNetworkAssets(newFilter);
-        fetchedNetworks.add(upperFilter);
-      }
-      await prefetchProtocolCurrenciesForNetwork(newFilter).catch((e) => {
-        console.error("[ConfigStore] Failed to prefetch protocol currencies:", e);
-      });
+    if (!initialized.value) return;
+    if (!newFilter) return;
+
+    if (!isAllowedNetworkFilter(newFilter)) {
+      console.error("[ConfigStore] Invalid network filter rejected:", newFilter);
+      return;
+    }
+
+    const upperFilter = newFilter.toUpperCase();
+    if (fetchedNetworks.has(upperFilter)) return;
+
+    try {
+      await fetchNetworkAssets(newFilter);
+      await prefetchProtocolCurrenciesForNetwork(newFilter);
+      fetchedNetworks.add(upperFilter);
+    } catch (err) {
+      console.error("[ConfigStore] Failed to fetch assets for network:", upperFilter, err);
+      // Drop stale assets so the previous network's data is not visible under
+      // the new filter, then record the failure to prevent retry-storms.
+      assetsResponse.value = null;
+      fetchedNetworks.add(upperFilter);
     }
   });
 
@@ -924,7 +932,6 @@ export const useConfigStore = defineStore("config", () => {
     isLongPosition,
     getAvailableNetworkFilters,
     isValidNetworkFilter,
-    getNetworkFilterOptions,
     isProtocolFilterDisabled,
     getContracts,
 

--- a/src/common/stores/wallet/actions/connectKeplrLike.ts
+++ b/src/common/stores/wallet/actions/connectKeplrLike.ts
@@ -2,7 +2,7 @@ import type { Keplr } from "@keplr-wallet/types";
 import type { OfflineDirectSigner } from "@cosmjs/proto-signing";
 import { type Store } from "../types";
 
-import { EnvNetworkUtils, WalletManager } from "@/common/utils";
+import { EnvNetworkUtils, WalletManager, applyWalletProtocolFilter } from "@/common/utils";
 import { fetchEndpoints } from "@/common/utils/EndpointService";
 import { ChainConstants, NolusClient, NolusWalletFactory } from "@nolus/nolusjs";
 import { type WalletConnectMechanism } from "@/common/types";
@@ -60,6 +60,7 @@ export async function connectKeplrLike(
       // Save mechanism only after wallet is fully set up
       WalletManager.saveWalletConnectMechanism(mechanism);
       WalletManager.setPubKey(Buffer.from((nolusWalletOfflineSigner?.pubKey ?? "") as string).toString("hex"));
+      applyWalletProtocolFilter(mechanism);
     }
   }
 

--- a/src/common/stores/wallet/actions/connectPhantom.ts
+++ b/src/common/stores/wallet/actions/connectPhantom.ts
@@ -1,6 +1,6 @@
 import { type Store } from "../types";
 
-import { WalletManager } from "@/common/utils";
+import { WalletManager, applyWalletProtocolFilter } from "@/common/utils";
 import { NolusWalletFactory } from "@nolus/nolusjs";
 import { WalletConnectMechanism } from "@/common/types";
 import { Buffer } from "buffer";
@@ -18,6 +18,7 @@ export async function connectPhantom(this: Store) {
 
   WalletManager.saveWalletConnectMechanism(WalletConnectMechanism.EVM_PHANTOM);
   WalletManager.setPubKey(Buffer.from(pubkeyAny).toString("hex"));
+  applyWalletProtocolFilter(WalletConnectMechanism.EVM_PHANTOM);
 
   this.wallet = nolusWalletOfflineSigner;
   applyNolusWalletOverrides(this.wallet);

--- a/src/common/stores/wallet/actions/connectSolflare.ts
+++ b/src/common/stores/wallet/actions/connectSolflare.ts
@@ -1,6 +1,6 @@
 import { type Store } from "../types";
 
-import { WalletManager } from "@/common/utils";
+import { WalletManager, applyWalletProtocolFilter } from "@/common/utils";
 import { NolusWalletFactory } from "@nolus/nolusjs";
 import { WalletConnectMechanism } from "@/common/types";
 import { Buffer } from "buffer";
@@ -18,6 +18,7 @@ export async function connectSolflare(this: Store) {
 
   WalletManager.saveWalletConnectMechanism(WalletConnectMechanism.SOL_SOLFLARE);
   WalletManager.setPubKey(Buffer.from(pubkeyAny).toString("hex"));
+  applyWalletProtocolFilter(WalletConnectMechanism.SOL_SOLFLARE);
 
   this.wallet = nolusWalletOfflineSigner;
   applyNolusWalletOverrides(this.wallet);

--- a/src/common/stores/wallet/actions/disconnect.ts
+++ b/src/common/stores/wallet/actions/disconnect.ts
@@ -1,7 +1,11 @@
 import { IntercomService } from "@/common/utils/IntercomService";
+import { applyWalletProtocolFilter } from "@/common/utils/walletProtocolFilter";
 import type { Store } from "../types";
 
 export function disconnect(this: Store) {
   this.wallet = undefined;
   IntercomService.disconnect();
+  // Clear the wallet-driven network filter so the next connect's first
+  // watcher tick sees a fresh slate.
+  applyWalletProtocolFilter(null);
 }

--- a/src/common/stores/wallet/actions/protocolFilter.test.ts
+++ b/src/common/stores/wallet/actions/protocolFilter.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Wallet-driven network refactor — protocol-filter wiring contract.
+ *
+ * After the refactor, every successful wallet connect action MUST set
+ * `configStore.protocolFilter` to the network the connected mechanism owns:
+ *   - Keplr / Keplr-like → "OSMOSIS"
+ *   - Phantom (EVM)      → "SOLANA"
+ *   - Solflare (SOL)     → "SOLANA"
+ *
+ * Ledger is sunset and intentionally NOT wired — it must NOT call
+ * setProtocolFilter at all (config-store keeps its current value).
+ *
+ * disconnect() clears the filter back to "" so the next connect's first
+ * watcher tick sees a fresh slate.
+ *
+ * The setProtocolFilter spy is the contract surface we test here. The store
+ * itself is verified separately by the config-store watcher tests.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The actions barrel pulls in heavy modules transitively (ThemeManager via
+// utils, IntercomService, network wallets). Keep this file focused on the
+// protocol-filter wiring by stubbing ALL of those out — only the spy on
+// setProtocolFilter should fire.
+vi.hoisted(() => {
+  if (typeof window !== "undefined" && !window.matchMedia) {
+    (window as unknown as { matchMedia: unknown }).matchMedia = () => ({
+      matches: false,
+      media: "",
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false
+    });
+  }
+});
+
+const setProtocolFilter = vi.fn();
+vi.mock("@/common/stores/config", () => ({
+  useConfigStore: () => ({ setProtocolFilter })
+}));
+
+// EndpointService.fetchEndpoints is invoked by connectKeplrLike / connectLedger.
+// Return a stub network config — the real one would hit the backend.
+vi.mock("@/common/utils/EndpointService", () => ({
+  fetchEndpoints: vi.fn().mockResolvedValue({
+    rpc: "http://localhost:0/rpc",
+    api: "http://localhost:0/api"
+  })
+}));
+
+vi.mock("@/common/utils/IntercomService", () => ({
+  IntercomService: { load: vi.fn(), disconnect: vi.fn() }
+}));
+
+vi.mock("@/networks/cosm/NolusWalletOverride", () => ({
+  applyNolusWalletOverrides: vi.fn()
+}));
+
+vi.mock("@/config/global/keplr", () => ({
+  KeplrEmbedChainInfo: vi.fn().mockReturnValue({})
+}));
+
+vi.mock("@nolus/nolusjs", () => ({
+  ChainConstants: { CHAIN_KEY: "nolus", BECH32_PREFIX_ACC_ADDR: "nolus" },
+  NolusClient: {
+    setInstance: vi.fn(),
+    getInstance: () => ({ getChainId: vi.fn().mockResolvedValue("nolus-1") })
+  },
+  NolusWalletFactory: {
+    nolusOfflineSigner: vi.fn().mockResolvedValue({
+      pubKey: "deadbeef",
+      address: "nolus1abc",
+      useAccount: vi.fn().mockResolvedValue(undefined)
+    }),
+    nolusLedgerWallet: vi.fn().mockResolvedValue({
+      pubKey: "ledgerpubkey",
+      address: "nolus1ledger",
+      useAccount: vi.fn().mockResolvedValue(undefined)
+    })
+  }
+}));
+
+// WalletManager has localStorage side-effects. Stub the static surface we
+// touch so we don't pollute jsdom localStorage between tests.
+vi.mock("@/common/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/common/utils")>("@/common/utils");
+  return {
+    ...actual,
+    WalletManager: {
+      ...actual.WalletManager,
+      saveWalletConnectMechanism: vi.fn(),
+      setPubKey: vi.fn(),
+      getWalletConnectMechanism: vi.fn().mockReturnValue(null)
+    }
+  };
+});
+
+// MetaMaskWallet (EVM) — stub `connect` and `makeWCOfflineSigner`.
+vi.mock("@/networks/evm", () => ({
+  MetaMaskWallet: vi.fn().mockImplementation(() => ({
+    connect: vi.fn().mockResolvedValue({ pubkeyAny: new Uint8Array([1, 2, 3]) }),
+    makeWCOfflineSigner: vi.fn().mockReturnValue({})
+  }))
+}));
+
+// SolanaWallet — same shape as MetaMaskWallet.
+vi.mock("@/networks/sol", () => ({
+  SolanaWallet: vi.fn().mockImplementation(() => ({
+    connect: vi.fn().mockResolvedValue({ pubkeyAny: new Uint8Array([4, 5, 6]) }),
+    makeWCOfflineSigner: vi.fn().mockReturnValue({})
+  }))
+}));
+
+// Ledger transports never run in jsdom. Stub create() to a minimal object.
+vi.mock("@ledgerhq/hw-transport-web-ble", () => ({
+  default: { create: vi.fn().mockResolvedValue({ close: vi.fn() }) }
+}));
+vi.mock("@ledgerhq/hw-transport-webusb", () => ({
+  default: { create: vi.fn().mockResolvedValue({ close: vi.fn() }) }
+}));
+vi.mock("@cosmjs/ledger-amino", () => ({
+  LedgerSigner: vi.fn().mockImplementation(() => ({}))
+}));
+vi.mock("@cosmjs/amino", () => ({
+  makeCosmoshubPath: vi.fn().mockReturnValue([])
+}));
+
+import { WalletConnectMechanism } from "@/common/types";
+import { connectKeplrLike } from "./connectKeplrLike";
+import { connectPhantom } from "./connectPhantom";
+import { connectSolflare } from "./connectSolflare";
+import { connectLedger } from "./connectLedger";
+import { disconnect } from "./disconnect";
+import type { Store } from "../types";
+
+beforeEach(() => {
+  setProtocolFilter.mockClear();
+  localStorage.clear();
+});
+
+/** Minimal Store-shaped object — enough to be passed as `this` / first arg. */
+function makeStore(): Store {
+  return {
+    wallet: undefined,
+    vest: [],
+    delegated_vesting: undefined,
+    delegated_free: undefined,
+    apr: 0,
+    $patch: vi.fn()
+  } as unknown as Store;
+}
+
+/** Stub keplr/keplr-like extension that exposes the surface connectKeplrLike needs. */
+function makeKeplrExtension() {
+  return {
+    getOfflineSignerOnlyAmino: vi.fn().mockReturnValue({}),
+    experimentalSuggestChain: vi.fn().mockResolvedValue(undefined),
+    enable: vi.fn().mockResolvedValue(undefined)
+  } as unknown as Parameters<typeof connectKeplrLike>[1] extends () => Promise<infer T> ? T : never;
+}
+
+describe("connectKeplrLike (Keplr success path)", () => {
+  it("sets protocolFilter to OSMOSIS exactly once on success", async () => {
+    const store = makeStore();
+    const extension = makeKeplrExtension();
+    await connectKeplrLike(
+      store,
+      async () =>
+        extension as unknown as Parameters<typeof connectKeplrLike>[1] extends () => Promise<infer T> ? T : never,
+      WalletConnectMechanism.KEPLR,
+      "Keplr"
+    );
+
+    expect(setProtocolFilter).toHaveBeenCalledTimes(1);
+    expect(setProtocolFilter).toHaveBeenCalledWith("OSMOSIS");
+  });
+});
+
+describe("connectPhantom", () => {
+  it("sets protocolFilter to SOLANA exactly once on success", async () => {
+    const store = makeStore();
+    await connectPhantom.call(store);
+
+    expect(setProtocolFilter).toHaveBeenCalledTimes(1);
+    expect(setProtocolFilter).toHaveBeenCalledWith("SOLANA");
+  });
+});
+
+describe("connectSolflare", () => {
+  it("sets protocolFilter to SOLANA exactly once on success", async () => {
+    const store = makeStore();
+    await connectSolflare.call(store);
+
+    expect(setProtocolFilter).toHaveBeenCalledTimes(1);
+    expect(setProtocolFilter).toHaveBeenCalledWith("SOLANA");
+  });
+});
+
+describe("connectLedger (sunset, intentionally unwired)", () => {
+  it("does NOT call setProtocolFilter on success", async () => {
+    const store = makeStore();
+    await connectLedger.call(store, {});
+
+    expect(setProtocolFilter).not.toHaveBeenCalled();
+  });
+});
+
+describe("disconnect", () => {
+  it("calls setProtocolFilter('') to clear the filter", () => {
+    const store = makeStore();
+    store.wallet = { address: "nolus1abc" } as unknown as Store["wallet"];
+    disconnect.call(store);
+
+    expect(setProtocolFilter).toHaveBeenCalledTimes(1);
+    expect(setProtocolFilter).toHaveBeenCalledWith("");
+  });
+});

--- a/src/common/utils/WalletManager.test.ts
+++ b/src/common/utils/WalletManager.test.ts
@@ -1,15 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// WalletManager imports `{ useWalletStore }` (and config store) which transitively
-// pull heavy modules. We only exercise the localStorage gate, so stub them.
+// WalletManager imports `{ useWalletStore }` which transitively pulls heavy
+// modules. We only exercise the localStorage gate, so stub it.
 vi.mock("../stores/wallet", () => ({
   useWalletStore: () => ({ wallet: undefined })
-}));
-vi.mock("../stores/config", () => ({
-  useConfigStore: () => ({ isValidNetworkFilter: () => true })
-}));
-vi.mock("@/config/global", () => ({
-  DefaultProtocolFilter: "ALL"
 }));
 
 import { WalletManager } from "./WalletManager";
@@ -47,5 +41,20 @@ describe("WalletManager.getWalletConnectMechanism", () => {
     localStorage.setItem(WalletManager.WALLET_CONNECT_MECHANISM, "garbage");
     expect(WalletManager.getWalletConnectMechanism()).toBeNull();
     expect(localStorage.getItem(WalletManager.WALLET_CONNECT_MECHANISM)).toBeNull();
+  });
+});
+
+describe("WalletManager protocol filter surface (post-refactor)", () => {
+  // After the wallet-driven network refactor, the configStore is the sole
+  // owner of protocolFilter. WalletManager must NOT expose a PROTOCOL_FILTER
+  // constant or a getProtocolFilter() static — those were the legacy
+  // localStorage-backed read path and are gone.
+
+  it("does not expose a PROTOCOL_FILTER constant", () => {
+    expect((WalletManager as unknown as Record<string, unknown>).PROTOCOL_FILTER).toBeUndefined();
+  });
+
+  it("does not expose a getProtocolFilter static", () => {
+    expect((WalletManager as unknown as Record<string, unknown>).getProtocolFilter).toBeUndefined();
   });
 });

--- a/src/common/utils/WalletManager.ts
+++ b/src/common/utils/WalletManager.ts
@@ -1,7 +1,5 @@
 import { WalletConnectMechanism } from "@/common/types";
 import { useWalletStore } from "../stores/wallet";
-import { useConfigStore } from "../stores/config";
-import { DefaultProtocolFilter } from "@/config/global";
 
 export class WalletManager {
   public static WALLET_CONNECT_MECHANISM = "wallet_connect_mechanism";
@@ -9,7 +7,6 @@ export class WalletManager {
   public static WALLET_PUBKEY = "wallet_pubkey";
   public static SHOW_SMALL_BALANCES = "show_small_balances";
   public static HIDE_BALANCES = "hide_balances";
-  public static PROTOCOL_FILTER = "protocol_filter";
 
   public static saveWalletConnectMechanism(walletConnectMechanism: WalletConnectMechanism) {
     localStorage.setItem(this.WALLET_CONNECT_MECHANISM, walletConnectMechanism);
@@ -38,15 +35,6 @@ export class WalletManager {
 
   public static setPubKey(pubkey: string) {
     localStorage.setItem(this.WALLET_PUBKEY, pubkey);
-  }
-
-  public static getProtocolFilter(): string {
-    const configStore = useConfigStore();
-    const item = localStorage.getItem(this.PROTOCOL_FILTER);
-    if (item && configStore.isValidNetworkFilter(item)) {
-      return item;
-    }
-    return DefaultProtocolFilter;
   }
 
   public static getWalletAddress(): string {

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -22,5 +22,6 @@ export * from "./Logger";
 export * from "./LeaseUtils";
 export * from "./LeaseCalculator";
 export * from "./WalletConnect";
+export * from "./walletProtocolFilter";
 export * from "./NetworkUtils";
 export * from "./IntercomService";

--- a/src/common/utils/walletProtocolFilter.test.ts
+++ b/src/common/utils/walletProtocolFilter.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Stub the config store to a single setProtocolFilter spy. We only care
+// about the wiring here — protocolFilterForMechanism is a pure mapping,
+// applyWalletProtocolFilter is a thin wrapper that resolves "" for any
+// non-mapped mechanism (so the filter is cleared, not left stale).
+const setProtocolFilter = vi.fn();
+vi.mock("@/common/stores/config", () => ({
+  useConfigStore: () => ({ setProtocolFilter })
+}));
+
+import { WalletConnectMechanism } from "@/common/types";
+import { protocolFilterForMechanism, applyWalletProtocolFilter } from "./walletProtocolFilter";
+
+beforeEach(() => {
+  setProtocolFilter.mockClear();
+});
+
+describe("protocolFilterForMechanism", () => {
+  it("maps KEPLR to OSMOSIS", () => {
+    expect(protocolFilterForMechanism(WalletConnectMechanism.KEPLR)).toBe("OSMOSIS");
+  });
+
+  it("maps EVM_PHANTOM to SOLANA", () => {
+    expect(protocolFilterForMechanism(WalletConnectMechanism.EVM_PHANTOM)).toBe("SOLANA");
+  });
+
+  it("maps SOL_SOLFLARE to SOLANA", () => {
+    expect(protocolFilterForMechanism(WalletConnectMechanism.SOL_SOLFLARE)).toBe("SOLANA");
+  });
+
+  it("returns undefined for LEDGER (sunset, intentionally unwired)", () => {
+    expect(protocolFilterForMechanism(WalletConnectMechanism.LEDGER)).toBeUndefined();
+  });
+
+  it("returns undefined for LEDGER_BLUETOOTH (sunset, intentionally unwired)", () => {
+    expect(protocolFilterForMechanism(WalletConnectMechanism.LEDGER_BLUETOOTH)).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(protocolFilterForMechanism(null)).toBeUndefined();
+  });
+
+  it("returns undefined for undefined", () => {
+    expect(protocolFilterForMechanism(undefined)).toBeUndefined();
+  });
+});
+
+describe("applyWalletProtocolFilter", () => {
+  it("calls setProtocolFilter('OSMOSIS') for KEPLR", () => {
+    applyWalletProtocolFilter(WalletConnectMechanism.KEPLR);
+    expect(setProtocolFilter).toHaveBeenCalledTimes(1);
+    expect(setProtocolFilter).toHaveBeenCalledWith("OSMOSIS");
+  });
+
+  it("calls setProtocolFilter('SOLANA') for EVM_PHANTOM", () => {
+    applyWalletProtocolFilter(WalletConnectMechanism.EVM_PHANTOM);
+    expect(setProtocolFilter).toHaveBeenCalledTimes(1);
+    expect(setProtocolFilter).toHaveBeenCalledWith("SOLANA");
+  });
+
+  it("calls setProtocolFilter('SOLANA') for SOL_SOLFLARE", () => {
+    applyWalletProtocolFilter(WalletConnectMechanism.SOL_SOLFLARE);
+    expect(setProtocolFilter).toHaveBeenCalledTimes(1);
+    expect(setProtocolFilter).toHaveBeenCalledWith("SOLANA");
+  });
+
+  it("calls setProtocolFilter('') for LEDGER", () => {
+    applyWalletProtocolFilter(WalletConnectMechanism.LEDGER);
+    expect(setProtocolFilter).toHaveBeenCalledTimes(1);
+    expect(setProtocolFilter).toHaveBeenCalledWith("");
+  });
+
+  it("calls setProtocolFilter('') for LEDGER_BLUETOOTH", () => {
+    applyWalletProtocolFilter(WalletConnectMechanism.LEDGER_BLUETOOTH);
+    expect(setProtocolFilter).toHaveBeenCalledTimes(1);
+    expect(setProtocolFilter).toHaveBeenCalledWith("");
+  });
+
+  it("calls setProtocolFilter('') for null", () => {
+    applyWalletProtocolFilter(null);
+    expect(setProtocolFilter).toHaveBeenCalledTimes(1);
+    expect(setProtocolFilter).toHaveBeenCalledWith("");
+  });
+
+  it("calls setProtocolFilter('') for undefined", () => {
+    applyWalletProtocolFilter(undefined);
+    expect(setProtocolFilter).toHaveBeenCalledTimes(1);
+    expect(setProtocolFilter).toHaveBeenCalledWith("");
+  });
+});

--- a/src/common/utils/walletProtocolFilter.ts
+++ b/src/common/utils/walletProtocolFilter.ts
@@ -1,0 +1,38 @@
+import { useConfigStore } from "@/common/stores/config";
+import { WalletConnectMechanism } from "@/common/types";
+
+/**
+ * Map a wallet-connect mechanism to the network the wallet owns.
+ *
+ * Keplr (and Keplr-likes routed through `connectKeplrLike`) own OSMOSIS;
+ * Phantom (EVM bridge) and Solflare both own SOLANA. Ledger / Ledger BLE
+ * are sunset and intentionally unwired — callers must NOT call
+ * `applyWalletProtocolFilter` on a Ledger connect path; this function
+ * still returns `undefined` for them so the wrapper degrades to "" cleanly.
+ *
+ * NOTE: when adding a new producible network here, also add it to the
+ * `WALLET_PRODUCIBLE_NETWORKS` allowlist in `src/common/stores/config/index.ts`
+ * — the config-store watcher uses that set to decide whether a filter value
+ * is worth a fetch attempt (vs. rejecting it as gibberish).
+ */
+export function protocolFilterForMechanism(mechanism: WalletConnectMechanism | null | undefined): string | undefined {
+  switch (mechanism) {
+    case WalletConnectMechanism.KEPLR:
+      return "OSMOSIS";
+    case WalletConnectMechanism.EVM_PHANTOM:
+    case WalletConnectMechanism.SOL_SOLFLARE:
+      return "SOLANA";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Push the wallet's owned network into the config store as the active
+ * protocol filter. Pass `null` / `undefined` (e.g. on disconnect) to clear
+ * the filter back to "" so the next connect's first watcher tick sees a
+ * fresh slate.
+ */
+export function applyWalletProtocolFilter(mechanism: WalletConnectMechanism | null | undefined): void {
+  useConfigStore().setProtocolFilter(protocolFilterForMechanism(mechanism) ?? "");
+}

--- a/src/config/global/contracts.ts
+++ b/src/config/global/contracts.ts
@@ -27,8 +27,6 @@ export const CONTRACTS: Record<string, ContractsConfig> = {
   }
 };
 
-export const DefaultProtocolFilter = "OSMOSIS";
-
 //add deleted protocols
 export const SORT_PROTOCOLS = [
   "OSMOSIS-OSMOSIS-USDC_NOBLE",

--- a/src/entry-client.ts
+++ b/src/entry-client.ts
@@ -20,6 +20,9 @@ import { initWebMcp } from "./common/webmcp";
 const { app, router } = createApp();
 
 async function bootstrap() {
+  // One-shot cleanup of legacy "protocol_filter" localStorage key — remove in a follow-up release.
+  localStorage.removeItem("protocol_filter");
+
   // Initialize NolusClient with RPC endpoint (still needed for wallet signing)
   const endpoints = await fetchEndpoints(ChainConstants.CHAIN_KEY);
   const rpc = endpoints.rpc;


### PR DESCRIPTION
## Summary

Drive `configStore.protocolFilter` from the connected wallet rather than a settings dropdown. Keplr maps to OSMOSIS; Phantom (EVM) and Solflare both map to SOLANA; Ledger is intentionally unwired since it is being sunset in a separate task. Disconnect clears the filter so the next connect lands cleanly.

## Changes

- New helper `walletProtocolFilter.ts` exposing `protocolFilterForMechanism` (pure mapping) and `applyWalletProtocolFilter` (side-effecting wrapper that pushes into the config store).
- `connectKeplrLike`, `connectPhantom`, `connectSolflare`, and `disconnect` call the wrapper at the end of their successful path. `connectLedger` is intentionally not wired.
- Config store no longer seeds `protocolFilter` from `localStorage` and no longer persists changes; the legacy `protocol_filter` localStorage key is one-shot-cleaned from existing browsers in `entry-client.ts`. The cleanup line is intended for removal in a future release once the key has aged out.
- Config store watcher hardened: rejects filters that are neither in the live network list nor in the new `WALLET_PRODUCIBLE_NETWORKS` allowlist, logs failures via `console.error`, drops stale `assetsResponse` on a failed switch, and records every attempted network in `fetchedNetworks` to prevent retry storms when the user toggles wallets.
- Settings dropdown for network selection removed from `ThemeSettings.vue`. The `message.network` i18n key is kept — it is also consumed by `SendForm.vue` and `ReceiveForm.vue` for cross-chain destination labels.
- `WalletManager.getProtocolFilter` and `DefaultProtocolFilter` are deleted.

## Trade-offs

`EVM_PHANTOM → SOLANA` produces empty Leases, Earn, Swap, and Dashboard surfaces today because no Solana protocols exist in production. We considered defaulting Phantom to OSMOSIS until Solana protocols ship, and rejected it: the value of an empty-but-honest Solana view outweighs the value of a populated-but-misleading Osmosis view under a Solana wallet. The watcher's `console.error` on a failed Solana asset fetch is the loud-failure signal we want.

We considered leaving the localStorage seed in place as a startup hint, and rejected it: wallet connect runs early enough in the bootstrap that the seed value would be overwritten within the same tick, so it adds noise without changing observable behavior.

## Verification

- `npm test` — full vitest run passed locally (761 tests across 50 files), including the new tests in `walletProtocolFilter.test.ts`, `wallet/actions/protocolFilter.test.ts`, and the four watcher-contract tests in `config/index.test.ts`.
- `npx eslint src/ --max-warnings=0` and `npx prettier --check src/` — clean.
- `npx tsc --noEmit` — clean.
- `npm run build` — clean.
- Pre-commit hook (lint + build) ran on each of the 4 commits; each commit builds in isolation for `git bisect`.

## Follow-ups

- Remove the one-shot `localStorage.removeItem("protocol_filter")` line in `entry-client.ts` after the next release has been live ≥ 1 month.
- Wire Ledger off the action paths entirely (tracked under the existing Ledger sunset task).