### PR TITLE
fix(single-lease): use stable decimals for short size in header

### DIFF
--- a/src/modules/leases/components/single-lease/SingleLeaseHeader.vue
+++ b/src/modules/leases/components/single-lease/SingleLeaseHeader.vue
@@ -232,8 +232,7 @@ const stable = computed(() => {
     const value = new Dec(props.lease.amount.amount, asset?.decimal_digits ?? 0).mul(new Dec(price?.price ?? "0"));
     return formatUsd(value.toString(2));
   } else if (posType === "short") {
-    const lpn = configStore.getLpnByProtocol(protocol);
-    const value = new Dec(props.lease.amount.amount, lpn?.decimal_digits ?? 0);
+    const value = new Dec(props.lease.amount.amount, asset?.decimal_digits ?? 0);
     return formatUsd(value.toString(2));
   }
 


### PR DESCRIPTION
## Summary
Fix the single-lease header's size readout for short positions. On a short, \`lease.amount\` is denominated in the stable the user holds, not in the LPN. The header was applying LPN decimals to the stable amount, producing values 100× off — a BTC short showing \$0.69 instead of \$69.98 while the Summary widget directly below showed the correct figure.

## Changes
- \`SingleLeaseHeader.vue\` — replace \`lpn.decimal_digits\` with \`asset.decimal_digits\` (decimals of \`lease.amount.ticker\`) in the short branch of the \`stable\` computed. Drop the now-unused \`getLpnByProtocol\` lookup.

## Verification
- Reproduced the bug on a BTC short: header showed \$0.69, Summary showed \$69.98. After the fix, header matched Summary (\$69.98).
- Ran lint, vitest, and the worker build via the pre-commit hook — all clean.
- Cross-checked against \`PositionSummaryWidget.vue:326\` which already used \`asset.decimal_digits\` for the same lease, confirming the fix aligns the two surfaces on a single source of truth.