### PR TITLE
fix(wallet): remove broken isKeplr guard rejecting real Keplr

### DIFF
--- a/src/common/utils/WalletUtils.test.ts
+++ b/src/common/utils/WalletUtils.test.ts
@@ -96,26 +96,11 @@ describe("WalletUtils.getKeplr", () => {
     vi.restoreAllMocks();
   });
 
-  it("should return window.keplr when extension is already set and identifies as Keplr", async () => {
-    const fakeKeplr = { isKeplr: true, marker: "keplr-instance" };
+  it("should return window.keplr when extension is already set", async () => {
+    const fakeKeplr = { marker: "keplr-instance" };
     w.keplr = fakeKeplr;
     const result = await WalletUtils.getKeplr();
     expect(result).toBe(fakeKeplr);
-  });
-
-  it("should return undefined when window.keplr is set but isKeplr !== true", async () => {
-    // Defends against wallet-aggregator placeholder injection: a hostile extension can
-    // populate window.keplr with a Keplr-shaped object lacking the identity flag.
-    w.keplr = { marker: "aggregator-shim" };
-    const result = await WalletUtils.getKeplr();
-    expect(result).toBeUndefined();
-  });
-
-  it("should return undefined when isKeplr is truthy-but-not-strictly-true", async () => {
-    // Strict equality `=== true` rejects truthy non-true values like 1 or "yes".
-    w.keplr = { isKeplr: 1, marker: "loose-keplr" };
-    const result = await WalletUtils.getKeplr();
-    expect(result).toBeUndefined();
   });
 
   it("should return the extension when document is complete and extension becomes available", async () => {
@@ -142,7 +127,7 @@ describe("WalletUtils.getKeplr", () => {
         configurable: true,
         get: () => "complete"
       });
-      const fakeKeplr = { isKeplr: true, marker: "delayed-keplr" };
+      const fakeKeplr = { marker: "delayed-keplr" };
       w.keplr = fakeKeplr;
       document.dispatchEvent(new Event("readystatechange"));
 

--- a/src/common/utils/WalletUtils.ts
+++ b/src/common/utils/WalletUtils.ts
@@ -5,28 +5,26 @@ import { WalletManager } from ".";
 import { Wallet, NETWORK_DATA } from "@/networks";
 import { fetchEndpoints } from "./EndpointService";
 
-// Defense against extensions that inject a `window.keplr` shim without identifying as
-// Keplr. Real Keplr always sets `isKeplr === true`. Strict-equality guard mirrors the
-// `isPhantom`/`isSolflare` checks in `src/networks/sol/wallet.ts` (PR #155).
-function isRealKeplr(k?: Keplr): k is Keplr {
-  return (k as unknown as { isKeplr?: unknown })?.isKeplr === true;
-}
-
+// Note: unlike Phantom/Solflare, Keplr does NOT expose an `isKeplr === true` marker
+// on its Cosmos provider (`window.keplr`). The `isKeplr` flag in `@keplr-wallet/types`
+// is on the EthereumProvider type — Keplr's EVM bridge — not on the main Keplr
+// interface. A strict-equality marker check rejects real Keplr; do not re-add one
+// without a verified, Cosmos-side identity signal. See `runbooks/webapp_wallet_network.md`.
 function getKeplrExtension(): Promise<Keplr | undefined> {
   const w = window as unknown as { keplr?: Keplr };
 
-  if (isRealKeplr(w.keplr)) {
+  if (w.keplr) {
     return Promise.resolve(w.keplr);
   }
 
   if (document.readyState === "complete") {
-    return Promise.resolve(isRealKeplr(w.keplr) ? w.keplr : undefined);
+    return Promise.resolve(w.keplr);
   }
 
   return new Promise((resolve) => {
     const documentStateChange = (event: Event) => {
       if (event.target && (event.target as Document).readyState === "complete") {
-        resolve(isRealKeplr(w.keplr) ? w.keplr : undefined);
+        resolve(w.keplr);
         document.removeEventListener("readystatechange", documentStateChange);
       }
     };


### PR DESCRIPTION
## Summary

Removes the `window.keplr.isKeplr === true` strict-equality guard added to `WalletUtils.getKeplrExtension` in #155. The guard rejected real Keplr as "not installed" on app-dev; restoring the original `if (w.keplr)` semantics that worked pre-#155 unblocks Keplr connect immediately.

## Root cause

The guard pattern-matched the `isPhantom`/`isSolflare` defenses on the Solana wallets (PR #155). It does not generalise to Keplr: `isKeplr` is declared in `@keplr-wallet/types` only on `EthereumProvider` (`node_modules/@keplr-wallet/types/build/wallet/ethereum.d.ts:7`) — Keplr's EVM bridge that competes with MetaMask. The main Cosmos `Keplr` interface that `window.keplr` resolves to does not expose that flag, so the strict-equality check rejected every real Keplr extension.

## Changes

- `src/common/utils/WalletUtils.ts` — drop `isRealKeplr` helper; restore the original `if (w.keplr) return Promise.resolve(w.keplr)` paths. Add a comment block above the function explaining why a Cosmos-side `isKeplr` check is not viable, so a future contributor does not re-add it.
- `src/common/utils/WalletUtils.test.ts` — drop the two test cases that asserted the guard's behaviour; restore the original test fixtures (`marker: "keplr-instance"`).

The Phantom and Solflare guards are unaffected and remain in place — those wallets do expose `isPhantom`/`isSolflare` on their Solana providers.

## Verification

- `npx tsc --noEmit` clean.
- `npm run lint` clean.
- `npx vitest run` — 760/760 passing (was 762; the two dropped tests targeted the removed guard).
- `npm run build` clean.
- Reproduced the original failure on app-dev (`Error: Keplr wallet is not installed.`) and traced it to `getKeplrExtension` returning undefined for a real Keplr lacking the marker.

## Follow-ups

- Devnet broadcast smoke for Phantom and Solflare (deferred to Solana go-live; unchanged).
- A Cosmos-side identity signal for Keplr would still be valuable. None is documented today; do not re-add a marker check without one verified against the live `window.keplr` shape.