### PR TITLE
fix(stats): map OSMO pool icon in gated network config

### DIFF
--- a/backend/config/gated/network-config.json
+++ b/backend/config/gated/network-config.json
@@ -32,6 +32,9 @@
       "OSMOSIS-OSMOSIS-USDC_NOBLE": {
         "icon": "/assets/icons/pools/osmosis-usdc.svg"
       },
+      "OSMOSIS-OSMOSIS-OSMO": {
+        "icon": "/assets/icons/pools/osmosis-osmo.svg"
+      },
       "OSMOSIS-OSMOSIS-ALL_SOL": {
         "icon": "/assets/icons/pools/osmosis-allsol.svg"
       },


### PR DESCRIPTION
## Summary

Add the missing `OSMOSIS-OSMOSIS-OSMO` entry to the gated network-config pools map so the stats page Funds Utilization table renders the correct OSMO icon. The asset already shipped at `public/assets/icons/pools/osmosis-osmo.svg`; only the config mapping was missing, which left `pool.icon` as `None` in the backend's `get_pools` handler and produced a generic-looking icon in the row.

## Notes

- `backend/config/` is excluded from the rclone deploy sync, so merging this PR makes future fresh deploys correct but does NOT rewrite the persistent config on the running app and app-dev hosts. The live fix is being applied separately on the deploy host with a service restart to clear the in-memory `gated_config` cache.
- USDC.axl uses the same icon as Noble USDC by design — no entry needed there.

## Verification

- Confirmed `osmosis-osmo.svg` exists in `public/assets/icons/pools/` and is bundled into `dist/`.
- Pre-commit hook (lint + build) passed on the commit.