### PR TITLE
fix(leases): show insufficient-balance error while typing on open-position

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Copy and edit the environment files as needed:
 
 | File | Purpose |
 |------|---------|
-| `.env.spa` | Local dev (backend serves frontend) |
-| `.env.serve` | Vite dev server mode (frontend only) |
+| `.env.serve` | Vite dev server mode (`npm run serve`) — user-created, not shipped |
 | `backend/.env` | Backend configuration (see `backend/.env.example`) |
 
 ### 3. Build and run
@@ -68,6 +67,7 @@ npm run serve
 | Backend tests | `cd backend && cargo test` |
 | Format frontend | `npm run format` |
 | Format backend | `cd backend && cargo fmt` |
+| Lint frontend | `npm run lint` |
 | Lint backend | `cd backend && cargo clippy` |
 
 ## License

--- a/src/modules/leases/components/new-lease/LongForm.test.ts
+++ b/src/modules/leases/components/new-lease/LongForm.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+
+vi.hoisted(() => {
+  if (typeof window !== "undefined" && !window.matchMedia) {
+    (window as unknown as { matchMedia: unknown }).matchMedia = () => ({
+      matches: false,
+      media: "",
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false
+    });
+  }
+});
+
+const hoisted = vi.hoisted(() => {
+  const leaseQuote = vi.fn();
+  const getDownpaymentRange = vi.fn();
+  const getCachedProtocolCurrencies = vi.fn();
+  const getActiveProtocolsForNetwork = vi.fn();
+  const routerPush = vi.fn();
+  const loggerError = vi.fn();
+
+  const LONG_PROTOCOL = "OSMOSIS-OSMOSIS-ALL_BTC";
+
+  const longProtocols = [{ protocol: LONG_PROTOCOL, network: "Osmosis", position_type: "Long" }];
+
+  // WETH listed first so it is the default selected collateral (index 0).
+  const protocolCurrencies = [
+    { ticker: "WETH", decimals: 18, shortName: "ETH", group: "lease" as const },
+    { ticker: "ALL_BTC", decimals: 8, shortName: "BTC", group: "lease" as const }
+  ];
+
+  const currenciesData = {
+    "WETH@OSMOSIS-OSMOSIS-ALL_BTC": {
+      key: "WETH@OSMOSIS-OSMOSIS-ALL_BTC",
+      ticker: "WETH",
+      name: "Ethereum",
+      shortName: "ETH",
+      symbol: "ibc/WETH",
+      icon: "",
+      decimal_digits: 18,
+      ibcData: "ibc/WETH",
+      native: false
+    },
+    "ALL_BTC@OSMOSIS-OSMOSIS-ALL_BTC": {
+      key: "ALL_BTC@OSMOSIS-OSMOSIS-ALL_BTC",
+      ticker: "ALL_BTC",
+      name: "Alloyed BTC",
+      shortName: "BTC",
+      symbol: "ibc/ALLBTC",
+      icon: "",
+      decimal_digits: 8,
+      ibcData: "ibc/ALLBTC",
+      native: false
+    }
+  };
+
+  const prices = {
+    "WETH@OSMOSIS-OSMOSIS-ALL_BTC": { price: "2000" },
+    "ALL_BTC@OSMOSIS-OSMOSIS-ALL_BTC": { price: "77000" }
+  };
+
+  // Mutable per-test: default to no balance (the zero-balance repro).
+  const state: { balances: { denom: string; amount: string }[] } = { balances: [] };
+
+  return {
+    leaseQuote,
+    getDownpaymentRange,
+    getCachedProtocolCurrencies,
+    getActiveProtocolsForNetwork,
+    routerPush,
+    loggerError,
+    LONG_PROTOCOL,
+    longProtocols,
+    protocolCurrencies,
+    currenciesData,
+    prices,
+    state
+  };
+});
+
+vi.mock("vue-router", async () => {
+  const actual = await vi.importActual<typeof import("vue-router")>("vue-router");
+  return {
+    ...actual,
+    useRouter: () => ({ push: hoisted.routerPush }),
+    useRoute: () => ({ params: {}, meta: {} })
+  };
+});
+
+vi.mock("@/router", () => ({
+  RouteNames: { LEASES: "leases" }
+}));
+
+vi.mock("@/common/stores/wallet", () => ({
+  useWalletStore: () => ({ wallet: null })
+}));
+
+vi.mock("@/common/stores/balances", () => ({
+  useBalancesStore: () => ({
+    get balances() {
+      return hoisted.state.balances;
+    },
+    fetchBalances: vi.fn()
+  })
+}));
+
+vi.mock("@/common/stores/config", () => ({
+  useConfigStore: () => ({
+    initialized: true,
+    protocolFilter: "OSMOSIS",
+    get longProtocolsForCurrentNetwork() {
+      return hoisted.longProtocols;
+    },
+    getCachedProtocolCurrencies: hoisted.getCachedProtocolCurrencies,
+    getActiveProtocolsForNetwork: hoisted.getActiveProtocolsForNetwork,
+    hasShortProtocols: () => false,
+    isNetworkDisabled: () => false,
+    get currenciesData() {
+      return hoisted.currenciesData;
+    },
+    contracts: {
+      [hoisted.LONG_PROTOCOL]: { leaser: "nolus1leaser" }
+    }
+  })
+}));
+
+vi.mock("@/common/stores/prices", () => ({
+  usePricesStore: () => ({
+    get prices() {
+      return hoisted.prices;
+    }
+  })
+}));
+
+vi.mock("@/common/stores/history", () => ({
+  useHistoryStore: () => ({ loadActivities: vi.fn() })
+}));
+
+vi.mock("@/common/utils", async () => {
+  const Int = (await import("@keplr-wallet/unit")).Int;
+  return {
+    getMicroAmount: (_denom: string, amount: string) => ({
+      mAmount: {
+        amount: new Int(Math.trunc(Number(amount || "0") * 1e8))
+      },
+      coinMinimalDenom: "ibc/WETH"
+    }),
+    Logger: { error: hoisted.loggerError },
+    walletOperation: vi.fn()
+  };
+});
+
+vi.mock("@/common/utils/NumberFormatUtils", () => ({
+  formatDecAsUsd: () => "$0",
+  formatUsd: () => "$0",
+  formatTokenBalance: () => "0"
+}));
+
+vi.mock("@/common/utils/LeaseConfigService", () => ({
+  getDownpaymentRange: hoisted.getDownpaymentRange
+}));
+
+// Child component of LongForm — its internal logic is irrelevant for these tests.
+vi.mock("@/modules/leases/components/new-lease/LongLeaseDetails.vue", () => ({
+  default: { name: "LongLeaseDetails", template: "<div />" }
+}));
+
+vi.mock("@nolus/nolusjs", async () => {
+  const actual = await vi.importActual<typeof import("@nolus/nolusjs")>("@nolus/nolusjs");
+  return {
+    ...actual,
+    NolusClient: {
+      getInstance: () => ({ getCosmWasmClient: async () => ({}) })
+    }
+  };
+});
+
+vi.mock("@nolus/nolusjs/build/contracts", () => ({
+  Leaser: class {
+    leaseQuote = hoisted.leaseQuote;
+  }
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k })
+}));
+
+vi.mock("web-components", () => ({
+  AdvancedFormControl: {
+    name: "AdvancedFormControl",
+    props: [
+      "id",
+      "currencyOptions",
+      "label",
+      "balanceLabel",
+      "placeholder",
+      "calculatedBalance",
+      "disabledCurrencyPicker",
+      "disabledInputField",
+      "errorMsg",
+      "inputClass",
+      "itemsHeadline",
+      "itemTemplate",
+      "selectedCurrencyOption"
+    ],
+    emits: ["input", "onSelectedCurrency"],
+    template: `
+      <div>
+        <div data-test="err">{{ errorMsg }}</div>
+        <input data-test="amount" @input="$emit('input', $event.target.value)" />
+      </div>
+    `
+  },
+  Button: {
+    name: "Button",
+    props: ["label", "disabled", "loading", "size", "severity"],
+    template: '<button data-test="submit" :disabled="disabled || loading">{{ label }}</button>'
+  },
+  Dropdown: {
+    name: "Dropdown",
+    props: ["id", "onSelect", "options", "size", "selected", "searchable", "disabled"],
+    template: '<div data-test="dropdown" />'
+  },
+  Radio: {
+    name: "Radio",
+    props: ["id", "label", "checked", "name", "disabled"],
+    template: '<input type="radio" />'
+  },
+  Slider: {
+    name: "Slider",
+    props: ["disabled", "minPosition", "maxPosition", "positions"],
+    emits: ["onDrag"],
+    template: '<div data-test="slider" />'
+  },
+  Size: { medium: "medium" },
+  AssetItem: { name: "AssetItem", template: "<div />" },
+  ToastType: { success: "success", error: "error" }
+}));
+
+import { mount } from "@vue/test-utils";
+import LongForm from "./LongForm.vue";
+
+function flushMicrotasks() {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+function factory() {
+  return mount(LongForm, {
+    global: {
+      mocks: { $t: (k: string) => k },
+      provide: {
+        onShowToast: vi.fn(),
+        reload: vi.fn()
+      }
+    }
+  });
+}
+
+describe("LongForm.vue — reactive balance validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+    hoisted.state.balances = [];
+
+    hoisted.getDownpaymentRange.mockResolvedValue({
+      WETH: { min: "1", max: "1000000000" },
+      ALL_BTC: { min: "1", max: "1000000000" }
+    });
+    hoisted.getCachedProtocolCurrencies.mockReturnValue(hoisted.protocolCurrencies);
+    hoisted.getActiveProtocolsForNetwork.mockReturnValue([hoisted.LONG_PROTOCOL]);
+
+    hoisted.leaseQuote.mockResolvedValue({
+      borrow: { ticker: "WETH", amount: "100000" },
+      total: { ticker: "WETH", amount: "500000000" },
+      annual_interest_rate: 100,
+      annual_interest_rate_margin: 80
+    });
+  });
+
+  it("shows insufficient-balance (not 'Unexpected error') when collateral balance is zero", async () => {
+    // No wallet balance for the selected collateral — the exact repro from the
+    // bug report. The quote must NOT be attempted; the message must be specific.
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("0.5");
+    await flushMicrotasks();
+    await wrapper.vm.$nextTick();
+    await flushMicrotasks();
+
+    expect(wrapper.find('[data-test="err"]').text()).toBe("message.invalid-balance-big");
+    expect(wrapper.find('[data-test="err"]').text()).not.toBe("message.unexpected-error");
+    expect(hoisted.leaseQuote).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it("flags a zero amount as invalid before attempting a quote", async () => {
+    hoisted.state.balances = [{ denom: "ibc/WETH", amount: "1000000000000000000" }];
+
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("0");
+    await flushMicrotasks();
+    await wrapper.vm.$nextTick();
+    await flushMicrotasks();
+
+    expect(wrapper.find('[data-test="err"]').text()).toBe("message.invalid-balance-low");
+    expect(hoisted.leaseQuote).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it("attempts the quote when the amount is within the wallet balance", async () => {
+    // 1 WETH balance; 0.5 WETH down payment is within it and within range.
+    hoisted.state.balances = [{ denom: "ibc/WETH", amount: "1000000000000000000" }];
+
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("0.5");
+    await flushMicrotasks();
+    await wrapper.vm.$nextTick();
+    await flushMicrotasks();
+
+    expect(wrapper.find('[data-test="err"]').text()).toBe("");
+    expect(hoisted.leaseQuote).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+});

--- a/src/modules/leases/components/new-lease/LongForm.vue
+++ b/src/modules/leases/components/new-lease/LongForm.vue
@@ -259,6 +259,10 @@ watch(
   () => [selectedCurrency.value, amount.value, selectedLoanCurrency.value, ltd.value],
   async () => {
     amountErrorMsg.value = "";
+    if (!validateAmountAgainstBalance()) {
+      leaseApply.value = null;
+      return;
+    }
     if (await validateMinMaxValues()) {
       calculate();
     } else {
@@ -495,45 +499,59 @@ async function validateMinMaxValues(): Promise<boolean> {
   }
 }
 
-function isDownPaymentAmountValid() {
-  let isValid = true;
-  amountErrorMsg.value = "";
-
+// Balance/amount validation that must run reactively (on every input change),
+// not only on submit. The contract quote in calculate() cannot stand in for it:
+// a zero-balance collateral has no denom, so the quote attempt throws and the
+// catch surfaces a generic "Unexpected error" instead of "Insufficient balance".
+function validateAmountAgainstBalance(): boolean {
   const selectedDownPaymentCurrency = currency.value;
   const downPaymentAmount = amount.value;
 
-  if (downPaymentAmount || downPaymentAmount !== "") {
-    const downPaymentAmountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(
-      downPaymentAmount,
-      "",
-      selectedDownPaymentCurrency.decimal_digits
-    );
-
-    const isLowerThanOrEqualsToZero = new Dec(downPaymentAmountInMinimalDenom.amount || "0").lte(new Dec(0));
-
-    const isGreaterThanWalletBalance = new Int(downPaymentAmountInMinimalDenom.amount.toString() || "0").gt(
-      new Int(selectedDownPaymentCurrency?.balance?.amount ?? "0")
-    );
-
-    if (isLowerThanOrEqualsToZero) {
-      amountErrorMsg.value = i18n.t("message.invalid-balance-low");
-      isValid = false;
-    }
-
-    if (isGreaterThanWalletBalance) {
-      amountErrorMsg.value = i18n.t("message.invalid-balance-big");
-      isValid = false;
-    }
-
-    if (!validateMinMaxValues()) {
-      isValid = false;
-    }
-  } else {
-    amountErrorMsg.value = i18n.t("message.missing-amount");
-    isValid = false;
+  if (!selectedDownPaymentCurrency || !downPaymentAmount) {
+    return true;
   }
 
-  return isValid;
+  const downPaymentAmountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(
+    downPaymentAmount,
+    "",
+    selectedDownPaymentCurrency.decimal_digits
+  );
+
+  const isLowerThanOrEqualsToZero = new Dec(downPaymentAmountInMinimalDenom.amount || "0").lte(new Dec(0));
+  const isGreaterThanWalletBalance = new Int(downPaymentAmountInMinimalDenom.amount.toString() || "0").gt(
+    new Int(selectedDownPaymentCurrency?.balance?.amount ?? "0")
+  );
+
+  if (isLowerThanOrEqualsToZero) {
+    amountErrorMsg.value = i18n.t("message.invalid-balance-low");
+    return false;
+  }
+
+  if (isGreaterThanWalletBalance) {
+    amountErrorMsg.value = i18n.t("message.invalid-balance-big");
+    return false;
+  }
+
+  return true;
+}
+
+function isDownPaymentAmountValid() {
+  amountErrorMsg.value = "";
+
+  if (!amount.value) {
+    amountErrorMsg.value = i18n.t("message.missing-amount");
+    return false;
+  }
+
+  if (!validateAmountAgainstBalance()) {
+    return false;
+  }
+
+  if (!validateMinMaxValues()) {
+    return false;
+  }
+
+  return true;
 }
 
 async function calculate() {

--- a/src/modules/leases/components/new-lease/ShortForm.test.ts
+++ b/src/modules/leases/components/new-lease/ShortForm.test.ts
@@ -335,8 +335,10 @@ describe("ShortForm.vue — leaseQuote ticker resolution", () => {
     await wrapper.vm.$nextTick();
 
     // Switch selected collateral to USDC_NOBLE via the stubbed picker.
+    // Amount stays within the 1 USDC fixture balance so the reactive balance
+    // check passes and the quote (the subject of this test) is attempted.
     await wrapper.find('[data-test="pick-usdc"]').trigger("click");
-    await wrapper.find('[data-test="amount"]').setValue("100");
+    await wrapper.find('[data-test="amount"]').setValue("1");
     await flushMicrotasks();
     await wrapper.vm.$nextTick();
     await flushMicrotasks();
@@ -400,6 +402,20 @@ describe("ShortForm.vue — leaseQuote ticker resolution", () => {
     await flushMicrotasks();
 
     expect(wrapper.find('[data-test="err"]').text()).toBe("message.unexpected-error");
+    wrapper.unmount();
+  });
+
+  it("shows insufficient-balance (not a quote error) when amount exceeds the wallet balance", async () => {
+    // BTC balance is 0.005 (500000 micro); 1 BTC is far above it.
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("1");
+    await flushMicrotasks();
+    await wrapper.vm.$nextTick();
+    await flushMicrotasks();
+
+    expect(wrapper.find('[data-test="err"]').text()).toBe("message.invalid-balance-big");
+    expect(hoisted.leaseQuote).not.toHaveBeenCalled();
     wrapper.unmount();
   });
 });

--- a/src/modules/leases/components/new-lease/ShortForm.vue
+++ b/src/modules/leases/components/new-lease/ShortForm.vue
@@ -260,6 +260,10 @@ watch(
   () => [selectedCurrency.value, amount.value, selectedLoanCurrency.value, ltd.value],
   async () => {
     amountErrorMsg.value = "";
+    if (!validateAmountAgainstBalance()) {
+      leaseApply.value = null;
+      return;
+    }
     if (await validateMinMaxValues()) {
       calculate();
     } else {
@@ -480,45 +484,59 @@ async function validateMinMaxValues(): Promise<boolean> {
   }
 }
 
-function isDownPaymentAmountValid() {
-  let isValid = true;
-  amountErrorMsg.value = "";
-
+// Balance/amount validation that must run reactively (on every input change),
+// not only on submit. The contract quote in calculate() cannot stand in for it:
+// a zero-balance collateral has no denom, so the quote attempt throws and the
+// catch surfaces a generic "Unexpected error" instead of "Insufficient balance".
+function validateAmountAgainstBalance(): boolean {
   const selectedDownPaymentCurrency = currency.value;
   const downPaymentAmount = amount.value;
 
-  if (downPaymentAmount || downPaymentAmount !== "") {
-    const downPaymentAmountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(
-      downPaymentAmount,
-      "",
-      selectedDownPaymentCurrency.decimal_digits
-    );
-
-    const isLowerThanOrEqualsToZero = new Dec(downPaymentAmountInMinimalDenom.amount || "0").lte(new Dec(0));
-
-    const isGreaterThanWalletBalance = new Int(downPaymentAmountInMinimalDenom.amount.toString() || "0").gt(
-      new Int(selectedDownPaymentCurrency?.balance?.amount ?? "0")
-    );
-
-    if (isLowerThanOrEqualsToZero) {
-      amountErrorMsg.value = i18n.t("message.invalid-balance-low");
-      isValid = false;
-    }
-
-    if (isGreaterThanWalletBalance) {
-      amountErrorMsg.value = i18n.t("message.invalid-balance-big");
-      isValid = false;
-    }
-
-    if (!validateMinMaxValues()) {
-      isValid = false;
-    }
-  } else {
-    amountErrorMsg.value = i18n.t("message.missing-amount");
-    isValid = false;
+  if (!selectedDownPaymentCurrency || !downPaymentAmount) {
+    return true;
   }
 
-  return isValid;
+  const downPaymentAmountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(
+    downPaymentAmount,
+    "",
+    selectedDownPaymentCurrency.decimal_digits
+  );
+
+  const isLowerThanOrEqualsToZero = new Dec(downPaymentAmountInMinimalDenom.amount || "0").lte(new Dec(0));
+  const isGreaterThanWalletBalance = new Int(downPaymentAmountInMinimalDenom.amount.toString() || "0").gt(
+    new Int(selectedDownPaymentCurrency?.balance?.amount ?? "0")
+  );
+
+  if (isLowerThanOrEqualsToZero) {
+    amountErrorMsg.value = i18n.t("message.invalid-balance-low");
+    return false;
+  }
+
+  if (isGreaterThanWalletBalance) {
+    amountErrorMsg.value = i18n.t("message.invalid-balance-big");
+    return false;
+  }
+
+  return true;
+}
+
+function isDownPaymentAmountValid() {
+  amountErrorMsg.value = "";
+
+  if (!amount.value) {
+    amountErrorMsg.value = i18n.t("message.missing-amount");
+    return false;
+  }
+
+  if (!validateAmountAgainstBalance()) {
+    return false;
+  }
+
+  if (!validateMinMaxValues()) {
+    return false;
+  }
+
+  return true;
 }
 
 async function calculate() {


### PR DESCRIPTION
## What

On the open-position lease forms (`/leases/open/long` and `/short`), entering an amount that exceeds the wallet balance — including a zero-balance collateral — showed **"Unexpected error"** instead of **"Insufficient balance"**.

Closes #192.

## Why

Two validation paths had diverged:

- The **reactive** `watch` (fires on every input change) ran only `validateMinMaxValues()` → `calculate()`. It never checked balance.
- The balance check (`invalid-balance-big`) lived only in `isDownPaymentAmountValid()`, called solely on submit.

With zero balance, `calculate()` called `getMicroAmount(undefined, …)` (no denom), which threw; the catch mapped it to the generic `unexpected-error`.

## Change

- Extract `validateAmountAgainstBalance()` (synchronous balance/amount check) in both `LongForm.vue` and `ShortForm.vue`.
- Run it first in the reactive watch — on failure, clear `leaseApply` and return before attempting the quote.
- Refactor `isDownPaymentAmountValid()` to reuse it, preserving the submit-path behavior (missing-amount, invalid-balance-low/big, min/max).
- Both forms kept byte-identical in the new logic.

## Tests

- New `LongForm.test.ts`: zero-balance (→ `invalid-balance-big`, no quote), zero-amount (→ `invalid-balance-low`), within-balance (quote attempted).
- Extended `ShortForm.test.ts` with an over-balance case; adjusted an existing test's amount to stay within the fixture balance.
- Full suite green (764 tests); lint, format, build clean.

## Note (pre-existing, out of scope)

The submit-path `isDownPaymentAmountValid()` calls `validateMinMaxValues()` without `await`, so that Promise is always truthy and the min/max check never blocks submit. Carried forward verbatim; worth a follow-up.

Also bundles a small unrelated README touch-up (env-file table + lint command), per request.
