### PR TITLE
fix(ci): install from committed lockfile at deploy

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -34,7 +34,6 @@ jobs:
           VITE_WS_URL: wss://app-dev.nolus.io/ws
           VITE_APP_URL: https://app-dev.nolus.io
         run: |
-          npm update web-components
           npm ci
           npm run build
 

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -34,7 +34,6 @@ jobs:
           VITE_WS_URL: wss://app.nolus.io/ws
           VITE_APP_URL: https://app.nolus.io
         run: |
-          npm update web-components
           npm ci
           npm run build
 


### PR DESCRIPTION
## Problem

Both deploy workflows ran `npm update web-components && npm ci && npm run build`. The `npm update` step floats the `web-components` git dependency forward and rewrites `package-lock.json`, then `npm ci` installs from that mutated lockfile.

`pr-validate.yaml` runs a clean `npm ci` with no `npm update`, so the **deployed artifact is built against a different dependency closure than the one that passed validation** — the deployed build is not the validated build. Reproducibility / supply-chain smell: the lockfile stops being the source of truth exactly when it matters.

## Change

Remove `npm update web-components` from `deploy-dev.yaml` and `deploy-prod.yaml`. Deploys now install strictly from the committed lockfile via `npm ci`.

`web-components` is already tag-pinned in `package.json` (`github:nolus-protocol/web-components#v2.0.66`, lockfile-resolved to commit `425b5ec`) — the `npm update` line was the only thing breaking the pin.

## Intentional bumps

To bump `web-components`: edit the pin in `package.json`, run `npm install` to refresh the lockfile, and open a PR so `pr-validate` re-runs against the new closure — never float it at deploy time.

## Acceptance

- [x] `npm update web-components` removed from both deploy workflows
- [x] Deploy builds install strictly from the committed lockfile (`npm ci` only)
- [x] Documented path for intentional `web-components` bumps that re-runs validation

Closes #172