### PR TITLE
fix(leases): correct liquidation line on single-lease price chart

### DIFF
--- a/src/modules/leases/components/single-lease/PriceOverTimeChart.vue
+++ b/src/modules/leases/components/single-lease/PriceOverTimeChart.vue
@@ -33,7 +33,7 @@ import Chart from "@/common/components/Chart.vue";
 import { Tooltip } from "web-components";
 
 import type { LeaseInfo } from "@/common/api";
-import { LeaseUtils } from "@/common/utils";
+import { computeChartLiquidationPrice } from "./liquidationLine";
 import { formatPriceUsd, formatUsd } from "@/common/utils/NumberFormatUtils";
 import {
   CHART_AXIS,
@@ -48,7 +48,6 @@ import { plot, lineY } from "@observablehq/plot";
 import { computed, ref, watch } from "vue";
 import { pointer, select, type Selection } from "d3";
 import { useI18n } from "vue-i18n";
-import { Dec } from "@keplr-wallet/unit";
 import { useConfigStore } from "@/common/stores/config";
 import { usePricesStore } from "@/common/stores/prices";
 import { useAnalyticsStore } from "@/common/stores";
@@ -104,22 +103,17 @@ const currency = computed(() => {
 async function setData() {
   if (props.lease) {
     const chartData = await loadData(props.interval);
-    const liquidations = getLiquidations();
+    const liquidation = resolveLiquidationPrice();
+    // computeChartLiquidationPrice returns 0 for any non-opened / zero-value lease.
+    const liquidationLabel = liquidation <= 0 ? null : liquidation.toString();
+
     data.value = (chartData ?? [])
       .map((item) => {
         const [date, price] = item;
-        const now = new Date(date);
-
-        const l = liquidations.reduce((closest, date) =>
-          Math.abs(date.date.getTime() - now.getTime()) < Math.abs(closest.date.getTime() - now.getTime())
-            ? date
-            : closest
-        );
-
         return {
-          Date: now,
+          Date: new Date(date),
           Price: price,
-          Liquidation: props.lease?.status === "opening" ? null : l.amount.toString()
+          Liquidation: liquidationLabel
         };
       })
       .reverse();
@@ -127,65 +121,19 @@ async function setData() {
   }
 }
 
-function getLiquidations() {
-  let asset = new Dec(0);
-  const asset2 = new Dec(0);
-
-  const liquidations: {
-    amount: Dec;
-    date: Date;
-  }[] = [];
-
+// Current liquidation trigger, resolved with the same decimals the position
+// widgets use. Rendered as a flat line across the series — see liquidationLine.ts.
+function resolveLiquidationPrice(): number {
   const protocolKey = props.lease?.protocol as string;
+  const unitAssetInfo = configStore.currenciesData?.[`${props.lease?.amount.ticker}@${protocolKey}`];
+  const lpn = getLpnByProtocol(protocolKey);
+  const stableAssetInfo = lpn ? configStore.currenciesData?.[lpn.key] : null;
 
-  if (props.lease?.status === "opened") {
-    const historyElements = [...(props.lease?.etl_data?.history ?? [])].reverse();
-
-    for (const history of historyElements) {
-      const ticker = history.symbol;
-
-      const unitAssetInfo = configStore.currenciesData![`${ticker!}@${protocolKey}`];
-      if (unitAssetInfo) {
-        asset = asset.add(new Dec(history.amount ?? "0", unitAssetInfo.decimal_digits));
-      }
-
-      const l = parceLiquidaitons(asset, asset2);
-      liquidations.push({
-        amount: l,
-        date: new Date(history.timestamp ?? Date.now())
-      });
-    }
-  }
-  const l = parceLiquidaitons(new Dec(0), new Dec(0));
-  liquidations.unshift({
-    amount: l,
-    date: new Date()
+  return computeChartLiquidationPrice(props.lease, {
+    positionType: configStore.getPositionType(protocolKey),
+    unitDecimals: Number(unitAssetInfo?.decimal_digits ?? 0),
+    stableDecimals: Number(stableAssetInfo?.decimal_digits ?? 0)
   });
-
-  return liquidations;
-}
-
-function parceLiquidaitons(stableAdd: Dec, uAsset: Dec) {
-  let liquidation = new Dec(0);
-  if (props.lease?.status === "opened") {
-    const protocolKey = props.lease?.protocol as string;
-    const ticker = props.lease?.amount.ticker;
-    const unitAssetInfo = configStore.currenciesData![`${ticker!}@${protocolKey}`];
-    const lpn = getLpnByProtocol(protocolKey);
-    const stableAssetInfo = lpn ? configStore.currenciesData?.[lpn.key] : null;
-
-    const unitAsset = new Dec(props.lease.amount.amount, Number(unitAssetInfo?.decimal_digits ?? 0));
-    const stableAsset = new Dec(props.lease.debt.principal, Number(stableAssetInfo?.decimal_digits ?? 0));
-
-    const positionType = configStore.getPositionType(protocolKey);
-    if (positionType === "Long") {
-      liquidation = LeaseUtils.calculateLiquidation(stableAsset.add(stableAdd), unitAsset.add(uAsset));
-    } else {
-      liquidation = LeaseUtils.calculateLiquidationShort(unitAsset.add(uAsset), stableAsset.add(stableAdd));
-    }
-  }
-
-  return liquidation;
 }
 
 async function loadData(intetval: string) {
@@ -253,7 +201,10 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
     y: {
       type: "linear",
       domain: yDomain,
-      clamp: true,
+      // Not clamped: a liquidation far outside the price range is clipped to the
+      // frame (invisible) rather than pinned to an edge at a position that would
+      // contradict its tooltip value.
+      clamp: false,
       grid: true,
       label: null,
       labelArrow: false,
@@ -332,18 +283,21 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
 
         dotPrice.attr("cx", xPixel).attr("cy", yScale.apply(closestData.Price)).style("display", null);
 
-        if (closestData.Liquidation !== null) {
-          dotLiquidation
-            .attr("cx", xPixel)
-            .attr("cy", yScale.apply(Number(closestData.Liquidation)))
-            .style("display", null);
+        const liquidationValue = closestData.Liquidation !== null ? Number(closestData.Liquidation) : null;
+        // Only place the liquidation dot when its value is inside the visible Y
+        // domain; otherwise it would be pinned to an edge and contradict the
+        // tooltip value.
+        if (liquidationValue !== null && liquidationValue >= yDomain[0] && liquidationValue <= yDomain[1]) {
+          dotLiquidation.attr("cx", xPixel).attr("cy", yScale.apply(liquidationValue)).style("display", null);
         } else {
           dotLiquidation.style("display", "none");
         }
 
-        tooltip.html(
-          `<strong>${i18n.t("message.price")}:</strong> ${formatUsd(closestData.Price)}<br><strong>${i18n.t("message.chart-liquidation-tooltip")}:</strong> ${formatUsd(Number(closestData.Liquidation!))}`
-        );
+        const liquidationHtml =
+          liquidationValue !== null
+            ? `<br><strong>${i18n.t("message.chart-liquidation-tooltip")}:</strong> ${formatUsd(liquidationValue)}`
+            : "";
+        tooltip.html(`<strong>${i18n.t("message.price")}:</strong> ${formatUsd(closestData.Price)}${liquidationHtml}`);
 
         const node = tooltip.node()!.getBoundingClientRect();
         const height = node.height;

--- a/src/modules/leases/components/single-lease/liquidationLine.test.ts
+++ b/src/modules/leases/components/single-lease/liquidationLine.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import type { LeaseInfo } from "@/common/api";
+import { computeChartLiquidationPrice } from "./liquidationLine";
+
+function lease(overrides: Partial<LeaseInfo> = {}): LeaseInfo {
+  return {
+    address: "nolus1abc",
+    protocol: "OSMOSIS-OSMOSIS-ALL_BTC",
+    status: "opened",
+    amount: { ticker: "ALL_BTC", amount: "100000000" }, // 1 BTC at 8 decimals
+    debt: {
+      ticker: "USDC_NOBLE",
+      principal: "56700000000", // 56,700 USDC at 6 decimals
+      overdue_margin: "0",
+      overdue_interest: "0",
+      due_margin: "0",
+      due_interest: "0",
+      total: "56700000000"
+    },
+    interest: { loan_rate: 0, margin_rate: 0, annual_rate_percent: 0 },
+    ...overrides
+  } as LeaseInfo;
+}
+
+describe("computeChartLiquidationPrice", () => {
+  it("Long: (debt / collateral) / 0.9 — below spot, not inflated", () => {
+    // 56,700 / 1 / 0.9 = 63,000
+    const result = computeChartLiquidationPrice(lease(), {
+      positionType: "Long",
+      unitDecimals: 8,
+      stableDecimals: 6
+    });
+    expect(result).toBeCloseTo(63000, 6);
+  });
+
+  it("Short: (collateral * 0.9) / debt", () => {
+    // collateral 1 (unit), debt 0.5 (stable) -> 1 * 0.9 / 0.5 = 1.8
+    const result = computeChartLiquidationPrice(
+      lease({
+        amount: { ticker: "USDC_NOBLE", amount: "100000000" },
+        debt: {
+          ticker: "ALL_BTC",
+          principal: "50000000",
+          overdue_margin: "0",
+          overdue_interest: "0",
+          due_margin: "0",
+          due_interest: "0",
+          total: "50000000"
+        }
+      }),
+      { positionType: "Short", unitDecimals: 8, stableDecimals: 8 }
+    );
+    expect(result).toBeCloseTo(1.8, 6);
+  });
+
+  it("prefers an explicit backend liquidation_price when present", () => {
+    const result = computeChartLiquidationPrice(lease({ liquidation_price: "61234.5" }), {
+      positionType: "Long",
+      unitDecimals: 8,
+      stableDecimals: 6
+    });
+    expect(result).toBe(61234.5);
+  });
+
+  it("returns 0 for a lease that is not opened", () => {
+    expect(
+      computeChartLiquidationPrice(lease({ status: "opening" }), {
+        positionType: "Long",
+        unitDecimals: 8,
+        stableDecimals: 6
+      })
+    ).toBe(0);
+  });
+
+  it("returns 0 when collateral or debt is zero", () => {
+    expect(
+      computeChartLiquidationPrice(lease({ amount: { ticker: "ALL_BTC", amount: "0" } }), {
+        positionType: "Long",
+        unitDecimals: 8,
+        stableDecimals: 6
+      })
+    ).toBe(0);
+  });
+
+  it("returns 0 for a null lease", () => {
+    expect(computeChartLiquidationPrice(null, { positionType: "Long", unitDecimals: 8, stableDecimals: 6 })).toBe(0);
+  });
+});

--- a/src/modules/leases/components/single-lease/liquidationLine.ts
+++ b/src/modules/leases/components/single-lease/liquidationLine.ts
@@ -1,0 +1,57 @@
+/**
+ * Current liquidation-trigger price for the single-lease price chart.
+ *
+ * The chart draws a flat line at the position's *current* liquidation price —
+ * the same value the position widgets show — instead of reconstructing a
+ * per-event historical series. The backend exposes no liquidation-price
+ * history, and the reconstruction this replaced added every history delta to
+ * the debt side only, inflating the value far above spot (a Long BTC position
+ * near $62k rendered a ~$109k trigger).
+ *
+ * Mirrors LeaseCalculator.calculateLiquidationPrice:
+ *   Long:  (debt / collateral) / 0.9
+ *   Short: (collateral * 0.9) / debt
+ */
+import { Dec } from "@keplr-wallet/unit";
+import { LeaseUtils } from "@/common/utils/LeaseUtils";
+import type { LeaseInfo } from "@/common/api";
+
+export interface LiquidationPriceInputs {
+  /** `Long` / `Short` — raw value from `configStore.getPositionType`. */
+  positionType: "Long" | "Short" | string;
+  /** Collateral decimals — `lease.amount.ticker`'s currency decimals. */
+  unitDecimals: number;
+  /** Debt-principal decimals — the protocol LPN's currency decimals. */
+  stableDecimals: number;
+}
+
+/**
+ * Returns the liquidation price as a plain number, or `0` when it cannot be
+ * computed (not an opened lease, or missing/zero collateral or debt). The
+ * caller renders no liquidation line for a `0`.
+ */
+export function computeChartLiquidationPrice(
+  lease: LeaseInfo | null | undefined,
+  inputs: LiquidationPriceInputs
+): number {
+  if (!lease || lease.status !== "opened") {
+    return 0;
+  }
+
+  if (lease.liquidation_price) {
+    return Number(lease.liquidation_price);
+  }
+
+  const unitAsset = new Dec(lease.amount.amount, inputs.unitDecimals);
+  const stableAsset = new Dec(lease.debt.principal, inputs.stableDecimals);
+  if (!unitAsset.isPositive() || !stableAsset.isPositive()) {
+    return 0;
+  }
+
+  const liquidation =
+    inputs.positionType === "Short"
+      ? LeaseUtils.calculateLiquidationShort(unitAsset, stableAsset)
+      : LeaseUtils.calculateLiquidation(stableAsset, unitAsset);
+
+  return Number(liquidation.toString());
+}


### PR DESCRIPTION
## What

The single-lease Price chart drew a wrong "Liquidation Trigger" line. For a Long BTC position near spot ~$61.8K, the tooltip reported ~$109,634 (impossible for a Long — it can only liquidate below spot), the dashed line was pinned to the top of the visible range contradicting the tooltip, and the step landed at the wrong time.

Closes #193.

## Why

`PriceOverTimeChart.vue` reconstructed a per-event liquidation series in `getLiquidations()`/`parceLiquidaitons()`:

- It accumulated every `etl_data.history` amount onto the **debt** side only, inflating the trigger far above spot.
- `setData()` matched each price point to the **nearest** liquidation entry by absolute time (not most-recent-as-of), shifting the step.
- The y-axis was `clamp: true`, so an out-of-range value was pinned to a chart edge while the tooltip showed the true value.

The backend exposes no liquidation-price history (`liquidation_price` is always `None`), so a correct per-event reconstruction isn't possible from the current data anyway.

## Change

- New tested pure module `liquidationLine.ts` — `computeChartLiquidationPrice(lease, {positionType, unitDecimals, stableDecimals})`, mirroring `LeaseCalculator.calculateLiquidationPrice` (Long: `debt/collateral/0.9`; Short: `collateral*0.9/debt`; prefers `lease.liquidation_price` when present; returns `0` for non-opened or zero collateral/debt).
- `PriceOverTimeChart.vue`: draws a flat line at the position's **current** liquidation price — the same value the position widgets show — and removes the broken reconstruction. `clamp` is now `false` (out-of-range trigger is clipped via `clip: "frame"`, not pinned), and the hover dot is shown only when the value is inside the visible Y domain.

## Note on behavior change

This intentionally drops the historical *stepping* of the liquidation line. It was producing incorrect values and there's no backend liquidation-price history to reconstruct it correctly. The chart now matches the single liquidation price shown elsewhere on the position. If true historical movement is wanted later, it needs a backend liquidation-price time series (follow-up).

## Tests

- `liquidationLine.test.ts`: Long, Short, explicit backend price, not-opened, zero collateral/debt, null lease.
- Full suite green (774 tests); lint, format, build clean.
