### PR TITLE
fix(share-pnl): group covers left, lift content block

### DIFF
--- a/src/modules/leases/components/single-lease/SharePnLDialog.vue
+++ b/src/modules/leases/components/single-lease/SharePnLDialog.vue
@@ -10,7 +10,7 @@
         <div class="flex flex-col gap-6 px-6 pb-6 text-typography-default">
           <div class="flex flex-col gap-4">
             <span class="text-16">{{ $t("message.cover-design") }}</span>
-            <div class="flex justify-between">
+            <div class="flex flex-wrap justify-start gap-3">
               <button
                 class="w-full max-w-[108px] overflow-hidden rounded"
                 v-for="(img, index) of images"
@@ -287,7 +287,7 @@ const renderCard = async (ctx: CanvasRenderingContext2D, bgSrc: string) => {
   }
 
   // Optional rows stack below the PnL block. y-cursor advances per rendered row.
-  let cursorY = 540;
+  let cursorY = 490;
   if (showPrice.value) {
     setEntryPriceRow(ctx, cursorY);
     cursorY += 50;
@@ -421,7 +421,7 @@ function setBrandUrl(ctx: CanvasRenderingContext2D) {
   ctx.fillText("nolus.io", 90, 858);
 }
 
-const PNL_HERO_BASELINE_Y = 430;
+const PNL_HERO_BASELINE_Y = 380;
 
 function setPnlPercent(ctx: CanvasRenderingContext2D) {
   const pos = pnlNumber();
@@ -505,7 +505,7 @@ function setTimeStamp(ctx: CanvasRenderingContext2D) {
 
   ctx.font = "500 28px 'Garet'";
   ctx.fillStyle = palette().muted;
-  ctx.fillText(`${datePart} · ${timePart}`, 90, 820);
+  ctx.fillText(`${datePart} · ${timePart}`, 90, 790);
 }
 
 function download() {


### PR DESCRIPTION
## Summary
Tighten the share-PnL dialog layout: cluster the cover thumbnails on the left of the picker and shift the entire content block (PnL %, optional rows, timestamp) up so the bottom of the card no longer crowds the nolus.io brand line.

## Changes
- Cover picker row: `justify-between` → `flex-wrap justify-start gap-3`. The three thumbnails now sit together at the left of the picker instead of being stretched across the dialog width.
- `PNL_HERO_BASELINE_Y` 430 → 380. Moves the big `+XX.XX%` hero up 50px.
- Optional-rows cursor 540 → 490. Entry price, mark price and position size move up with the hero so the spacing between the % block and the rows is preserved.
- Timestamp y 820 → 790. Adds 30px of breathing room between the date and the `nolus.io` brand line below it.

No behavioral change to canvas rendering, font specs, palette logic, or the PNG download / Web Share path.

## Verification
- Ran `npm run lint`, `npm test`, and the worker bundle via the pre-commit hook — all clean.
- Opened the share dialog in the browser against a real lease, verified cover row groups left, hero + rows + timestamp move up together, and the timestamp is no longer flush against the nolus.io line.
- Checked all three cover variants (dark navy, orange, light lavender) and toggled the optional info checkboxes (PnL amount inline, prices, position size) — rows reflow with the new cursor without overlap.