### PR TITLE
chore(lint): type-aware ESLint over .vue + house rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,9 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 import prettierConfig from "eslint-config-prettier";
+import { fileURLToPath } from "node:url";
+
+const tsconfigRootDir = fileURLToPath(new URL(".", import.meta.url));
 
 export default tseslint.config(
   {
@@ -86,7 +89,9 @@ export default tseslint.config(
       parserOptions: {
         parser: tseslint.parser,
         extraFileExtensions: [".vue"],
-        sourceType: "module"
+        sourceType: "module",
+        projectService: true,
+        tsconfigRootDir
       }
     },
     rules: {
@@ -99,7 +104,19 @@ export default tseslint.config(
       "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
       "no-fallthrough": "error",
 
+      eqeqeq: ["error", "always", { null: "ignore" }],
+      "@typescript-eslint/no-non-null-assertion": "error",
+      "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "separate-type-imports" }],
+      "no-console": ["error", { allow: ["warn", "error"] }],
+
       "vue/multi-word-component-names": "off"
+    }
+  },
+
+  {
+    files: ["src/common/utils/Logger.ts"],
+    rules: {
+      "no-console": "off"
     }
   },
 

--- a/src/common/api/WebSocketClient.ts
+++ b/src/common/api/WebSocketClient.ts
@@ -7,6 +7,8 @@
 
 import type { LeaseInfo, BalanceInfo, StakingPositionsResponse } from "./BackendApi";
 
+import { Logger } from "@/common/utils/Logger";
+
 // WebSocket URL from environment, falls back to same-origin /ws (for Vite dev proxy)
 function getWsUrl(): string {
   return (
@@ -244,7 +246,7 @@ class WebSocketClientImpl {
         this.ws = new WebSocket(this.url);
 
         this.ws.onopen = () => {
-          console.log("[WebSocket] Connected");
+          Logger.log("[WebSocket] Connected");
           this.setConnectionState("connected");
           this.reconnectAttempts = 0;
           this.resubscribeAll();
@@ -252,7 +254,7 @@ class WebSocketClientImpl {
         };
 
         this.ws.onclose = (event) => {
-          console.log("[WebSocket] Disconnected", event.code, event.reason);
+          Logger.log("[WebSocket] Disconnected", event.code, event.reason);
           this.cleanup();
           this.setConnectionState("disconnected");
           this.scheduleReconnect();
@@ -310,7 +312,7 @@ class WebSocketClientImpl {
       this.config.maxReconnectInterval
     );
 
-    console.log(`[WebSocket] Reconnecting in ${interval}ms (attempt ${this.reconnectAttempts + 1})`);
+    Logger.log(`[WebSocket] Reconnecting in ${interval}ms (attempt ${this.reconnectAttempts + 1})`);
     this.setConnectionState("reconnecting");
 
     this.reconnectTimeout = setTimeout(() => {
@@ -340,11 +342,11 @@ class WebSocketClientImpl {
 
       switch (message.type) {
         case "subscribed":
-          console.log(`[WebSocket] Subscribed to ${message.topic}`);
+          Logger.log(`[WebSocket] Subscribed to ${message.topic}`);
           break;
 
         case "unsubscribed":
-          console.log(`[WebSocket] Unsubscribed from ${message.topic}`);
+          Logger.log(`[WebSocket] Unsubscribed from ${message.topic}`);
           break;
 
         case "error":
@@ -461,14 +463,15 @@ class WebSocketClientImpl {
       }
     }
 
-    subscription.callbacks.add(callback);
+    const sub = subscription;
+    sub.callbacks.add(callback);
 
     // Return unsubscribe function
     return () => {
-      subscription!.callbacks.delete(callback);
+      sub.callbacks.delete(callback);
 
       // If no more callbacks, unsubscribe from server
-      if (subscription!.callbacks.size === 0) {
+      if (sub.callbacks.size === 0) {
         this.subscriptions.delete(key);
         if (this.ws?.readyState === WebSocket.OPEN) {
           this.send({ type: "unsubscribe", topic, ...params });

--- a/src/common/components/auth/WalletBoxes.vue
+++ b/src/common/components/auth/WalletBoxes.vue
@@ -20,7 +20,8 @@
 </template>
 
 <script lang="ts" setup>
-import { useWalletStore, WalletActions } from "@/common/stores/wallet";
+import type { WalletActions } from "@/common/stores/wallet";
+import { useWalletStore } from "@/common/stores/wallet";
 import { Logger } from "@/common/utils";
 import { inject, ref } from "vue";
 import { useI18n } from "vue-i18n";

--- a/src/common/stores/balances/index.test.ts
+++ b/src/common/stores/balances/index.test.ts
@@ -66,6 +66,12 @@ import { useBalancesStore } from "./index";
 
 const { captured, BackendApi, subscribeBalances } = hoisted;
 
+function emitBalances(addr: string, balances: any) {
+  const handler = captured.onBalances;
+  expect(handler).toBeTruthy();
+  (handler as (addr: string, balances: any) => void)(addr, balances);
+}
+
 type BalanceRec = {
   key: string;
   symbol: string;
@@ -301,7 +307,7 @@ describe("useBalancesStore", () => {
     await store.setAddress("nolus1x");
 
     expect(captured.onBalances).not.toBeNull();
-    captured.onBalances!("nolus1x", [mkBalance({ amount: "5" })]);
+    emitBalances("nolus1x", [mkBalance({ amount: "5" })]);
     expect(store.balances.length).toBe(1);
     expect(store.balances[0].amount).toBe("5");
   });
@@ -314,7 +320,7 @@ describe("useBalancesStore", () => {
     const store = useBalancesStore();
     await store.setAddress("nolus1x");
 
-    captured.onBalances!("nolus1OTHER", [mkBalance({ amount: "99" })]);
+    emitBalances("nolus1OTHER", [mkBalance({ amount: "99" })]);
     expect(store.balances).toEqual([]);
   });
 
@@ -326,7 +332,7 @@ describe("useBalancesStore", () => {
     const store = useBalancesStore();
     await store.setAddress("nolus1x");
 
-    captured.onBalances!("nolus1x", "not an array" as any);
+    emitBalances("nolus1x", "not an array" as any);
     expect(store.balances).toEqual([]);
   });
 

--- a/src/common/stores/connection/index.test.ts
+++ b/src/common/stores/connection/index.test.ts
@@ -68,6 +68,12 @@ import { useConnectionStore } from "./index";
 
 const { captured, wsClient } = hoisted;
 
+function emitState(state: string) {
+  const handler = captured.onConnectionState;
+  expect(handler).toBeTruthy();
+  (handler as (state: string) => void)(state);
+}
+
 describe("useConnectionStore", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -142,7 +148,7 @@ describe("useConnectionStore", () => {
     expect(store.isReady).toBe(false);
 
     // Now simulate ws "connected" — isReady should flip.
-    captured.onConnectionState!("connected");
+    emitState("connected");
     expect(store.isWsConnected).toBe(true);
     expect(store.isReady).toBe(true);
   });
@@ -182,10 +188,10 @@ describe("useConnectionStore", () => {
     await store.initializeApp();
     expect(captured.onConnectionState).not.toBeNull();
 
-    captured.onConnectionState!("connecting");
+    emitState("connecting");
     expect(store.wsState).toBe("connecting");
 
-    captured.onConnectionState!("connected");
+    emitState("connected");
     expect(store.wsState).toBe("connected");
   });
 
@@ -195,13 +201,13 @@ describe("useConnectionStore", () => {
     store.connectWallet("nolus1abc");
 
     // First "connected" after a disconnected window → count=1.
-    captured.onConnectionState!("disconnected");
-    captured.onConnectionState!("connected");
+    emitState("disconnected");
+    emitState("connected");
     expect(store.wsReconnectCount).toBe(1);
 
     // Another cycle → count=2.
-    captured.onConnectionState!("disconnected");
-    captured.onConnectionState!("connected");
+    emitState("disconnected");
+    emitState("connected");
     expect(store.wsReconnectCount).toBe(2);
   });
 
@@ -210,8 +216,8 @@ describe("useConnectionStore", () => {
     await store.initializeApp();
     // No connectWallet.
 
-    captured.onConnectionState!("disconnected");
-    captured.onConnectionState!("connected");
+    emitState("disconnected");
+    emitState("connected");
     expect(store.wsReconnectCount).toBe(0);
   });
 
@@ -259,7 +265,7 @@ describe("useConnectionStore", () => {
     const store = useConnectionStore();
     await store.initializeApp();
     store.connectWallet("nolus1abc");
-    captured.onConnectionState!("connected");
+    emitState("connected");
 
     store.cleanup();
 

--- a/src/common/stores/earn/index.test.ts
+++ b/src/common/stores/earn/index.test.ts
@@ -63,6 +63,12 @@ import { useEarnStore } from "./index";
 
 const { captured, BackendApi, subscribeEarn } = hoisted;
 
+function emitEarn(addr: string, positions: any[], totalUsd: string) {
+  const handler = captured.onEarn;
+  expect(handler).toBeTruthy();
+  (handler as (addr: string, positions: any[], totalUsd: string) => void)(addr, positions, totalUsd);
+}
+
 describe("useEarnStore", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -480,7 +486,7 @@ describe("useEarnStore", () => {
     await store.setAddress("nolus1x");
     expect(captured.onEarn).not.toBeNull();
 
-    captured.onEarn!(
+    emitEarn(
       "nolus1x",
       [
         {
@@ -512,7 +518,7 @@ describe("useEarnStore", () => {
     const store = useEarnStore();
     await store.setAddress("nolus1x");
 
-    captured.onEarn!(
+    emitEarn(
       "nolus1OTHER",
       [
         {

--- a/src/common/stores/history/index.test.ts
+++ b/src/common/stores/history/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type * as CommonUtils from "@/common/utils";
 import { setActivePinia, createPinia } from "pinia";
 
 // jsdom doesn't implement matchMedia; ThemeManager (loaded via the utils barrel
@@ -52,7 +53,7 @@ vi.mock("@nolus/nolusjs", () => ({
 }));
 
 vi.mock("@/common/utils", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/common/utils")>();
+  const actual = await importOriginal<typeof CommonUtils>();
   return {
     ...actual,
     getCreatedAtForHuman: vi.fn(() => "just now"),

--- a/src/common/stores/history/index.ts
+++ b/src/common/stores/history/index.ts
@@ -266,10 +266,11 @@ export const useHistoryStore = defineStore("history", () => {
     try {
       const rawTxs = await BackendApi.getTransactions(address.value, skip, limit, filters);
       const transformedTxs = transformTransactions(rawTxs, address.value);
+      const currentAddress = address.value ?? "";
 
       // Process each transaction with message formatting
       const promises = transformedTxs.map(async (d) => {
-        const [msg, coin, route, routeDetails] = await message(d, address.value!, i18n.global, voteMessages);
+        const [msg, coin, route, routeDetails] = await message(d, currentAddress, i18n.global, voteMessages);
         d.historyData = {
           msg,
           coin,
@@ -337,9 +338,10 @@ export const useHistoryStore = defineStore("history", () => {
     try {
       const rawTxs = await BackendApi.getTransactions(address.value, 0, 10);
       const transformedTxs = transformTransactions(rawTxs, address.value);
+      const currentAddress = address.value ?? "";
 
       const promises = transformedTxs.map(async (d) => {
-        const [msg, coin, route, routeDetails] = await message(d, address.value!, i18n.global, voteMessages);
+        const [msg, coin, route, routeDetails] = await message(d, currentAddress, i18n.global, voteMessages);
         d.historyData = {
           msg,
           coin,
@@ -432,14 +434,14 @@ export const useHistoryStore = defineStore("history", () => {
           icon: from.icon,
           token: {
             balance: formatTokenBalance(
-              new Dec(index == 0 ? operation.amount_in : operation.amount_out, currency?.decimal_digits)
+              new Dec(index === 0 ? operation.amount_in : operation.amount_out, currency?.decimal_digits)
             ),
             symbol: currency?.shortName
           },
           meta: () => h("div", `${from.label} > ${to.label}`)
         });
 
-        if (index == route?.operations.length - 1) {
+        if (index === route?.operations.length - 1) {
           steps.push({
             label: i18nInstance.t("message.receive-stepper"),
             icon: to.icon,

--- a/src/common/stores/leases/index.test.ts
+++ b/src/common/stores/leases/index.test.ts
@@ -119,6 +119,12 @@ import { useLeasesStore } from "./index";
 
 const { captured, BackendApi, subscribeLeases } = hoisted;
 
+function emitLeases(lease: any) {
+  const handler = captured.onLeases;
+  expect(handler).toBeTruthy();
+  (handler as (lease: any) => void)(lease);
+}
+
 type LeaseRec = {
   address: string;
   protocol: string;
@@ -428,7 +434,7 @@ describe("useLeasesStore", () => {
     await store.setOwner("nolus1x");
 
     expect(captured.onLeases).not.toBeNull();
-    captured.onLeases!({ address: "l1", status: "opened", amount: { ticker: "ATOM", amount: "9999" } });
+    emitLeases({ address: "l1", status: "opened", amount: { ticker: "ATOM", amount: "9999" } });
 
     const lease = store.leases.find((l) => l.address === "l1");
     expect(lease?.amount.amount).toBe("9999");
@@ -440,7 +446,7 @@ describe("useLeasesStore", () => {
     await store.setOwner("nolus1x");
 
     // Send a regressing status via WS — store should ignore it.
-    captured.onLeases!(mkLease({ address: "l1", status: "opening" }));
+    emitLeases(mkLease({ address: "l1", status: "opening" }));
 
     expect(store.leases.find((l) => l.address === "l1")?.status).toBe("opened");
   });
@@ -450,7 +456,7 @@ describe("useLeasesStore", () => {
     BackendApi.getLeases.mockResolvedValueOnce([]);
     await store.setOwner("nolus1x");
 
-    captured.onLeases!(mkLease({ address: "new1", status: "opened" }));
+    emitLeases(mkLease({ address: "new1", status: "opened" }));
     expect(store.leases.find((l) => l.address === "new1")).toBeDefined();
   });
 

--- a/src/common/stores/prices/index.test.ts
+++ b/src/common/stores/prices/index.test.ts
@@ -38,6 +38,12 @@ const hoisted = vi.hoisted(() => {
 });
 const { captured, getPricesMock, subscribePricesMock } = hoisted;
 
+function emitPrices(payload: Record<string, string>) {
+  const handler = captured.onPrices;
+  expect(handler).toBeTruthy();
+  (handler as (payload: Record<string, string>) => void)(payload);
+}
+
 vi.mock("@/common/api", () => ({
   BackendApi: {
     getPrices: hoisted.getPricesMock
@@ -178,7 +184,7 @@ describe("usePricesStore", () => {
     await store.initialize();
 
     expect(captured.onPrices).not.toBeNull();
-    captured.onPrices!({ "USDC@A": "1.05" });
+    emitPrices({ "USDC@A": "1.05" });
     expect(store.prices["USDC@A"]).toEqual({ price: "1.05", symbol: "USDC" });
   });
 
@@ -187,7 +193,7 @@ describe("usePricesStore", () => {
     const store = usePricesStore();
     await store.initialize();
 
-    captured.onPrices!({ "DOT@X": "5.0" });
+    emitPrices({ "DOT@X": "5.0" });
     expect(store.prices["DOT@X"]).toEqual({ price: "5.0", symbol: "DOT" });
   });
 
@@ -197,11 +203,14 @@ describe("usePricesStore", () => {
     await store.initialize();
 
     const before = store.lastUpdated;
+    expect(before).toBeTruthy();
     // Force a measurable time gap
     await new Promise((r) => setTimeout(r, 5));
-    captured.onPrices!({ "A@P": "1" });
+    emitPrices({ "A@P": "1" });
     expect(store.lastUpdated).not.toBe(before);
-    expect(store.lastUpdated!.getTime()).toBeGreaterThanOrEqual(before!.getTime());
+    const after = store.lastUpdated;
+    expect(after).toBeTruthy();
+    expect((after as Date).getTime()).toBeGreaterThanOrEqual((before as Date).getTime());
   });
 
   it("cleanup unsubscribes from WS and allows re-subscribe", async () => {

--- a/src/common/stores/staking/index.test.ts
+++ b/src/common/stores/staking/index.test.ts
@@ -61,6 +61,12 @@ import { useStakingStore } from "./index";
 
 const { captured, BackendApi, subscribeStaking } = hoisted;
 
+function emitStaking(addr: string, response: any) {
+  const handler = captured.onStaking;
+  expect(handler).toBeTruthy();
+  (handler as (addr: string, response: any) => void)(addr, response);
+}
+
 describe("useStakingStore", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -337,17 +343,17 @@ describe("useStakingStore", () => {
     expect(captured.onStaking).not.toBeNull();
 
     // Mismatched address: ignored
-    captured.onStaking!("nolus1OTHER", {
+    emitStaking("nolus1OTHER", {
       delegations: [{ validator_address: "ignored", shares: "0", balance: { denom: "u", amount: "0" } }]
     });
     expect(store.delegations).toEqual([]);
 
     // Null response: ignored (response is falsy)
-    captured.onStaking!("nolus1x", null);
+    emitStaking("nolus1x", null);
     expect(store.delegations).toEqual([]);
 
     // Matching address + partial response: fields only updated where present
-    captured.onStaking!("nolus1x", {
+    emitStaking("nolus1x", {
       delegations: [{ validator_address: "v1", shares: "1", balance: { denom: "u", amount: "5" } }],
       total_staked: "5"
       // rewards, unbonding, total_rewards omitted — should remain at defaults

--- a/src/common/stores/wallet/actions/protocolFilter.test.ts
+++ b/src/common/stores/wallet/actions/protocolFilter.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as CommonUtils from "@/common/utils";
 
 // The actions barrel pulls in heavy modules transitively (ThemeManager via
 // utils, IntercomService, network wallets). Keep this file focused on the
@@ -87,7 +88,7 @@ vi.mock("@nolus/nolusjs", () => ({
 // WalletManager has localStorage side-effects. Stub the static surface we
 // touch so we don't pollute jsdom localStorage between tests.
 vi.mock("@/common/utils", async () => {
-  const actual = await vi.importActual<typeof import("@/common/utils")>("@/common/utils");
+  const actual = await vi.importActual<typeof CommonUtils>("@/common/utils");
   return {
     ...actual,
     WalletManager: {

--- a/src/common/utils/ChartUtils.ts
+++ b/src/common/utils/ChartUtils.ts
@@ -10,10 +10,14 @@ export const CHART_AXIS = {
 };
 
 export function getChartWidth(plotContainer: HTMLElement): number {
-  return plotContainer.parentElement!.clientWidth;
+  return plotContainer.parentElement?.clientWidth ?? 0;
 }
 
-const measureCanvas = document.createElement("canvas").getContext("2d")!;
+const measureCanvasContext = document.createElement("canvas").getContext("2d");
+if (!measureCanvasContext) {
+  throw new Error("2D canvas context not available");
+}
+const measureCanvas = measureCanvasContext;
 
 export function computeMarginLeft(
   yDomain: [number, number],

--- a/src/common/utils/LeaseCalculator.test.ts
+++ b/src/common/utils/LeaseCalculator.test.ts
@@ -85,7 +85,7 @@ const makeLease = (overrides: MakeLeaseOverrides = {}): LeaseInfo => {
 };
 
 // Bias toward stable Dec equality comparisons via string form.
-const decEq = (a: Dec, expected: string) => expect(a.toString()).toBe(new Dec(expected).toString());
+const decEq = (a: Dec | undefined, expected: string) => expect(a?.toString()).toBe(new Dec(expected).toString());
 
 // ============================================================================
 // Tests
@@ -421,8 +421,8 @@ describe("LeaseCalculator", () => {
       // stable=8, unit=1 → 8 / 0.8 / 1 = 10
       const result = calc.calculateStopLoss(lease, "long", new Dec(1), new Dec(8));
       expect(result).not.toBeNull();
-      decEq(result!.price, "10");
-      expect(result!.percent).toBe(80);
+      decEq(result?.price, "10");
+      expect(result?.percent).toBe(80);
     });
 
     it("should compute short slPrice = unit * (sl/1000) / stable", () => {
@@ -430,14 +430,14 @@ describe("LeaseCalculator", () => {
       // unit=4, stable=1 → 4 * 0.75 / 1 = 3
       const result = calc.calculateStopLoss(lease, "short", new Dec(4), new Dec(1));
       expect(result).not.toBeNull();
-      decEq(result!.price, "3");
-      expect(result!.percent).toBe(75);
+      decEq(result?.price, "3");
+      expect(result?.percent).toBe(75);
     });
 
     it("should return slPercent as sl/10", () => {
       const lease = makeLease({ close_policy: { stop_loss: 750 } });
       const result = calc.calculateStopLoss(lease, "long", new Dec(1), new Dec(1));
-      expect(result!.percent).toBe(75);
+      expect(result?.percent).toBe(75);
     });
   });
 
@@ -463,8 +463,8 @@ describe("LeaseCalculator", () => {
       // stable=12, unit=1 → 12 / 1.2 / 1 = 10
       const result = calc.calculateTakeProfit(lease, "long", new Dec(1), new Dec(12));
       expect(result).not.toBeNull();
-      decEq(result!.price, "10");
-      expect(result!.percent).toBe(120);
+      decEq(result?.price, "10");
+      expect(result?.percent).toBe(120);
     });
 
     it("should compute short tpPrice", () => {
@@ -472,8 +472,8 @@ describe("LeaseCalculator", () => {
       // unit=2, stable=1 → 2 * 1.5 / 1 = 3
       const result = calc.calculateTakeProfit(lease, "short", new Dec(2), new Dec(1));
       expect(result).not.toBeNull();
-      decEq(result!.price, "3");
-      expect(result!.percent).toBe(150);
+      decEq(result?.price, "3");
+      expect(result?.percent).toBe(150);
     });
   });
 
@@ -519,7 +519,7 @@ describe("LeaseCalculator", () => {
       expect(interestDueDate).not.toBeNull();
       // Date.now() fixed at 2026-01-01; add 3 days in ms
       const expected = new Date("2026-01-01T00:00:00.000Z").getTime() + 3 * 24 * 60 * 60 * 1000;
-      expect(interestDueDate!.getTime()).toBe(expected);
+      expect(interestDueDate?.getTime()).toBe(expected);
     });
   });
 

--- a/src/common/utils/NumberFormatUtils.ts
+++ b/src/common/utils/NumberFormatUtils.ts
@@ -4,7 +4,8 @@
  * Handles number formatting for display in the UI.
  */
 
-import { Dec, CoinPretty } from "@keplr-wallet/unit";
+import type { CoinPretty } from "@keplr-wallet/unit";
+import { Dec } from "@keplr-wallet/unit";
 import { DECIMALS_AMOUNT, MAX_DECIMALS, NATIVE_CURRENCY } from "@/config/global";
 
 // Intl.NumberFormat construction is expensive — cache instances by options signature.

--- a/src/common/utils/SkipRoute.ts
+++ b/src/common/utils/SkipRoute.ts
@@ -142,7 +142,11 @@ export class SkipRouter {
     const addresses: Record<string, string> = {};
 
     for (const key in wallets) {
-      addresses[key] = wallets[key].address!;
+      const walletAddress = wallets[key].address;
+      if (!walletAddress) {
+        throw new Error(`Wallet address not available for ${key}`);
+      }
+      addresses[key] = walletAddress;
     }
 
     for (const id of route.chain_ids) {

--- a/src/common/utils/WalletConnect.ts
+++ b/src/common/utils/WalletConnect.ts
@@ -12,7 +12,7 @@ import { authenticateKeplr, authenticateLedger, type BaseWallet, type Wallet } f
 import { authenticatePhantom, authenticateSolFlare } from "@/networks/cosm/WalletFactory";
 
 export const validateAddress = (address: string) => {
-  if (!address || address.trim() == "") {
+  if (!address || address.trim() === "") {
     return i18n.global.t("message.invalid-address");
   }
 
@@ -28,7 +28,7 @@ export const validateAmountV2 = (amount: string, amount2: string) => {
   amount = removeSpace(removeComma(amount?.toString() ?? ""));
   amount2 = removeSpace(removeComma(amount2?.toString() ?? ""));
 
-  const hasDot = amount?.at?.(0) == ".";
+  const hasDot = amount?.at?.(0) === ".";
 
   if (!amount || hasDot) {
     return i18n.global.t("message.invalid-amount");

--- a/src/modules/assets/components/AssetsTable.vue
+++ b/src/modules/assets/components/AssetsTable.vue
@@ -143,7 +143,7 @@ const assets = computed<TableRowItemProps[]>(() => {
   const param = search.value.toLowerCase();
   return filteredAssets.value
     .filter((item) => {
-      if (param.length == 0) {
+      if (param.length === 0) {
         return true;
       }
       const c = item.currency;

--- a/src/modules/assets/components/ReceiveForm.vue
+++ b/src/modules/assets/components/ReceiveForm.vue
@@ -107,7 +107,8 @@ import { NETWORK_DATA } from "@/networks/config";
 import { NATIVE_NETWORK } from "../../../config/global/network";
 import { IGNORED_NETWORKS } from "../../../config/global";
 
-import { type BaseWallet, Wallet } from "@/networks";
+import type { Wallet } from "@/networks";
+import { type BaseWallet } from "@/networks";
 import { CONFIRM_STEP, type Network, type SkipRouteConfigType } from "@/common/types";
 import { useWalletStore } from "@/common/stores/wallet";
 import { useBalancesStore } from "@/common/stores/balances";
@@ -137,7 +138,7 @@ const assets = computed(() => {
   const data = [];
 
   for (const asset of networkCurrencies.value ?? []) {
-    const currency = tryGetCurrencyByDenom(asset.from!);
+    const currency = tryGetCurrencyByDenom(asset.from);
     if (!currency) continue; // Skip deprecated/removed denoms
 
     const value = new Dec(asset.balance?.amount.toString() ?? 0, asset.decimal_digits);
@@ -148,7 +149,7 @@ const assets = computed(() => {
     const stable = price.mul(value);
     data.push({
       name: currency.name,
-      value: asset.from!,
+      value: asset.from,
       label: currency.shortName,
       shortName: currency.shortName,
       icon: currency.icon,
@@ -156,7 +157,7 @@ const assets = computed(() => {
       balance: {
         value: exactBalance,
         customLabel: `${balance} ${currency.shortName}`,
-        ticker: currency.shortName!,
+        ticker: currency.shortName,
         denom: asset.balance.denom,
         amount: asset.balance?.amount
       },
@@ -222,7 +223,7 @@ async function onInit() {
     chainsData = chns;
 
     const n = NETWORK_DATA.list.filter((item) => {
-      if (skipRouteConfig!.transfers[item.key]) {
+      if (config.transfers[item.key]) {
         return true;
       }
       return false;
@@ -231,7 +232,7 @@ async function onInit() {
     networks.value = [...n].filter((item) => {
       return !IGNORED_NETWORKS.includes(item.key);
     });
-    const index = networks.value.findIndex((item: Network) => item.key == configStore.protocolFilter);
+    const index = networks.value.findIndex((item: Network) => item.key === configStore.protocolFilter);
     if (index < 0) {
       selectedNetwork.value = 0;
     } else {
@@ -244,11 +245,11 @@ async function onInit() {
 }
 
 onUnmounted(() => {
-  if (client && step.value != CONFIRM_STEP.PENDING) {
+  if (client && step.value !== CONFIRM_STEP.PENDING) {
     destroyClient();
   }
 
-  clearTimeout(timeOut!);
+  clearTimeout(timeOut);
 });
 
 const network = computed(() => {
@@ -265,7 +266,7 @@ const calculatedBalance = computed(() => {
     return formatUsd(0);
   }
 
-  const currency = tryGetCurrencyByDenom(asset.from!);
+  const currency = tryGetCurrencyByDenom(asset.from);
   if (!currency) return formatUsd(0);
 
   const price = new Dec(getPriceForCurrency(currency));
@@ -283,7 +284,7 @@ function destroyClient() {
 }
 
 function setHistory() {
-  const chains = getChainIds(tempRoute.value! as RouteResponse);
+  const chains = getChainIds(tempRoute.value as RouteResponse);
 
   const data = {
     id,
@@ -327,7 +328,7 @@ watch(
 
 async function onUpdateNetwork(event: Network) {
   tempRoute.value = null;
-  selectedNetwork.value = networks.value.findIndex((item) => item == event);
+  selectedNetwork.value = networks.value.findIndex((item) => item === event);
   if (!event.native) {
     await setCosmosNetwork();
   }
@@ -366,7 +367,7 @@ async function setCosmosNetwork() {
   const promises = [];
   const data = (skipRouteConfig as SkipRouteConfigType)?.transfers?.[network.value.key].currencies;
   for (const c of data ?? []) {
-    if (c.visible && configStore.protocolFilter != c.visible) continue;
+    if (c.visible && configStore.protocolFilter !== c.visible) continue;
 
     const currency = tryGetCurrencyByDenom(c.from);
     if (!currency) continue; // Skip deprecated/removed denoms
@@ -481,7 +482,11 @@ async function onSubmit() {
         const addresses: Record<string, string> = {};
 
         for (const key in wallets) {
-          addresses[key] = wallets[key].address!;
+          const walletAddress = wallets[key].address;
+          if (!walletAddress) {
+            throw new Error(`Wallet address not available for ${key}`);
+          }
+          addresses[key] = walletAddress;
         }
 
         setHistory();
@@ -523,7 +528,10 @@ async function onSubmit() {
 }
 
 async function submit(wallets: { [key: string]: BaseWallet }) {
-  await SkipRouter.submitRoute(route!, wallets, async (tx: SkipTxResult, wallet: BaseWallet, chainId: string) => {
+  if (!route) {
+    throw new Error("Route not available");
+  }
+  await SkipRouter.submitRoute(route, wallets, async (tx: SkipTxResult, wallet: BaseWallet, chainId: string) => {
     walletStore.history[id].historyData.route.activeStep++;
     walletStore.history[id].historyData.routeDetails.activeStep++;
 
@@ -549,11 +557,14 @@ async function submit(wallets: { [key: string]: BaseWallet }) {
 }
 
 async function getWallets(): Promise<{ [key: string]: BaseWallet }> {
+  if (!route) {
+    throw new Error("Route not available");
+  }
   const native = walletStore.wallet.signer.chainId as string;
   const addrs = {
     [native]: walletStore.wallet
   };
-  const chainToParse: { [key: string]: NetworkInfo } = getChains(route!);
+  const chainToParse: { [key: string]: NetworkInfo } = getChains(route);
   const promises = [];
 
   for (const chain in chainToParse) {
@@ -577,28 +588,28 @@ async function getRoute() {
   const chainId = await client.getChainId();
   const asset = assets.value[selectedCurrency.value];
 
-  const transferAmount = Decimal.fromUserInput(amount.value, asset!.decimal_digits as number);
+  const transferAmount = Decimal.fromUserInput(amount.value, asset.decimal_digits as number);
 
-  const route = await SkipRouter.getRoute(asset.balance.denom, asset.from!, transferAmount.atomics, false, chainId);
+  const route = await SkipRouter.getRoute(asset.balance.denom, asset.from, transferAmount.atomics, false, chainId);
   return route;
 }
 
-function getChains(route?: RouteResponse) {
+function getChains(route: RouteResponse) {
   const chainToParse: { [key: string]: NetworkInfo } = {};
   const native = walletStore.wallet.signer.chainId as string;
 
   const chains = chainsData.filter((item) => {
-    if (item.chain_id == native) {
+    if (item.chain_id === native) {
       return false;
     }
-    return route!.chain_ids.includes(item.chain_id);
+    return route.chain_ids.includes(item.chain_id);
   });
 
   const supportedNetworks = configStore.supportedNetworksData;
   for (const chain of chains) {
     for (const key in supportedNetworks) {
       const networkData = supportedNetworks[key];
-      if (networkData?.value == chain.chain_name.toLowerCase()) {
+      if (networkData?.value === chain.chain_name.toLowerCase()) {
         chainToParse[key] = networkData;
       }
     }
@@ -607,17 +618,17 @@ function getChains(route?: RouteResponse) {
   return chainToParse;
 }
 
-function getChainIds(route?: RouteResponse) {
+function getChainIds(route: RouteResponse) {
   const chainToParse: { [key: string]: NetworkInfo } = {};
   const chains = chainsData.filter((item) => {
-    return route!.chain_ids.includes(item.chain_id);
+    return route.chain_ids.includes(item.chain_id);
   });
 
   const supportedNetworks = configStore.supportedNetworksData;
   for (const chain of chains) {
     for (const key in supportedNetworks) {
       const networkData = supportedNetworks[key];
-      if (networkData?.value == chain.chain_name.toLowerCase()) {
+      if (networkData?.value === chain.chain_name.toLowerCase()) {
         chainToParse[chain.chain_id] = networkData;
       }
     }

--- a/src/modules/assets/components/SendForm.vue
+++ b/src/modules/assets/components/SendForm.vue
@@ -114,7 +114,8 @@ import { NETWORK_DATA } from "@/networks/config";
 import { NATIVE_NETWORK } from "../../../config/global/network";
 import { IGNORED_NETWORKS } from "../../../config/global";
 
-import { type BaseWallet, Wallet } from "@/networks";
+import type { Wallet } from "@/networks";
+import { type BaseWallet } from "@/networks";
 import { CONFIRM_STEP, type ExternalCurrency, type Network, type SkipRouteConfigType } from "@/common/types";
 import { useWalletStore } from "@/common/stores/wallet";
 import { useBalancesStore } from "@/common/stores/balances";
@@ -148,7 +149,7 @@ const assets = computed(() => {
   const data = [];
   for (const asset of (networkCurrenciesRef.value as ExternalCurrency[] | AssetBalance[]) ?? []) {
     const denom = (asset as ExternalCurrency).ibcData ?? (asset as AssetBalance).from;
-    const currency = tryGetCurrencyByDenom(denom!);
+    const currency = tryGetCurrencyByDenom(denom);
     if (!currency) continue; // Skip deprecated/removed denoms
 
     const value = new Dec(asset.balance?.amount.toString() ?? 0, asset.decimal_digits);
@@ -160,22 +161,22 @@ const assets = computed(() => {
     data.push({
       name: asset.name,
       value: denom,
-      label: asset.shortName!,
-      shortName: asset.shortName!,
-      icon: asset.icon!,
-      decimal_digits: asset.decimal_digits!,
+      label: asset.shortName,
+      shortName: asset.shortName,
+      icon: asset.icon,
+      decimal_digits: asset.decimal_digits,
       balance: {
         value: exactBalance,
         customLabel: `${balance} ${asset.shortName}`,
-        ticker: asset.shortName!,
+        ticker: asset.shortName,
         denom: asset.balance.denom,
         amount: asset.balance?.amount
       },
       ibcData: (asset as ExternalCurrency).ibcData,
       from: (asset as AssetBalance).from,
-      native: asset.native!,
-      symbol: asset.symbol!,
-      ticker: asset.ticker!,
+      native: asset.native,
+      symbol: asset.symbol,
+      ticker: asset.ticker,
       stable,
       price: formatDecAsUsd(stable)
     });
@@ -258,7 +259,7 @@ async function onInit() {
     skipRouteConfig = config;
     chainsData = chns;
     const n = NETWORK_DATA.list.filter((item) => {
-      if (skipRouteConfig!.transfers[item.key]) {
+      if (config.transfers[item.key]) {
         return true;
       }
       return false;
@@ -266,7 +267,7 @@ async function onInit() {
     networks.value = [...n].filter((item) => {
       return !IGNORED_NETWORKS.includes(item.key);
     });
-    const index = networks.value.findIndex((item: Network) => item.key == configStore.protocolFilter);
+    const index = networks.value.findIndex((item: Network) => item.key === configStore.protocolFilter);
     if (index < 0) {
       selectedNetwork.value = 0;
     } else {
@@ -279,8 +280,8 @@ async function onInit() {
 }
 
 onUnmounted(() => {
-  clearTimeout(timeOut!);
-  if (client && step.value != CONFIRM_STEP.PENDING) {
+  clearTimeout(timeOut);
+  if (client && step.value !== CONFIRM_STEP.PENDING) {
     destroyClient();
   }
 });
@@ -309,7 +310,7 @@ function destroyClient() {
 }
 
 function setHistory() {
-  const chains = getChainIds(tempRoute.value! as RouteResponse);
+  const chains = getChainIds(tempRoute.value as RouteResponse);
 
   const data = {
     id,
@@ -351,7 +352,7 @@ watch(
 
 async function onUpdateNetwork(event: Network) {
   tempRoute.value = null;
-  selectedNetwork.value = networks.value.findIndex((item) => item == event);
+  selectedNetwork.value = networks.value.findIndex((item) => item === event);
   if (!event.native) {
     await setCosmosNetwork();
   } else {
@@ -400,7 +401,7 @@ async function setCosmosNetwork() {
   const currencies = [];
   const data = (skipRouteConfig as SkipRouteConfigType)?.transfers?.[network.value.key].currencies;
   for (const c of data ?? []) {
-    if (c.visible && configStore.protocolFilter != c.visible) continue;
+    if (c.visible && configStore.protocolFilter !== c.visible) continue;
 
     const currency = tryGetCurrencyByDenom(c.from);
     if (!currency) continue; // Skip deprecated/removed denoms
@@ -440,7 +441,7 @@ function validateAmount() {
     return false;
   }
 
-  if (amount.value.at(0) == ".") {
+  if (amount.value.at(0) === ".") {
     amountErrorMsg.value = i18n.t("message.invalid-amount");
     return false;
   }
@@ -488,7 +489,7 @@ async function onSendClick() {
 }
 
 function onSubmitNative() {
-  const isValid = validateAmount() && validateAddress(receiverAddress.value).length == 0;
+  const isValid = validateAmount() && validateAddress(receiverAddress.value).length === 0;
 
   if (isValid) {
     onSwap();
@@ -603,7 +604,11 @@ async function onSwapCosmos() {
         const addresses: Record<string, string> = {};
 
         for (const key in wallets) {
-          addresses[key] = wallets[key].address!;
+          const walletAddress = wallets[key].address;
+          if (!walletAddress) {
+            throw new Error(`Wallet address not available for ${key}`);
+          }
+          addresses[key] = walletAddress;
         }
 
         setHistory();
@@ -649,7 +654,10 @@ async function onSwapCosmos() {
 }
 
 async function submit(wallets: { [key: string]: BaseWallet }) {
-  await SkipRouter.submitRoute(route!, wallets, async (tx: SkipTxResult, wallet: BaseWallet, chainId: string) => {
+  if (!route) {
+    throw new Error("Route not available");
+  }
+  await SkipRouter.submitRoute(route, wallets, async (tx: SkipTxResult, wallet: BaseWallet, chainId: string) => {
     walletStore.history[id].historyData.route.activeStep++;
     walletStore.history[id].historyData.routeDetails.activeStep++;
 
@@ -674,16 +682,19 @@ async function submit(wallets: { [key: string]: BaseWallet }) {
 }
 
 async function getWallets(): Promise<{ [key: string]: BaseWallet }> {
+  if (!route) {
+    throw new Error("Route not available");
+  }
   const native = walletStore.wallet.signer.chainId as string;
   const addrs = {
     [native]: walletStore.wallet
   };
 
-  const chainToParse: { [key: string]: NetworkInfo } = getChains(route!);
+  const chainToParse: { [key: string]: NetworkInfo } = getChains(route);
   const promises = [];
   for (const chain in chainToParse) {
     const fn = async function () {
-      if (chain != NATIVE_NETWORK.key) {
+      if (chain !== NATIVE_NETWORK.key) {
         const client = await WalletUtils.getWallet(chain);
         const network = NETWORK_DATA;
         const networkData = network?.supportedNetworks[chain];
@@ -703,10 +714,10 @@ async function getRoute() {
   const chainId = await client.getChainId();
   const asset = assets.value[selectedCurrency.value];
 
-  const transferAmount = Decimal.fromUserInput(amount.value, asset!.decimal_digits as number);
+  const transferAmount = Decimal.fromUserInput(amount.value, asset.decimal_digits as number);
 
   const route = await SkipRouter.getRoute(
-    asset.from!,
+    asset.from,
     asset.balance.denom,
     transferAmount.atomics,
     false,
@@ -717,21 +728,21 @@ async function getRoute() {
   return route;
 }
 
-function getChains(route?: RouteResponse) {
+function getChains(route: RouteResponse) {
   const chainToParse: { [key: string]: NetworkInfo } = {};
   const native = walletStore.wallet.signer.chain_id as string;
   const chains = chainsData.filter((item) => {
-    if (item.chain_id == native) {
+    if (item.chain_id === native) {
       return false;
     }
-    return route!.chain_ids?.includes(item.chain_id);
+    return route.chain_ids?.includes(item.chain_id);
   });
 
   const supportedNetworks = configStore.supportedNetworksData;
   for (const chain of chains) {
     for (const key in supportedNetworks) {
       const networkData = supportedNetworks[key];
-      if (networkData?.value == chain.chain_name.toLowerCase()) {
+      if (networkData?.value === chain.chain_name.toLowerCase()) {
         chainToParse[key] = networkData;
       }
     }
@@ -740,17 +751,17 @@ function getChains(route?: RouteResponse) {
   return chainToParse;
 }
 
-function getChainIds(route?: RouteResponse) {
+function getChainIds(route: RouteResponse) {
   const chainToParse: { [key: string]: NetworkInfo } = {};
   const chains = chainsData.filter((item) => {
-    return route!.chain_ids?.includes?.(item.chain_id);
+    return route.chain_ids?.includes?.(item.chain_id);
   });
 
   const supportedNetworks = configStore.supportedNetworksData;
   for (const chain of chains) {
     for (const key in supportedNetworks) {
       const networkData = supportedNetworks[key];
-      if (networkData?.value == chain.chain_name.toLowerCase()) {
+      if (networkData?.value === chain.chain_name.toLowerCase()) {
         chainToParse[chain.chain_id] = networkData;
       }
     }

--- a/src/modules/assets/components/SwapForm.vue
+++ b/src/modules/assets/components/SwapForm.vue
@@ -125,7 +125,8 @@ import { externalWallet, Logger, validateAmountV2, walletOperation, WalletUtils 
 import { getSkipRouteConfig } from "@/common/utils/ConfigService";
 import { getPriceForCurrency, tryGetCurrencyByDenom } from "@/common/utils/CurrencyLookup";
 import { formatDecAsUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
-import { Coin, Dec, Int } from "@keplr-wallet/unit";
+import type { Coin } from "@keplr-wallet/unit";
+import { Dec, Int } from "@keplr-wallet/unit";
 import { h } from "vue";
 import { CurrencyUtils } from "@nolus/nolusjs";
 import { MultipleCurrencyEventType, type SkipRouteConfigType } from "@/common/types";
@@ -189,7 +190,7 @@ const assets = computed(() => {
   const data = [];
 
   for (const c of swapCurrencies.value) {
-    if (c.visible && configStore.protocolFilter != c.visible) continue;
+    if (c.visible && configStore.protocolFilter !== c.visible) continue;
     if (blacklist.value.includes(c.from)) continue;
 
     const currency = tryGetCurrencyByDenom(c.from);
@@ -247,8 +248,8 @@ const secondCalculatedBalance = computed(() => {
 const selectedAsset = computed(() => {
   if (!selectedFirstCurrencyOption.value) return undefined;
   return (
-    assets.value.find((item) => item.value == selectedFirstCurrencyOption.value?.value) ??
-    assets.value.find((item) => item.ibcData == selectedFirstCurrencyOption.value?.ibcData) ??
+    assets.value.find((item) => item.value === selectedFirstCurrencyOption.value?.value) ??
+    assets.value.find((item) => item.ibcData === selectedFirstCurrencyOption.value?.ibcData) ??
     selectedFirstCurrencyOption.value
   );
 });
@@ -275,9 +276,9 @@ async function onInit() {
     swapCurrencies.value = networkTransfers;
 
     const firstCurrency = assets.value.find(
-      (item) => item.ibcData == config[`swap_currency_${protocol}` as keyof SkipRouteConfigType]
+      (item) => item.ibcData === config[`swap_currency_${protocol}` as keyof SkipRouteConfigType]
     );
-    const secondCurrency = assets.value.find((item) => item.ibcData == config.swap_to_currency);
+    const secondCurrency = assets.value.find((item) => item.ibcData === config.swap_to_currency);
 
     if (!firstCurrency || !secondCurrency) {
       Logger.error(
@@ -300,7 +301,7 @@ async function onInit() {
 }
 
 async function onNextClick() {
-  if (validateInputs().length == 0) {
+  if (validateInputs().length === 0) {
     try {
       disabled.value = true;
       await walletOperation(onSwap);
@@ -318,7 +319,7 @@ function updateAmount(value: {
   type: MultipleCurrencyEventType;
 }) {
   amount.value = value.input.value ?? 0;
-  const match = assets.value.find((item) => item.value == value.currency.value);
+  const match = assets.value.find((item) => item.value === value.currency.value);
   if (!match) {
     Logger.error(`Swap currency not available (first side): ${value.currency.value}`);
     onShowToast({
@@ -337,7 +338,7 @@ function updateSwapToAmount(value: {
   type: MultipleCurrencyEventType;
 }) {
   swapToAmount.value = value.input.value;
-  const match = assets.value.find((item) => item.value == value.currency.value);
+  const match = assets.value.find((item) => item.value === value.currency.value);
   if (!match) {
     Logger.error(`Swap currency not available (second side): ${value.currency.value}`);
     onShowToast({
@@ -387,14 +388,14 @@ async function setSwapFee() {
 }
 
 function updateRoute() {
-  if (!amount.value.length || amount.value.length == 0) {
+  if (!amount.value.length || amount.value.length === 0) {
     return false;
   }
 
   const first = selectedFirstCurrencyOption.value;
   if (!first) return;
 
-  if (validateInputs().length == 0) {
+  if (validateInputs().length === 0) {
     const token = CurrencyUtils.convertDenomToMinimalDenom(
       amount.value.toString(),
       first.ibcData,
@@ -410,7 +411,7 @@ function updateSwapToRoute() {
   const second = selectedSecondCurrencyOption.value;
   if (!second) return;
 
-  if (validateSwapToInputs().length == 0) {
+  if (validateSwapToInputs().length === 0) {
     const token = CurrencyUtils.convertDenomToMinimalDenom(
       swapToAmount.value.toString(),
       second.ibcData,
@@ -480,9 +481,9 @@ async function setRoute(token: Coin, revert = false) {
 function validateInputs() {
   const first = selectedFirstCurrencyOption.value;
   const second = selectedSecondCurrencyOption.value;
-  if (!first || !second) return error.value;
+  if (!first || !second || !first.balance) return error.value;
 
-  error.value = validateAmountV2(amount.value, first.balance!.value);
+  error.value = validateAmountV2(amount.value, first.balance.value);
   if (first.ibcData === second.ibcData) {
     error.value = i18n.t("message.swap-same-error");
   }
@@ -492,9 +493,9 @@ function validateInputs() {
 function validateSwapToInputs() {
   const first = selectedFirstCurrencyOption.value;
   const second = selectedSecondCurrencyOption.value;
-  if (!first || !second) return error.value;
+  if (!first || !second || !second.balance) return error.value;
 
-  error.value = validateAmountV2(swapToAmount.value, second.balance!.value);
+  error.value = validateAmountV2(swapToAmount.value, second.balance.value);
   if (first.ibcData === second.ibcData) {
     error.value = i18n.t("message.swap-same-error");
   }
@@ -513,10 +514,17 @@ async function onSwap() {
     const addresses: Record<string, string> = {};
 
     for (const key in wallets) {
-      addresses[key] = wallets[key].address!;
+      const walletAddress = wallets[key].address;
+      if (!walletAddress) {
+        throw new Error(`Wallet address not available for ${key}`);
+      }
+      addresses[key] = walletAddress;
     }
 
-    await SkipRouter.submitRoute(route!, wallets, async (tx: SkipTxResult, baseWallet: BaseWallet) => {
+    if (!route) {
+      throw new Error("Route not available");
+    }
+    await SkipRouter.submitRoute(route, wallets, async (tx: SkipTxResult, baseWallet: BaseWallet) => {
       const element = {
         hash: tx.txHash,
         status: SwapStatus.pending,
@@ -552,6 +560,10 @@ async function onSwap() {
 }
 
 async function getWallets(): Promise<{ [key: string]: BaseWallet }> {
+  if (!route) {
+    throw new Error("Route not available");
+  }
+  const currentRoute = route;
   const native = wallet.wallet.signer.chainId as string;
   const addrs = {
     [native]: wallet.wallet
@@ -559,17 +571,17 @@ async function getWallets(): Promise<{ [key: string]: BaseWallet }> {
 
   const chainToParse: { [key: string]: NetworkInfo } = {};
   const chains = (await SkipRouter.getChains()).filter((item) => {
-    if (item.chain_id == native) {
+    if (item.chain_id === native) {
       return false;
     }
-    return route!.chain_ids.includes(item.chain_id);
+    return currentRoute.chain_ids.includes(item.chain_id);
   });
 
   const supportedNetworks = configStore.supportedNetworksData;
   for (const chain of chains) {
     for (const key in supportedNetworks) {
       const networkData = supportedNetworks[key];
-      if (networkData?.value == chain.chain_name) {
+      if (networkData?.value === chain.chain_name) {
         chainToParse[key] = networkData;
       }
     }

--- a/src/modules/assets/components/TransferDialog.vue
+++ b/src/modules/assets/components/TransferDialog.vue
@@ -68,7 +68,7 @@ const title = computed(() => {
 function onChangeTab(event: number) {
   let path = route.matched[1].path ?? "/";
 
-  if (path == "/") {
+  if (path === "/") {
     path = "";
   }
 

--- a/src/modules/dashboard/components/UnrealizedPnlChart.vue
+++ b/src/modules/dashboard/components/UnrealizedPnlChart.vue
@@ -190,7 +190,13 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
           <strong>${i18n.t("message.debt-label")}</strong> ${formatUsd(closestData?.debt ?? 0)}`
         );
 
-        const node = tooltip.node()!.getBoundingClientRect();
+        const tooltipNode = tooltip.node();
+
+        if (!tooltipNode) {
+          return;
+        }
+
+        const node = tooltipNode.getBoundingClientRect();
         const height = node.height;
         const width = node.width;
 

--- a/src/modules/earn/components/EarnChart.vue
+++ b/src/modules/earn/components/EarnChart.vue
@@ -51,7 +51,7 @@ const chart = ref<typeof Chart>();
 const props = defineProps<{ amount: Dec; currencyKey: string }>();
 
 const currency = computed(() => {
-  return configStore.currenciesData![props.currencyKey];
+  return configStore.currenciesData[props.currencyKey];
 });
 
 watch(
@@ -118,7 +118,11 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
           `<strong>${i18n.t("message.amount")}</strong> ${formatNumber(closestData.amount, 2)} ${currency.value?.shortName}`
         );
 
-        const node = tooltip.node()!.getBoundingClientRect();
+        const tooltipNode = tooltip.node();
+        if (!tooltipNode) {
+          return;
+        }
+        const node = tooltipNode.getBoundingClientRect();
         const height = node.height;
         const width = node.width;
 

--- a/src/modules/earn/components/SupplyForm.vue
+++ b/src/modules/earn/components/SupplyForm.vue
@@ -116,8 +116,8 @@ const assets = computed(() => {
   try {
     const activeProtocols = configStore.getActiveProtocolsForNetwork(configStore.protocolFilter);
     const lpns = configStore.lpn?.filter((item) => {
-      const c = configStore.currenciesData![item.key!];
-      const [_currency, protocol] = c.key!.split("@");
+      const c = configStore.currenciesData[item.key];
+      const [_currency, protocol] = c.key.split("@");
       return activeProtocols.includes(protocol);
     });
 
@@ -154,7 +154,7 @@ const assets = computed(() => {
     for (const protocol of SORT_PROTOCOLS) {
       const index = data.findIndex((item) => {
         const [_key, pr] = item.value.split("@");
-        return pr == protocol;
+        return pr === protocol;
       });
       if (index > -1) {
         items.push(data[index]);
@@ -247,7 +247,7 @@ const amountStr = computed(() => {
 });
 
 async function onNextClick() {
-  if (validateInputs().length == 0) {
+  if (validateInputs().length === 0) {
     try {
       disabled.value = true;
       await walletOperation(transferAmount);
@@ -265,7 +265,7 @@ async function transferAmount() {
   if (wallet && error.value === "") {
     try {
       loading.value = true;
-      const currency = configStore.currenciesData![assets.value[selectedCurrency.value].value];
+      const currency = configStore.currenciesData[assets.value[selectedCurrency.value].value];
       const microAmount = getMicroAmount(currency.ibcData, input.value);
 
       const [_currency, protocol] = currency.key.split("@");
@@ -303,7 +303,7 @@ async function fetchDepositCapacity() {
   const value: { [key: string]: boolean } = {};
   const data = [];
   for (const lpn of lpns ?? []) {
-    const [_currency, protocol] = lpn.key!.split("@");
+    const [_currency, protocol] = lpn.key.split("@");
 
     const fn = async () => {
       try {
@@ -315,7 +315,7 @@ async function fetchDepositCapacity() {
         const lppClient = new Lpp(cosmWasmClient, contract);
         const depositCapacity = await lppClient.getDepositCapacity();
 
-        if (Number(depositCapacity?.amount) == 0) {
+        if (Number(depositCapacity?.amount) === 0) {
           value[protocol] = false;
           maxSupply.value[protocol] = new Int(0);
         } else {
@@ -347,7 +347,7 @@ function validateSupply() {
     return "";
   }
 
-  const i = input.value.length == 0 ? "0" : input.value;
+  const i = input.value.length === 0 ? "0" : input.value;
 
   const a = CurrencyUtils.convertDenomToMinimalDenom(i, asset.ibcData, asset.decimal_digits);
 
@@ -365,7 +365,7 @@ function validateSupply() {
 }
 
 function onSelect(event: AdvancedCurrencyFieldOption) {
-  const index = assets.value.findIndex((item) => item == event);
+  const index = assets.value.findIndex((item) => item === event);
   selectedCurrency.value = index;
 }
 

--- a/src/modules/earn/components/WithdrawForm.vue
+++ b/src/modules/earn/components/WithdrawForm.vue
@@ -109,15 +109,15 @@ const configStore = useConfigStore();
 const assets = computed(() => {
   const activeProtocols = configStore.getActiveProtocolsForNetwork(configStore.protocolFilter);
   const lpns = configStore.lpn?.filter((item) => {
-    const c = configStore.currenciesData![item.key!];
-    const [_currency, protocol] = c.key!.split("@");
+    const c = configStore.currenciesData[item.key];
+    const [_currency, protocol] = c.key.split("@");
     return activeProtocols.includes(protocol);
   });
 
   const data = [];
 
   for (const lpn of lpns ?? []) {
-    const asset = lpnBalances.value.find((item) => item.key == lpn.key);
+    const asset = lpnBalances.value.find((item) => item.key === lpn.key);
     const value = new Dec(asset?.coin?.amount.toString() ?? 0, lpn.decimal_digits);
     const balance = formatTokenBalance(value);
 
@@ -178,7 +178,7 @@ const stable = computed(() => {
 });
 
 const isEmpty = computed(() => {
-  if (input.value.length == 0 || Number(input.value) == 0) {
+  if (input.value.length === 0 || Number(input.value) === 0) {
     return true;
   }
   return false;
@@ -239,7 +239,7 @@ function onInput(data: string) {
 }
 
 async function onNextClick() {
-  if (validateInputs().length == 0) {
+  if (validateInputs().length === 0) {
     try {
       await onValidateAmount();
 
@@ -260,7 +260,7 @@ async function onValidateAmount() {
     return;
   }
   const cosmWasmClient = await NolusClient.getInstance().getCosmWasmClient();
-  const currency = configStore.currenciesData![asset.value];
+  const currency = configStore.currenciesData[asset.value];
   const [_currency, protocol] = currency.key.split("@");
   const lppClient = new Lpp(cosmWasmClient, configStore.contracts[protocol].lpp);
   const data = await lppClient.getLppBalance();
@@ -280,9 +280,9 @@ async function transferAmount() {
     try {
       loading.value = true;
 
-      const currency = configStore.currenciesData![assets.value[selectedCurrency.value].value];
+      const currency = configStore.currenciesData[assets.value[selectedCurrency.value].value];
       const microAmount = getMicroAmount(currency.ibcData, input.value);
-      const asset = lpnBalances.value.find((item) => item.key == currency.key);
+      const asset = lpnBalances.value.find((item) => item.key === currency.key);
       if (!asset) {
         onShowToast({
           type: ToastType.error,
@@ -327,7 +327,7 @@ async function transferAmount() {
 }
 
 function onSelect(event: AdvancedCurrencyFieldOption) {
-  const index = assets.value.findIndex((item) => item == event);
+  const index = assets.value.findIndex((item) => item === event);
   selectedCurrency.value = index;
 }
 

--- a/src/modules/history/common.ts
+++ b/src/modules/history/common.ts
@@ -44,7 +44,7 @@ export async function message(msg: IObjectKeys, address: string, i18n: IObjectKe
         }
       ];
 
-      if (msg.from == address) {
+      if (msg.from === address) {
         return [
           i18n.t("message.send-action", {
             address: truncateString(msg.data?.toAddress),
@@ -62,7 +62,7 @@ export async function message(msg: IObjectKeys, address: string, i18n: IObjectKe
         ];
       }
 
-      if (msg.to == address) {
+      if (msg.to === address) {
         return [
           i18n.t("message.receive-action", {
             address: truncateString(msg.data.fromAddress),
@@ -82,13 +82,13 @@ export async function message(msg: IObjectKeys, address: string, i18n: IObjectKe
       return [formatMessageType(msg.type), null];
     }
     case Messages["/ibc.applications.transfer.v1.MsgTransfer"]: {
-      if (msg.from == address) {
+      if (msg.from === address) {
         const token = await fetchCurrency(msg.data.token);
 
-        const receiver = getIcon(getChainName(msg.data.receiver)!);
-        const sender = getIcon(getChainName(msg.data.sender)!);
-        const labelReceiver = getChainLabel(getChainName(msg.data.receiver)!);
-        const labelSender = getChainLabel(getChainName(msg.data.sender)!);
+        const receiver = getIcon(getChainName(msg.data.receiver));
+        const sender = getIcon(getChainName(msg.data.sender));
+        const labelReceiver = getChainLabel(getChainName(msg.data.receiver));
+        const labelSender = getChainLabel(getChainName(msg.data.sender));
 
         const steps = [
           {
@@ -131,7 +131,7 @@ export async function message(msg: IObjectKeys, address: string, i18n: IObjectKe
         ];
       }
 
-      if (msg.to == address) {
+      if (msg.to === address) {
         const token = getCurrency(msg.data.token);
         return [
           i18n.t("message.receive-action", {
@@ -152,10 +152,10 @@ export async function message(msg: IObjectKeys, address: string, i18n: IObjectKe
         const coin = parseCoins(`${data.amount}${denom}`)[0];
         delete msg.fee_denom;
 
-        const receiver = getIcon(getChainName(data.receiver)!);
-        const sender = getIcon(getChainName(data.sender)!);
-        const labelReceiver = getChainLabel(getChainName(data.receiver)!);
-        const labelSender = getChainLabel(getChainName(data.sender)!);
+        const receiver = getIcon(getChainName(data.receiver));
+        const sender = getIcon(getChainName(data.sender));
+        const labelReceiver = getChainLabel(getChainName(data.receiver));
+        const labelSender = getChainLabel(getChainName(data.sender));
 
         const detailedSteps = [
           {
@@ -301,8 +301,8 @@ export async function message(msg: IObjectKeys, address: string, i18n: IObjectKe
           const withdraw = await BackendApi.getLpWithdraw(msg.tx_hash);
           const token = CurrencyUtils.convertMinimalDenomToDenom(
             withdraw.LP_amnt_asset ?? 0,
-            lpn.ibcData!,
-            lpn.shortName!,
+            lpn.ibcData,
+            lpn.shortName,
             Number(lpn.decimal_digits)
           );
           return [
@@ -631,12 +631,12 @@ function getChainName(address: string) {
   }
 }
 
-function getIcon(prefix: string) {
+function getIcon(prefix: string | null) {
   try {
     const configStore = useConfigStore();
     const supportedNetworks = configStore.supportedNetworksData;
     for (const key in supportedNetworks) {
-      if (supportedNetworks[key].prefix == prefix) {
+      if (supportedNetworks[key].prefix === prefix) {
         return supportedNetworks[key].icon;
       }
     }
@@ -646,12 +646,12 @@ function getIcon(prefix: string) {
   }
 }
 
-function getChainLabel(prefix: string) {
+function getChainLabel(prefix: string | null) {
   try {
     const configStore = useConfigStore();
     const supportedNetworks = configStore.supportedNetworksData;
     for (const key in supportedNetworks) {
-      if (supportedNetworks[key].prefix == prefix) {
+      if (supportedNetworks[key].prefix === prefix) {
         return supportedNetworks[key].name;
       }
     }

--- a/src/modules/history/components/HistoryTableRowWrapper.vue
+++ b/src/modules/history/components/HistoryTableRowWrapper.vue
@@ -80,7 +80,7 @@ const transactionData = computed<TableRowItemProps>(() => {
 
 function getTimeStamp() {
   if (props.transaction.historyData.skipRoute) {
-    return getCreatedAtForHuman(new Date(props.transaction.historyData.id!));
+    return getCreatedAtForHuman(new Date(props.transaction.historyData.id ?? ""));
   }
   if (props.transaction.historyData.timestamp) {
     return props.transaction.historyData.timestamp;

--- a/src/modules/history/components/RealisedPnl.vue
+++ b/src/modules/history/components/RealisedPnl.vue
@@ -193,7 +193,11 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
         rects.filter((_, i) => i === barIndex).style("fill", hoverColor);
 
         tooltip.html(`<strong>${nearestData.ticker}:</strong> ${nearestData.loan}`);
-        const node = tooltip.node()!.getBoundingClientRect();
+        const tooltipNode = tooltip.node();
+        if (!tooltipNode) {
+          return;
+        }
+        const node = tooltipNode.getBoundingClientRect();
         tooltip
           .style("opacity", 1)
           .style("left", `${event.pageX - node.width / 2}px`)

--- a/src/modules/leases/components/Leases.vue
+++ b/src/modules/leases/components/Leases.vue
@@ -220,7 +220,7 @@ const leasesData = computed<TableRowItemProps[]>(() => {
   const mobile = isMobile();
   const items = networkFilteredLeases.value
     .filter((item) => {
-      if (param.length == 0) {
+      if (param.length === 0) {
         return true;
       }
       const positionTicker = item.etl_data?.lease_position_ticker ?? item.amount.ticker;

--- a/src/modules/leases/components/NewLease.test.ts
+++ b/src/modules/leases/components/NewLease.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type * as VueRouter from "vue-router";
 
 vi.hoisted(() => {
   if (typeof window !== "undefined" && !window.matchMedia) {
@@ -22,7 +23,7 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock("vue-router", async () => {
-  const actual = await vi.importActual<typeof import("vue-router")>("vue-router");
+  const actual = await vi.importActual<typeof VueRouter>("vue-router");
   return {
     ...actual,
     useRouter: () => ({ push: hoisted.routerPush }),

--- a/src/modules/leases/components/new-lease/LongForm.test.ts
+++ b/src/modules/leases/components/new-lease/LongForm.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as VueRouter from "vue-router";
+import type * as NolusJs from "@nolus/nolusjs";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -84,7 +86,7 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock("vue-router", async () => {
-  const actual = await vi.importActual<typeof import("vue-router")>("vue-router");
+  const actual = await vi.importActual<typeof VueRouter>("vue-router");
   return {
     ...actual,
     useRouter: () => ({ push: hoisted.routerPush }),
@@ -171,7 +173,7 @@ vi.mock("@/modules/leases/components/new-lease/LongLeaseDetails.vue", () => ({
 }));
 
 vi.mock("@nolus/nolusjs", async () => {
-  const actual = await vi.importActual<typeof import("@nolus/nolusjs")>("@nolus/nolusjs");
+  const actual = await vi.importActual<typeof NolusJs>("@nolus/nolusjs");
   return {
     ...actual,
     NolusClient: {

--- a/src/modules/leases/components/new-lease/LongForm.vue
+++ b/src/modules/leases/components/new-lease/LongForm.vue
@@ -212,7 +212,8 @@ import type { AssetBalance } from "@/common/stores/wallet/types";
 import { Dec, Int } from "@keplr-wallet/unit";
 import { h } from "vue";
 import { useI18n } from "vue-i18n";
-import { CurrencyUtils, NolusClient, NolusWallet } from "@nolus/nolusjs";
+import type { NolusWallet } from "@nolus/nolusjs";
+import { CurrencyUtils, NolusClient } from "@nolus/nolusjs";
 import { Leaser, type LeaseApply } from "@nolus/nolusjs/build/contracts";
 import { useRouter } from "vue-router";
 
@@ -332,21 +333,21 @@ const assets = computed(() => {
     data.push({
       name: asset.name,
       value: denom,
-      label: asset.shortName!,
-      shortName: asset.shortName!,
-      icon: asset.icon!,
-      decimal_digits: asset.decimal_digits!,
+      label: asset.shortName,
+      shortName: asset.shortName,
+      icon: asset.icon,
+      decimal_digits: asset.decimal_digits,
       balance: {
         value: exactBalance,
         customLabel: `${balance} ${asset.shortName}`,
-        ticker: asset.shortName!,
+        ticker: asset.shortName,
         denom: asset.balance?.denom,
         amount: asset.balance?.amount
       },
       ibcData: (asset as ExternalCurrency).ibcData,
-      native: asset.native!,
-      symbol: asset.symbol!,
-      ticker: asset.ticker!,
+      native: asset.native,
+      symbol: asset.symbol,
+      ticker: asset.ticker,
       key: asset.key,
       stable,
       price: formatDecAsUsd(stable)
@@ -397,7 +398,7 @@ const calculatedBalance = computed(() => {
   if (!asset) {
     return formatUsd(0);
   }
-  const price = new Dec(pricesStore.prices[asset.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[asset.key]?.price ?? 0);
   const v = amount?.value?.length ? amount?.value : "0";
   const stable = price.mul(new Dec(v));
   return formatDecAsUsd(stable);
@@ -645,7 +646,7 @@ async function openLease() {
       const tx = await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
 
       const item = tx?.events.find((item: IObjectKeys) => {
-        return item.type == WASM_EVENTS["wasm-ls-request-loan"].key;
+        return item.type === WASM_EVENTS["wasm-ls-request-loan"].key;
       });
 
       const data = item?.attributes[WASM_EVENTS["wasm-ls-request-loan"].index];

--- a/src/modules/leases/components/new-lease/LongLeaseDetails.vue
+++ b/src/modules/leases/components/new-lease/LongLeaseDetails.vue
@@ -165,7 +165,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
-  clearTimeout(time!);
+  clearTimeout(time);
 });
 
 watch(
@@ -218,7 +218,7 @@ const downPaymentAsset = computed(() => {
 });
 
 const downPaymentAmount = computed(() => {
-  const price = new Dec(pricesStore.prices[downPaymentAsset.value.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[downPaymentAsset.value.key]?.price ?? 0);
   const decimals = new Dec(10 ** downPaymentAsset.value.decimal_digits);
   const v = downPaymentStable.value;
   const amount = v.quo(price).mul(decimals);
@@ -226,14 +226,14 @@ const downPaymentAmount = computed(() => {
 });
 
 const downPaymentStable = computed(() => {
-  const price = new Dec(pricesStore.prices[downPaymentAsset.value.key!]?.price ?? 0);
-  const v = props.downpaymenAmount.length == 0 ? "0" : props.downpaymenAmount;
+  const price = new Dec(pricesStore.prices[downPaymentAsset.value.key]?.price ?? 0);
+  const v = props.downpaymenAmount.length === 0 ? "0" : props.downpaymenAmount;
   const stable = price.mul(new Dec(v));
   return stable;
 });
 
 const borrowAmount = computed(() => {
-  const price = new Dec(pricesStore.prices[asset.value.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[asset.value.key]?.price ?? 0);
   const decimals = new Dec(10 ** asset.value.decimal_digits);
   const v = borrowStable.value;
   const amount = v.quo(price).mul(decimals);
@@ -241,7 +241,7 @@ const borrowAmount = computed(() => {
 });
 
 const swapFeeAmount = computed(() => {
-  const price = new Dec(pricesStore.prices[asset.value.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[asset.value.key]?.price ?? 0);
   const decimals = new Dec(10 ** asset.value.decimal_digits);
   const v = new Dec(swapStableFee.value);
   const amount = v.quo(price).mul(decimals);
@@ -249,7 +249,7 @@ const swapFeeAmount = computed(() => {
 });
 
 const borrowStable = computed(() => {
-  const price = new Dec(pricesStore.prices[lpn.value.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[lpn.value.key]?.price ?? 0);
   const v = props.lease?.borrow?.amount ?? "0";
   const stable = price.mul(new Dec(v, lpn.value.decimal_digits));
   return stable;
@@ -283,13 +283,13 @@ const percentLique = computed(() => {
 
 function getLquidation() {
   const lease = props.lease;
-  if (lease) {
-    const unitAssetInfo = getCurrencyByTicker(lease.borrow.ticker!);
-    const stableAssetInfo = getCurrencyByTicker(lease.total.ticker!);
+  if (lease && lease.borrow.ticker && lease.total.ticker) {
+    const unitAssetInfo = getCurrencyByTicker(lease.borrow.ticker);
+    const stableAssetInfo = getCurrencyByTicker(lease.total.ticker);
 
-    const unitAsset = new Dec(getBorrowedAmount(), Number(unitAssetInfo!.decimal_digits));
+    const unitAsset = new Dec(getBorrowedAmount(), Number(unitAssetInfo.decimal_digits));
 
-    const stableAsset = new Dec(getTotalAmount(), Number(stableAssetInfo!.decimal_digits));
+    const stableAsset = new Dec(getTotalAmount(), Number(stableAssetInfo.decimal_digits));
     return LeaseUtils.calculateLiquidation(unitAsset, stableAsset);
   }
 
@@ -313,8 +313,9 @@ function getTotalAmount() {
 }
 
 async function setSwapFee() {
-  clearTimeout(time!);
-  if (props.lease) {
+  clearTimeout(time);
+  const lease = props.lease;
+  if (lease) {
     time = setTimeout(async () => {
       const currency = downPaymentAsset.value;
       const [_, p] = asset.value.key.split("@");
@@ -335,7 +336,7 @@ async function setSwapFee() {
 
           return Number(data?.swap_price_impact_percent ?? 0);
         }),
-        SkipRouter.getRoute(lpn.ibcData, asset.value.ibcData, props.lease!.borrow.amount).then((data) => {
+        SkipRouter.getRoute(lpn.ibcData, asset.value.ibcData, lease.borrow.amount).then((data) => {
           amountIn += Number(data.usd_amount_in ?? 0);
           amountOut += Number(data.usd_amount_out ?? 0);
 

--- a/src/modules/leases/components/new-lease/PositionPreviewChart.vue
+++ b/src/modules/leases/components/new-lease/PositionPreviewChart.vue
@@ -76,13 +76,13 @@ async function setStats() {
   responses.value = [
     {
       name: i18n.t("message.borrowed-taxes"),
-      value: v1 == 0 ? zero : v1,
+      value: v1 === 0 ? zero : v1,
       ticker: `${new Dec(props.borrowAmount, props.borrowAsset?.decimal_digits ?? 0).toString(props.borrowAsset?.decimal_digits ?? 0)} ${props.borrowAsset?.shortName ?? ""}`,
       price: formatDecAsUsd(props.borrowStable)
     },
     {
       name: i18n.t("message.downpayment"),
-      value: v2 == 0 ? zero : v2,
+      value: v2 === 0 ? zero : v2,
       ticker: `${new Dec(props.downPaymentAmount, props.downPaymentAsset?.decimal_digits ?? 0).toString(props.downPaymentAsset?.decimal_digits ?? 0)} ${props.downPaymentAsset?.shortName ?? ""}`,
       price: formatDecAsUsd(props.downPaymentStable)
     }
@@ -201,7 +201,11 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
           )}`
         );
 
-        const node = tooltip.node()!.getBoundingClientRect();
+        const tooltipNode = tooltip.node();
+        if (!tooltipNode) {
+          return;
+        }
+        const node = tooltipNode.getBoundingClientRect();
         const height = node.height;
         const width = node.width;
 

--- a/src/modules/leases/components/new-lease/ShortForm.test.ts
+++ b/src/modules/leases/components/new-lease/ShortForm.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as VueRouter from "vue-router";
+import type * as NolusJs from "@nolus/nolusjs";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -116,7 +118,7 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock("vue-router", async () => {
-  const actual = await vi.importActual<typeof import("vue-router")>("vue-router");
+  const actual = await vi.importActual<typeof VueRouter>("vue-router");
   return {
     ...actual,
     useRouter: () => ({ push: hoisted.routerPush }),
@@ -200,7 +202,7 @@ vi.mock("@/modules/leases/components/new-lease/ShortLeaseDetails.vue", () => ({
 }));
 
 vi.mock("@nolus/nolusjs", async () => {
-  const actual = await vi.importActual<typeof import("@nolus/nolusjs")>("@nolus/nolusjs");
+  const actual = await vi.importActual<typeof NolusJs>("@nolus/nolusjs");
   return {
     ...actual,
     NolusClient: {

--- a/src/modules/leases/components/new-lease/ShortForm.vue
+++ b/src/modules/leases/components/new-lease/ShortForm.vue
@@ -213,7 +213,8 @@ import type { AssetBalance } from "@/common/stores/wallet/types";
 import { Dec, Int } from "@keplr-wallet/unit";
 import { h } from "vue";
 import { useI18n } from "vue-i18n";
-import { CurrencyUtils, NolusClient, NolusWallet } from "@nolus/nolusjs";
+import type { NolusWallet } from "@nolus/nolusjs";
+import { CurrencyUtils, NolusClient } from "@nolus/nolusjs";
 import { Leaser, type LeaseApply } from "@nolus/nolusjs/build/contracts";
 import { useRouter } from "vue-router";
 
@@ -328,21 +329,21 @@ const assets = computed(() => {
     data.push({
       name: asset.name,
       value: denom,
-      label: asset.shortName!,
-      shortName: asset.shortName!,
-      icon: asset.icon!,
-      decimal_digits: asset.decimal_digits!,
+      label: asset.shortName,
+      shortName: asset.shortName,
+      icon: asset.icon,
+      decimal_digits: asset.decimal_digits,
       balance: {
         value: exactBalance,
         customLabel: `${balance} ${asset.shortName}`,
-        ticker: asset.shortName!,
+        ticker: asset.shortName,
         denom: asset.balance.denom,
         amount: asset.balance?.amount
       },
       ibcData: (asset as ExternalCurrency).ibcData,
-      native: asset.native!,
-      symbol: asset.symbol!,
-      ticker: asset.ticker!,
+      native: asset.native,
+      symbol: asset.symbol,
+      ticker: asset.ticker,
       key: asset.key,
       stable,
       price: formatDecAsUsd(stable)
@@ -390,7 +391,7 @@ const calculatedBalance = computed(() => {
     return formatUsd(0);
   }
 
-  const price = new Dec(pricesStore.prices[asset.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[asset.key]?.price ?? 0);
   const v = amount?.value?.length ? amount?.value : "0";
   const stable = price.mul(new Dec(v));
   return formatDecAsUsd(stable);
@@ -637,7 +638,7 @@ async function openLease() {
       const tx = await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
 
       const item = tx?.events.find((item: IObjectKeys) => {
-        return item.type == WASM_EVENTS["wasm-ls-request-loan"].key;
+        return item.type === WASM_EVENTS["wasm-ls-request-loan"].key;
       });
 
       const data = item?.attributes[WASM_EVENTS["wasm-ls-request-loan"].index];

--- a/src/modules/leases/components/new-lease/ShortLeaseDetails.vue
+++ b/src/modules/leases/components/new-lease/ShortLeaseDetails.vue
@@ -167,7 +167,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
-  clearTimeout(time!);
+  clearTimeout(time);
 });
 
 watch(
@@ -208,7 +208,7 @@ const totalLoan = computed(() => {
   if (!props.lease?.total?.amount) {
     return "0";
   }
-  const price = new Dec(pricesStore.prices[asset.value.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[asset.value.key]?.price ?? 0);
   if (!price.isPositive()) {
     return "0";
   }
@@ -236,12 +236,12 @@ const downPaymentAsset = computed(() => {
 });
 
 const loanAsset = computed(() => {
-  const currency = configStore.currenciesData![props.loanCurrency];
+  const currency = configStore.currenciesData[props.loanCurrency];
   return currency;
 });
 
 const downPaymentAmount = computed(() => {
-  const price = new Dec(pricesStore.prices[downPaymentAsset.value.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[downPaymentAsset.value.key]?.price ?? 0);
   const decimals = new Dec(10 ** downPaymentAsset.value.decimal_digits);
   const v = downPaymentStable.value;
   const amount = v.quo(price).mul(decimals);
@@ -249,14 +249,14 @@ const downPaymentAmount = computed(() => {
 });
 
 const downPaymentStable = computed(() => {
-  const price = new Dec(pricesStore.prices[downPaymentAsset.value.key!]?.price ?? 0);
-  const v = props.downpaymenAmount.length == 0 ? "0" : props.downpaymenAmount;
+  const price = new Dec(pricesStore.prices[downPaymentAsset.value.key]?.price ?? 0);
+  const v = props.downpaymenAmount.length === 0 ? "0" : props.downpaymenAmount;
   const stable = price.mul(new Dec(v));
   return stable;
 });
 
 const borrowAmount = computed(() => {
-  const price = new Dec(pricesStore.prices[asset.value.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[asset.value.key]?.price ?? 0);
   const decimals = new Dec(10 ** lpn.value.decimal_digits);
   const v = borrowStable.value;
   const amount = v.quo(price).mul(decimals);
@@ -264,7 +264,7 @@ const borrowAmount = computed(() => {
 });
 
 const swapFeeAmount = computed(() => {
-  const price = new Dec(pricesStore.prices[asset.value.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[asset.value.key]?.price ?? 0);
   const decimals = new Dec(10 ** lpn.value.decimal_digits);
   const v = new Dec(swapStableFee.value);
   const amount = v.quo(price).mul(decimals);
@@ -272,7 +272,7 @@ const swapFeeAmount = computed(() => {
 });
 
 const borrowStable = computed(() => {
-  const price = new Dec(pricesStore.prices[lpn.value.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[lpn.value.key]?.price ?? 0);
   const v = props.lease?.borrow?.amount ?? "0";
   const stable = price.mul(new Dec(v, lpn.value.decimal_digits));
   return stable;
@@ -313,13 +313,13 @@ const percentLique = computed(() => {
 
 function getLquidation() {
   const lease = props.lease;
-  if (lease) {
-    const unitAssetInfo = getCurrencyByTicker(lease.borrow.ticker!);
-    const stableAssetInfo = getCurrencyByTicker(lease.total.ticker!);
+  if (lease && lease.borrow.ticker && lease.total.ticker) {
+    const unitAssetInfo = getCurrencyByTicker(lease.borrow.ticker);
+    const stableAssetInfo = getCurrencyByTicker(lease.total.ticker);
 
-    const unitAsset = new Dec(getBorrowedAmount(), Number(unitAssetInfo!.decimal_digits));
+    const unitAsset = new Dec(getBorrowedAmount(), Number(unitAssetInfo.decimal_digits));
 
-    const stableAsset = new Dec(getTotalAmount(), Number(stableAssetInfo!.decimal_digits));
+    const stableAsset = new Dec(getTotalAmount(), Number(stableAssetInfo.decimal_digits));
     return LeaseUtils.calculateLiquidationShort(stableAsset, unitAsset);
   }
 
@@ -343,8 +343,9 @@ function getTotalAmount() {
 }
 
 const setSwapFee = async () => {
-  clearTimeout(time!);
-  if (!props.lease) return;
+  clearTimeout(time);
+  const lease = props.lease;
+  if (!lease) return;
   time = setTimeout(async () => {
     const currency = downPaymentAsset.value;
     const [_, p] = asset.value.key.split("@");
@@ -354,7 +355,7 @@ const setSwapFee = async () => {
     // e.g. USDC_NOBLE) — NOT to asset.value (the borrowed/shorted asset, which
     // on a Short protocol is the same as the LPN). Routing source→source is a
     // no-op and Skip returns a zero fee, so the UI showed 0.00 BTC.
-    const stableTicker = props.lease!.total?.ticker;
+    const stableTicker = lease.total?.ticker;
     const stable = stableTicker ? configStore.currenciesData?.[`${stableTicker}@${p}`] : null;
     if (!stable) return;
 
@@ -374,7 +375,7 @@ const setSwapFee = async () => {
 
         return Number(data?.swap_price_impact_percent ?? 0);
       }),
-      SkipRouter.getRoute(lpn.ibcData, stable.ibcData, props.lease!.borrow.amount).then((data) => {
+      SkipRouter.getRoute(lpn.ibcData, stable.ibcData, lease.borrow.amount).then((data) => {
         amountIn += Number(data.usd_amount_in ?? 0);
         amountOut += Number(data.usd_amount_out ?? 0);
 

--- a/src/modules/leases/components/single-lease/CloseDialog.test.ts
+++ b/src/modules/leases/components/single-lease/CloseDialog.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as VueRouter from "vue-router";
+import type * as NolusJs from "@nolus/nolusjs";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -101,7 +103,7 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock("vue-router", async () => {
-  const actual = await vi.importActual<typeof import("vue-router")>("vue-router");
+  const actual = await vi.importActual<typeof VueRouter>("vue-router");
   return {
     ...actual,
     useRoute: () => hoisted.routeRef,
@@ -208,7 +210,7 @@ vi.mock("@/common/utils/SkipRoute", () => ({
 // Use real CurrencyUtils (Dec math) so computed properties don't crash.
 // Only mock NolusClient for the contract call path.
 vi.mock("@nolus/nolusjs", async () => {
-  const actual = await vi.importActual<typeof import("@nolus/nolusjs")>("@nolus/nolusjs");
+  const actual = await vi.importActual<typeof NolusJs>("@nolus/nolusjs");
   return {
     ...actual,
     NolusClient: {

--- a/src/modules/leases/components/single-lease/CloseDialog.vue
+++ b/src/modules/leases/components/single-lease/CloseDialog.vue
@@ -286,7 +286,8 @@ import type { ExternalCurrency } from "@/common/types";
 import { MAX_DECIMALS, minimumLeaseAmount, PERCENT } from "@/config/global";
 import type { AssetBalance } from "@/common/stores/wallet/types";
 import { CoinPretty, Dec, Int } from "@keplr-wallet/unit";
-import { CurrencyUtils, NolusClient, NolusWallet } from "@nolus/nolusjs";
+import type { NolusWallet } from "@nolus/nolusjs";
+import { CurrencyUtils, NolusClient } from "@nolus/nolusjs";
 import { SkipRouter } from "@/common/utils/SkipRoute";
 import { useI18n } from "vue-i18n";
 import type { Coin } from "@cosmjs/proto-signing";
@@ -367,7 +368,7 @@ const assets = computed(() => {
 
   if (lease.value && lease.value.status === "opened") {
     const ticker = lease.value.amount.ticker;
-    const asset = configStore.currenciesData![`${ticker}@${lease.value.protocol}`];
+    const asset = configStore.currenciesData[`${ticker}@${lease.value.protocol}`];
 
     // Version skew / config lag: chain returned a ticker we don't know about locally.
     // Bail out with empty assets so the component doesn't crash. The matching watcher
@@ -385,7 +386,7 @@ const assets = computed(() => {
       label: asset.shortName,
       ibcData: asset.ibcData,
       shortName: asset.shortName,
-      decimal_digits: asset.decimal_digits!,
+      decimal_digits: asset.decimal_digits,
       key: asset.key,
       ticker: asset.ticker
     });
@@ -418,9 +419,10 @@ const currency = computed(() => {
 });
 
 const price = computed(() => {
-  const positionType = configStore.getPositionType(lease.value!.protocol);
+  if (!lease.value) return "0";
+  const positionType = configStore.getPositionType(lease.value.protocol);
   if (positionType === "Short") {
-    const lpn = getLpnByProtocol(lease.value!.protocol);
+    const lpn = getLpnByProtocol(lease.value.protocol);
     return new Dec(pricesStore.prices[lpn?.key]?.price, lpn?.decimal_digits).toString(lpn?.decimal_digits);
   } else {
     return new Dec(pricesStore.prices[currency.value?.key]?.price, currency.value?.decimal_digits).toString(
@@ -432,12 +434,13 @@ const price = computed(() => {
 const priceUsd = computed(() => formatPriceUsd(price.value));
 
 const remaining = computed(() => {
-  const data = getAmountValue(amount.value == "" ? "0" : amount.value);
-  const positionType = configStore.getPositionType(lease.value!.protocol);
-  const lpn = getLpnByProtocol(lease.value!.protocol);
+  if (!lease.value) return "";
+  const data = getAmountValue(amount.value === "" ? "0" : amount.value);
+  const positionType = configStore.getPositionType(lease.value.protocol);
+  const lpn = getLpnByProtocol(lease.value.protocol);
 
   if (positionType === "Short") {
-    const price = new Dec(pricesStore.prices[lpn.key!]?.price ?? 0);
+    const price = new Dec(pricesStore.prices[lpn.key]?.price ?? 0);
     const stable = data.amount.toDec().quo(price);
     return `${formatTokenBalance(stable)} ${lpn.shortName}`;
   } else {
@@ -446,11 +449,12 @@ const remaining = computed(() => {
 });
 
 const paidDebt = computed(() => {
-  const positionType = configStore.getPositionType(lease.value!.protocol);
-  const lpn = getLpnByProtocol(lease.value!.protocol);
+  if (!lease.value) return formatUsd(0);
+  const positionType = configStore.getPositionType(lease.value.protocol);
+  const lpn = getLpnByProtocol(lease.value.protocol);
 
   if (positionType === "Short") {
-    const price = new Dec(pricesStore.prices[lpn.key!]?.price ?? 0);
+    const price = new Dec(pricesStore.prices[lpn.key]?.price ?? 0);
     const v = amount?.value?.length ? amount?.value : "0";
     const stable = new Dec(v).quo(price);
     return `${formatTokenBalance(stable)} ${lpn.shortName}`;
@@ -459,7 +463,7 @@ const paidDebt = computed(() => {
     if (!asset) {
       return formatUsd(0);
     }
-    const price = new Dec(pricesStore.prices[asset.key!]?.price ?? 0);
+    const price = new Dec(pricesStore.prices[asset.key]?.price ?? 0);
     const v = amount?.value?.length ? amount?.value : "0";
     const stable = price.mul(new Dec(v));
     return `${formatTokenBalance(stable)} ${lpn.shortName}`;
@@ -477,7 +481,7 @@ const debtData = computed(() => {
       const sd = shortDebtAtom.value;
       if (!sd) return { debt: "", price: "", asset: "", fee: "" };
       const debtTicker = lease.value.debt.ticker;
-      const debtCurrency = configStore.currenciesData![`${debtTicker}@${lease.value.protocol}`];
+      const debtCurrency = configStore.currenciesData[`${debtTicker}@${lease.value.protocol}`];
       const currentDebtPrice = new Dec(pricesStore.prices[`${debtTicker}@${lease.value.protocol}`]?.price ?? "1");
       const value = new Dec(amount.value.length ? amount.value : "0").mul(new Dec(swapFee.value));
       return {
@@ -488,7 +492,7 @@ const debtData = computed(() => {
       };
     } else {
       const ticker = lease.value.etl_data?.lease_position_ticker ?? lease.value.amount.ticker;
-      const currecy = configStore.currenciesData![`${ticker}@${lease.value.protocol}`];
+      const currecy = configStore.currenciesData[`${ticker}@${lease.value.protocol}`];
       if (!currecy) {
         return { debt: "", price: "", asset: "", fee: "" };
       }
@@ -561,7 +565,7 @@ const lpn = computed(() => {
 
   for (const lpn of configStore.lpn ?? []) {
     const [_, p] = lpn.key.split("@");
-    if (p == protocol) {
+    if (p === protocol) {
       return lpn.shortName;
     }
   }
@@ -571,10 +575,10 @@ const lpn = computed(() => {
 const payout = computed(() => {
   if (!lease.value || lease.value.status !== "opened") return "0.00";
   const ticker = lease.value.amount.ticker;
-  const currencyData = configStore.currenciesData![`${ticker}@${lease.value.protocol}`];
+  const currencyData = configStore.currenciesData[`${ticker}@${lease.value.protocol}`];
   if (!currencyData) return "0.00";
-  const price = new Dec(pricesStore.prices[currencyData!.key as string]?.price ?? 0);
-  const value = new Dec(amount.value.length == 0 ? 0 : amount.value).mul(price);
+  const price = new Dec(pricesStore.prices[currencyData.key as string]?.price ?? 0);
+  const value = new Dec(amount.value.length === 0 ? 0 : amount.value).mul(price);
 
   const outStanding = getAmountValue("0").amountInStable.toDec();
   let payOutValue = value.sub(outStanding);
@@ -587,7 +591,7 @@ const payout = computed(() => {
   const lpnData = getLpnByProtocol(lease.value.protocol);
 
   if (positionType === "Short") {
-    const lpnPrice = new Dec(pricesStore.prices[lpnData!.key as string].price);
+    const lpnPrice = new Dec(pricesStore.prices[lpnData.key as string].price);
     payOutValue = payOutValue.quo(lpnPrice);
   }
 
@@ -598,17 +602,17 @@ const positionLeft = computed(() => {
   if (!lease.value || lease.value.status !== "opened") return "0.00";
 
   const ticker = lease.value.amount.ticker;
-  const currencyData = configStore.currenciesData![`${ticker}@${lease.value.protocol}`];
+  const currencyData = configStore.currenciesData[`${ticker}@${lease.value.protocol}`];
   if (!currencyData) return "0.00";
-  const a = new Dec(lease.value.amount.amount, Number(currencyData!.decimal_digits));
-  const value = new Dec(amount.value.length == 0 ? 0 : amount.value);
+  const a = new Dec(lease.value.amount.amount, Number(currencyData.decimal_digits));
+  const value = new Dec(amount.value.length === 0 ? 0 : amount.value);
   const left = a.sub(value);
 
   if (left.isNegative()) {
     return "0.00";
   }
 
-  return `${left.toString(Number(currencyData!.decimal_digits))} ${currencyData!.shortName}`;
+  return `${left.toString(Number(currencyData.decimal_digits))} ${currencyData.shortName}`;
 });
 
 // For short positions: stable values derived directly from chain data and current
@@ -622,7 +626,7 @@ const shortDebtAtom = computed(() => {
   if (positionType !== "Short" || !lease.value || !displayData.value || lease.value.status !== "opened") return null;
 
   const debtTicker = lease.value.debt.ticker;
-  const debtCurrency = configStore.currenciesData![`${debtTicker}@${lease.value.protocol}`];
+  const debtCurrency = configStore.currenciesData[`${debtTicker}@${lease.value.protocol}`];
 
   return { amount: displayData.value.totalDebt, symbol: debtCurrency.shortName };
 });
@@ -677,7 +681,7 @@ const calculatedBalance = computed(() => {
   if (!asset) {
     return formatUsd(0);
   }
-  const price = new Dec(pricesStore.prices[asset.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[asset.key]?.price ?? 0);
   const v = amount?.value?.length ? amount?.value : "0";
   const stable = price.mul(new Dec(v));
   return formatDecAsUsd(stable);
@@ -694,7 +698,7 @@ const midPosition = computed(() => {
 
 function handleAmountChange(event: string) {
   amount.value = event;
-  if (amount.value != "") {
+  if (amount.value !== "") {
     let percent = new Dec(amount.value).quo(total.value).mul(new Dec(100));
     if (percent.isNegative()) {
       percent = new Dec(0);
@@ -723,8 +727,12 @@ async function setSwapFee() {
   time = setTimeout(async () => {
     const lease_currency = currency.value;
     const lpnCurrency = getLpnByProtocol(lease.value?.protocol as string);
+    const debtValue = debt.value;
+    if (!debtValue || !lpnCurrency) {
+      return;
+    }
     let microAmount = CurrencyUtils.convertDenomToMinimalDenom(
-      debt.value!.amount.toDec().toString(),
+      debtValue.amount.toDec().toString(),
       lease_currency.ibcData,
       lease_currency.decimal_digits
     ).amount.toString();
@@ -733,16 +741,16 @@ async function setSwapFee() {
     let amountOut = 0;
 
     const positionType = configStore.getPositionType(lease.value?.protocol as string);
-    if (positionType === "Short" && lpnCurrency) {
+    if (positionType === "Short") {
       microAmount = CurrencyUtils.convertDenomToMinimalDenom(
-        debt.value!.amount.toDec().toString(),
+        debtValue.amount.toDec().toString(),
         lpnCurrency.ibcData,
         lpnCurrency.decimal_digits
       ).amount.toString();
     }
 
     await Promise.all([
-      SkipRouter.getRoute(lease_currency.ibcData, lpnCurrency!.ibcData, microAmount).then((data) => {
+      SkipRouter.getRoute(lease_currency.ibcData, lpnCurrency.ibcData, microAmount).then((data) => {
         amountIn += Number(data.usd_amount_in ?? 0);
         amountOut += Number(data.usd_amount_out ?? 0);
 
@@ -768,11 +776,15 @@ function isAmountValid() {
   amountErrorMsg.value = "";
   if (lease.value && lease.value.status === "opened") {
     const a = amount.value;
-    const currencyData = configStore.currenciesData![`${lease.value.amount.ticker}@${lease.value.protocol}`];
+    const currencyData = configStore.currenciesData[`${lease.value.amount.ticker}@${lease.value.protocol}`];
     const debtAmount = new Dec(lease.value.amount.amount, Number(currencyData.decimal_digits));
-    const minAssetTicker = minAsset.value!.ticker;
-    const minAmountCurrency = getCurrencyByTicker(minAssetTicker)!;
-    let minAmont = new Dec(minAsset.value!.amount, Number(minAmountCurrency.decimal_digits));
+    const minAssetSpec = minAsset.value;
+    if (!minAssetSpec) {
+      throw new Error("Minimum asset spec not available");
+    }
+    const minAssetTicker = minAssetSpec.ticker;
+    const minAmountCurrency = getCurrencyByTicker(minAssetTicker);
+    let minAmont = new Dec(minAssetSpec.amount, Number(minAmountCurrency.decimal_digits));
 
     const positionType = configStore.getPositionType(lease.value.protocol);
     if (positionType === "Short") {
@@ -782,7 +794,7 @@ function isAmountValid() {
     const price = new Dec(pricesStore.prices[currencyData.key as string].price);
 
     const minAmountTemp = new Dec(minimumLeaseAmount);
-    const amountInStable = new Dec(a.length == 0 ? "0" : a).mul(price);
+    const amountInStable = new Dec(a.length === 0 ? "0" : a).mul(price);
     if (amount.value || amount.value !== "") {
       const amountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(a, "", Number(currencyData.decimal_digits));
       const value = new Dec(amountInMinimalDenom.amount, Number(currencyData.decimal_digits));
@@ -832,7 +844,7 @@ function getRepayment(p: number) {
 
   const amount = outStandingDebt();
   const ticker = lease.value.debt.ticker;
-  const c = configStore.currenciesData![`${ticker}@${lease.value.protocol}`];
+  const c = configStore.currenciesData[`${ticker}@${lease.value.protocol}`];
 
   const amountToRepay = CurrencyUtils.convertMinimalDenomToDenom(
     amount.toString(),
@@ -850,7 +862,7 @@ function getRepayment(p: number) {
   }
 
   const positionType = configStore.getPositionType(lease.value.protocol);
-  const price = getPrice()!;
+  const price = getPrice();
 
   if (positionType === "Short") {
     // For short positions, debt is in the debt asset (e.g. ATOM).
@@ -860,7 +872,7 @@ function getRepayment(p: number) {
     const SHORT_PRICE_BUFFER = new Dec("1.01");
     const debtTicker = lease.value.debt.ticker;
     const debtAssetPrice = new Dec(pricesStore.prices[`${debtTicker}@${lease.value.protocol}`]?.price ?? "1");
-    const selected_asset_price = new Dec(pricesStore.prices[selectedCurrency!.key as string].price);
+    const selected_asset_price = new Dec(pricesStore.prices[selectedCurrency.key as string].price);
     const repayment = repaymentInStable.mul(debtAssetPrice).mul(SHORT_PRICE_BUFFER);
     return {
       repayment: repayment.quo(selected_asset_price),
@@ -870,7 +882,7 @@ function getRepayment(p: number) {
   } else {
     // Oracle hiccup / missing feed: dividing by zero throws `RangeError: Division by zero`.
     // The calling action surfaces a user-facing toast; here we just bail out safely.
-    if (price.isZero()) {
+    if (!price || price.isZero()) {
       return undefined;
     }
     const repayment = repaymentInStable.quo(price);
@@ -990,7 +1002,7 @@ function getAmountValue(a: string) {
   const lpnData = getLpnByProtocol(protocolKey);
 
   const amount = new Dec(a);
-  const price = new Dec(pricesStore.prices[selectedCurrency!.key as string]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[selectedCurrency.key as string]?.price ?? 0);
   const repaymentData = getRepayment(100);
   const repayment = repaymentData?.repayment ?? new Dec(0);
   const repaymentInStable = repaymentData?.repaymentInStable ?? new Dec(0);

--- a/src/modules/leases/components/single-lease/LeaseLogWidget.vue
+++ b/src/modules/leases/components/single-lease/LeaseLogWidget.vue
@@ -66,9 +66,10 @@ const columns = computed<TableColumnProps[]>(() => [
 ]);
 
 const leasesHistory = computed(() => {
+  const protocol = props.lease?.protocol ?? "";
   return (props.lease?.etl_data?.history ?? []).map((item) => {
     const ticker = item.symbol ?? "";
-    const currency = configStore.currenciesData?.[`${ticker}@${props.lease!.protocol}`];
+    const currency = configStore.currenciesData?.[`${ticker}@${protocol}`];
     const amountDec = new Dec(item.amount ?? "0", currency?.decimal_digits);
     const amountLabel = mobile ? formatMobileAmount(amountDec) : formatTokenBalance(amountDec);
     return {

--- a/src/modules/leases/components/single-lease/PnlOverTimeChart.vue
+++ b/src/modules/leases/components/single-lease/PnlOverTimeChart.vue
@@ -205,7 +205,13 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
 
         tooltip.html(`<strong>${i18n.t("message.amount")}:</strong> ${formatUsd(closestData.amount)}`);
 
-        const node = tooltip.node()!.getBoundingClientRect();
+        const tooltipNode = tooltip.node();
+
+        if (!tooltipNode) {
+          return;
+        }
+
+        const node = tooltipNode.getBoundingClientRect();
         const height = node.height;
         const width = node.width;
 

--- a/src/modules/leases/components/single-lease/PositionSummaryWidget.test.ts
+++ b/src/modules/leases/components/single-lease/PositionSummaryWidget.test.ts
@@ -13,6 +13,7 @@
  * decimals). Keep these tests green to prevent that returning.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as VueRouter from "vue-router";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -72,7 +73,7 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock("vue-router", async () => {
-  const actual = await vi.importActual<typeof import("vue-router")>("vue-router");
+  const actual = await vi.importActual<typeof VueRouter>("vue-router");
   return { ...actual, useRouter: () => ({ push: vi.fn() }) };
 });
 
@@ -365,7 +366,7 @@ describe("PositionSummaryWidget — Size rounding", () => {
         .findAllComponents({ name: "BigNumber" })
         .find((w) => w.props("label") === "message.interest-due");
       expect(bn).toBeTruthy();
-      const amount = bn!.props("amount") as BigNumberAmount;
+      const amount = bn?.props("amount") as BigNumberAmount;
       // Must go through the microAmount path with the volatile's decimals so
       // TokenAmount's adaptive renderer can show sat-level amounts. Passing
       // `decimals: 2` here would cut off crypto precision.
@@ -381,7 +382,7 @@ describe("PositionSummaryWidget — Size rounding", () => {
         .findAllComponents({ name: "BigNumber" })
         .find((w) => w.props("label") === "message.interest-due");
       expect(bn).toBeTruthy();
-      const amount = bn!.props("amount") as BigNumberAmount;
+      const amount = bn?.props("amount") as BigNumberAmount;
       expect(amount.decimals).toBe(hoisted.USDC.decimal_digits);
       expect(amount.denom).toBe(hoisted.USDC.shortName);
       expect(amount.microAmount).toBeDefined();

--- a/src/modules/leases/components/single-lease/PositionSummaryWidget.vue
+++ b/src/modules/leases/components/single-lease/PositionSummaryWidget.vue
@@ -247,7 +247,8 @@ import { useHistoryStore } from "@/common/stores/history";
 import { Dec } from "@keplr-wallet/unit";
 import { formatNumber, getAdaptivePriceDecimals } from "@/common/utils/NumberFormatUtils";
 import { getCurrencyByTicker, getCurrencyByDenom, getLpnByProtocol } from "@/common/utils/CurrencyLookup";
-import { NolusClient, NolusWallet } from "@nolus/nolusjs";
+import type { NolusWallet } from "@nolus/nolusjs";
+import { NolusClient } from "@nolus/nolusjs";
 import { dateParser, IntercomService, isMobile, Logger, walletOperation } from "@/common/utils";
 import { useRouter } from "vue-router";
 import { SingleLeaseDialog } from "@/modules/leases/enums";
@@ -389,7 +390,7 @@ const pricerPerAsset = computed(() => {
   } else if (posType === "short") {
     const p = props.lease?.protocol as string;
     const debtTicker = props.lease?.debt?.ticker;
-    const currency = configStore.currenciesData![`${debtTicker}@${p}`];
+    const currency = configStore.currenciesData[`${debtTicker}@${p}`];
     return currency;
   }
   return asset.value;

--- a/src/modules/leases/components/single-lease/PriceOverTimeChart.vue
+++ b/src/modules/leases/components/single-lease/PriceOverTimeChart.vue
@@ -143,7 +143,7 @@ async function loadData(intetval: string) {
   if (positionType === "Long") {
     const [key, protocol]: string[] = ticker?.includes("@")
       ? ticker.split("@")
-      : [ticker as string, props.lease!.protocol];
+      : [ticker as string, props.lease?.protocol ?? ""];
 
     const prices = await analyticsStore.fetchPriceSeries(key, protocol, intetval);
     return prices;
@@ -299,7 +299,13 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
             : "";
         tooltip.html(`<strong>${i18n.t("message.price")}:</strong> ${formatUsd(closestData.Price)}${liquidationHtml}`);
 
-        const node = tooltip.node()!.getBoundingClientRect();
+        const tooltipNode = tooltip.node();
+
+        if (!tooltipNode) {
+          return;
+        }
+
+        const node = tooltipNode.getBoundingClientRect();
         const height = node.height;
         const width = node.width;
 

--- a/src/modules/leases/components/single-lease/RepayDialog.test.ts
+++ b/src/modules/leases/components/single-lease/RepayDialog.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type * as VueRouter from "vue-router";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -95,7 +96,7 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock("vue-router", async () => {
-  const actual = await vi.importActual<typeof import("vue-router")>("vue-router");
+  const actual = await vi.importActual<typeof VueRouter>("vue-router");
   return {
     ...actual,
     useRoute: () => hoisted.routeRef,

--- a/src/modules/leases/components/single-lease/RepayDialog.vue
+++ b/src/modules/leases/components/single-lease/RepayDialog.vue
@@ -146,7 +146,8 @@ import { minimumLeaseAmount } from "@/config/global";
 import type { AssetBalance } from "@/common/stores/wallet/types";
 import { CoinPretty, Dec, Int } from "@keplr-wallet/unit";
 
-import { CurrencyUtils, NolusClient, NolusWallet } from "@nolus/nolusjs";
+import type { NolusWallet } from "@nolus/nolusjs";
+import { CurrencyUtils, NolusClient } from "@nolus/nolusjs";
 import { useI18n } from "vue-i18n";
 import type { Coin } from "@cosmjs/proto-signing";
 import { Lease } from "@nolus/nolusjs/build/contracts";
@@ -218,7 +219,7 @@ function onSetAmount(percent: number) {
   const a = getRepayment(percent);
   sliderValue.value = percent;
   sliderValueDec.value = new Dec(percent);
-  amount.value = a?.repayment ? a.repayment.toString(currency!.value.decimal_digits) : "";
+  amount.value = a?.repayment ? a.repayment.toString(currency.value.decimal_digits) : "";
 }
 
 const assets = computed(() => {
@@ -234,21 +235,21 @@ const assets = computed(() => {
     data.push({
       name: asset.name,
       value: denom,
-      label: asset.shortName!,
-      shortName: asset.shortName!,
-      icon: asset.icon!,
-      decimal_digits: asset.decimal_digits!,
+      label: asset.shortName,
+      shortName: asset.shortName,
+      icon: asset.icon,
+      decimal_digits: asset.decimal_digits,
       balance: {
         value: exactBalance,
         customLabel: `${balance} ${asset.shortName}`,
-        ticker: asset.shortName!,
+        ticker: asset.shortName,
         denom: asset.balance.denom,
         amount: asset.balance?.amount
       },
       ibcData: (asset as ExternalCurrency).ibcData,
-      native: asset.native!,
-      symbol: asset.symbol!,
-      ticker: asset.ticker!,
+      native: asset.native,
+      symbol: asset.symbol,
+      ticker: asset.ticker,
       key: asset.key,
       stable,
       price: formatDecAsUsd(stable)
@@ -262,7 +263,7 @@ const calculatedBalance = computed(() => {
   if (!asset) {
     return formatUsd(0);
   }
-  const price = new Dec(pricesStore.prices[asset.key!]?.price ?? 0);
+  const price = new Dec(pricesStore.prices[asset.key]?.price ?? 0);
   const v = amount?.value?.length ? amount?.value : "0";
   const stable = price.mul(new Dec(v));
   return formatDecAsUsd(stable);
@@ -277,23 +278,24 @@ const balances = computed(() => {
   if (positionType === "Short") {
     // Short: debt is in LPN (e.g. USDC_NOBLE), use debt.ticker
     const debtTicker = lease.value.debt.ticker;
-    repaymentCurrency = configStore.currenciesData![`${debtTicker}@${lease.value.protocol}`];
+    repaymentCurrency = configStore.currenciesData[`${debtTicker}@${lease.value.protocol}`];
   } else {
     // Long: debt is in LPN (e.g. USDC)
     repaymentCurrency = getLpnByProtocol(lease.value.protocol);
   }
 
   if (!repaymentCurrency) return [];
+  const resolvedCurrency = repaymentCurrency;
 
   // Use the protocol-specific currency directly (not a cross-protocol find by ibcData)
   // to ensure the .key matches the price entry in pricesStore.
-  const walletBalance = balancesStore.balances.find((item) => item.denom === repaymentCurrency!.ibcData);
-  return [{ ...repaymentCurrency, balance: walletBalance ?? { denom: repaymentCurrency.ibcData, amount: "0" } }];
+  const walletBalance = balancesStore.balances.find((item) => item.denom === resolvedCurrency.ibcData);
+  return [{ ...resolvedCurrency, balance: walletBalance ?? { denom: resolvedCurrency.ibcData, amount: "0" } }];
 });
 
 function handleAmountChange(event: string) {
   amount.value = event;
-  if (amount.value != "" && debt.value) {
+  if (amount.value !== "" && debt.value) {
     let percent = new Dec(amount.value).quo(debt.value.amount.toDec()).mul(new Dec(100));
     if (percent.isNegative()) {
       percent = new Dec(0);
@@ -310,7 +312,11 @@ function handleAmountChange(event: string) {
 const debt = computed(() => {
   const selectedCurrency = currency.value;
   if (selectedCurrency) {
-    const { repayment } = getRepayment(100)!;
+    const repaymentData = getRepayment(100);
+    if (!repaymentData) {
+      return undefined;
+    }
+    const { repayment } = repaymentData;
     const repaymentInt = repayment.mul(new Dec(10).pow(new Int(selectedCurrency.decimal_digits))).truncate();
 
     return {
@@ -332,6 +338,7 @@ function getRepayment(p: number) {
 
   const amount = outStandingDebt();
   const lpn = getLpnByProtocol(lease.value.protocol);
+  if (!lpn) return undefined;
   const c = lpn;
 
   const amountToRepay = CurrencyUtils.convertMinimalDenomToDenom(
@@ -344,6 +351,7 @@ function getRepayment(p: number) {
   const percent = new Dec(p).quo(new Dec(100));
   let repaymentInStable = amountToRepay.mul(percent);
   const selectedCurrency = currency.value;
+  if (!selectedCurrency) return undefined;
 
   if (swapFee.value) {
     repaymentInStable = repaymentInStable.add(repaymentInStable.mul(new Dec(swapFee.value)));
@@ -352,9 +360,10 @@ function getRepayment(p: number) {
   const positionType = configStore.getPositionType(lease.value.protocol);
 
   if (positionType === "Short") {
-    const lpn = getLpnByProtocol(lease.value.protocol);
-    const price = new Dec(pricesStore.prices[lpn!.key as string].price);
-    const selected_asset_price = new Dec(pricesStore.prices[selectedCurrency!.key as string].price);
+    const lpnShort = getLpnByProtocol(lease.value.protocol);
+    if (!lpnShort) return undefined;
+    const price = new Dec(pricesStore.prices[lpnShort.key as string].price);
+    const selected_asset_price = new Dec(pricesStore.prices[selectedCurrency.key as string].price);
     const repayment = repaymentInStable.mul(price);
     return {
       repayment: repayment.quo(selected_asset_price),
@@ -362,7 +371,7 @@ function getRepayment(p: number) {
       selectedCurrencyInfo: selectedCurrency
     };
   } else {
-    const price = new Dec(pricesStore.prices[selectedCurrency!.key as string]?.price ?? 1);
+    const price = new Dec(pricesStore.prices[selectedCurrency.key as string]?.price ?? 1);
     const repayment = repaymentInStable.quo(price);
     return {
       repayment,
@@ -390,10 +399,11 @@ function isAmountValid() {
 
   const amnt = amount.value;
   const coinData = currency.value;
+  const leaseValue = lease.value;
 
-  if (coinData) {
+  if (coinData && leaseValue) {
     if (amnt || amnt !== "") {
-      const price = pricesStore.prices[coinData!.key as string];
+      const price = pricesStore.prices[coinData.key as string];
 
       const amountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(amnt, "", coinData.decimal_digits);
       const balance = CurrencyUtils.calculateBalance(
@@ -403,10 +413,10 @@ function isAmountValid() {
       ).toDec();
       const minAmount = new Dec(minimumLeaseAmount);
       const p = new Dec(price.price);
-      const amountInStable = new Dec(amnt.length == 0 ? "0" : amnt).mul(p);
+      const amountInStable = new Dec(amnt.length === 0 ? "0" : amnt).mul(p);
 
       const debt = getDebtValue();
-      const lpn = getLpnByProtocol(lease.value!.protocol);
+      const lpn = getLpnByProtocol(leaseValue.protocol);
       const debtInCurrencies = debt.quo(new Dec(price.price));
       const minAmm = new Dec(minimumLeaseAmount).mul(new Dec(10 ** lpn.decimal_digits));
 
@@ -430,7 +440,7 @@ function isAmountValid() {
       if (debt.gt(minAmm) && amountInStable.lt(minAmount)) {
         amountErrorMsg.value = i18n.t("message.min-amount-allowed", {
           amount: formatTokenBalance(minAmountCurrency),
-          currency: coinData!.shortName
+          currency: coinData.shortName
         });
         isValid = false;
       }
@@ -461,10 +471,16 @@ function getDebtValue() {
   let debt = outStandingDebt();
   debt = debt.add(debt.mul(new Dec(swapFee.value)));
 
-  const positionType = configStore.getPositionType(lease.value!.protocol);
+  if (!lease.value) {
+    throw new Error("Lease not available");
+  }
+  const positionType = configStore.getPositionType(lease.value.protocol);
   if (positionType === "Short") {
-    const lpn = getLpnByProtocol(lease.value!.protocol);
-    const price = new Dec(pricesStore.prices[lpn!.key as string].price);
+    const lpn = getLpnByProtocol(lease.value.protocol);
+    if (!lpn) {
+      throw new Error("LPN currency not available");
+    }
+    const price = new Dec(pricesStore.prices[lpn.key as string].price);
     return debt.mul(price);
   }
   return debt;
@@ -539,7 +555,7 @@ const detbPartial = computed(() => {
   const d = debt?.repayment;
   if (price && d && debtTotal && lease.value) {
     const ticker = lease.value.etl_data?.lease_position_ticker ?? lease.value.amount.ticker;
-    const currecy = configStore.currenciesData![`${ticker}@${lease.value.protocol}`];
+    const currecy = configStore.currenciesData[`${ticker}@${lease.value.protocol}`];
 
     const positionType = configStore.getPositionType(lease.value.protocol);
     const rest = debtTotal.repayment.sub(d);
@@ -568,7 +584,7 @@ const debtData = computed(() => {
 
   if (price && d && lease.value) {
     const ticker = lease.value.etl_data?.lease_position_ticker ?? lease.value.amount.ticker;
-    const currecy = configStore.currenciesData![`${ticker}@${lease.value.protocol}`];
+    const currecy = configStore.currenciesData[`${ticker}@${lease.value.protocol}`];
 
     const positionType = configStore.getPositionType(lease.value.protocol);
     if (positionType === "Short") {
@@ -588,7 +604,7 @@ const liquidation = computed(() => {
   }
 
   const ticker = lease.value.amount.ticker;
-  const unitAssetInfo = configStore.currenciesData![`${ticker}@${lease.value.protocol}`];
+  const unitAssetInfo = configStore.currenciesData[`${ticker}@${lease.value.protocol}`];
   const lpn = getLpnByProtocol(lease.value.protocol);
 
   const unitAsset = new Dec(lease.value.amount.amount, Number(unitAssetInfo?.decimal_digits ?? 0));

--- a/src/modules/leases/components/single-lease/SharePnLDialog.vue
+++ b/src/modules/leases/components/single-lease/SharePnLDialog.vue
@@ -510,8 +510,11 @@ function setTimeStamp(ctx: CanvasRenderingContext2D) {
 }
 
 function download() {
+  if (!canvas.value) {
+    return;
+  }
   const anchor = document.createElement("a");
-  anchor.href = canvas.value!.toDataURL("image/png");
+  anchor.href = canvas.value.toDataURL("image/png");
   anchor.download = "position.png";
   anchor.click();
   anchor.remove();

--- a/src/modules/leases/components/single-lease/StopLossDialog.vue
+++ b/src/modules/leases/components/single-lease/StopLossDialog.vue
@@ -113,7 +113,8 @@ import { NATIVE_CURRENCY, NATIVE_NETWORK } from "../../../../config/global/netwo
 import type { ExternalCurrency } from "@/common/types";
 import type { AssetBalance } from "@/common/stores/wallet/types";
 import { Dec } from "@keplr-wallet/unit";
-import { NolusClient, NolusWallet } from "@nolus/nolusjs";
+import type { NolusWallet } from "@nolus/nolusjs";
+import { NolusClient } from "@nolus/nolusjs";
 import { useI18n } from "vue-i18n";
 import type { Coin } from "@cosmjs/proto-signing";
 import { Lease } from "@nolus/nolusjs/build/contracts";
@@ -170,7 +171,7 @@ onBeforeUnmount(() => {
 });
 
 const price = computed(() => {
-  return formatPriceUsd(amount.value.length == 0 ? 0 : amount.value);
+  return formatPriceUsd(amount.value.length === 0 ? 0 : amount.value);
 });
 
 const currency = computed(() => {
@@ -188,7 +189,10 @@ const assets = computed(() => {
   const data = [];
 
   if (lease.value) {
-    const asset = getCurrency()!;
+    const asset = getCurrency();
+    if (!asset) {
+      return data;
+    }
     const denom = (asset as ExternalCurrency).ibcData ?? (asset as AssetBalance).from;
 
     data.push({
@@ -198,7 +202,7 @@ const assets = computed(() => {
       label: asset.shortName,
       ibcData: asset.ibcData,
       shortName: asset.shortName,
-      decimal_digits: asset.decimal_digits!,
+      decimal_digits: asset.decimal_digits,
       key: asset.key,
       ticker: asset.ticker
     });
@@ -213,7 +217,7 @@ function getCurrency() {
 
   if (positionType === "Long") {
     const ticker = lease.value.amount.ticker;
-    return configStore.currenciesData![`${ticker}@${lease.value.protocol}`];
+    return configStore.currenciesData[`${ticker}@${lease.value.protocol}`];
   } else {
     return getLpnByProtocol(lease.value.protocol);
   }
@@ -226,7 +230,7 @@ function getPrice() {
 
 const payout = computed(() => {
   if (!lease.value || !displayData.value) return "0";
-  const end_price = new Dec(amount.value.length == 0 ? 0 : amount.value);
+  const end_price = new Dec(amount.value.length === 0 ? 0 : amount.value);
   const positionType = configStore.getPositionType(lease.value.protocol);
   const debt = displayData.value.totalDebt ?? new Dec(0);
 
@@ -253,7 +257,7 @@ const total = computed(() => {
 
 function handleAmountChange(event: string) {
   amount.value = event;
-  if (amount.value != "") {
+  if (amount.value !== "") {
     let percent = new Dec(amount.value).quo(total.value).mul(new Dec(100));
     if (percent.isNegative()) {
       percent = new Dec(0);
@@ -270,8 +274,11 @@ function isAmountValid() {
   amountErrorMsg.value = "";
   if (lease.value && lease.value.status === "opened") {
     const a = new Dec(amount.value.length > 0 ? amount.value : 0);
-    const currencyData = getCurrency()!;
-    const price = getPrice()!;
+    const currencyData = getCurrency();
+    const price = getPrice();
+    if (!currencyData || !price) {
+      return isValid;
+    }
 
     if (amount.value || amount.value !== "") {
       const isLowerThanOrEqualsToZero = a.lte(new Dec(0));
@@ -341,7 +348,7 @@ async function operation() {
 
       const percent = getPercent();
       const takeProfit = lease.value.close_policy?.take_profit;
-      const stopLoss = Number(percent!.mul(new Dec(PERMILLE)).round().toString());
+      const stopLoss = Number(percent.mul(new Dec(PERMILLE)).round().toString());
 
       const {
         txHash: _txHash,
@@ -368,7 +375,7 @@ async function operation() {
 
 function getPercent() {
   if (!lease.value || !displayData.value) return new Dec(0);
-  const value = new Dec(amount.value.length == 0 ? 0 : amount.value);
+  const value = new Dec(amount.value.length === 0 ? 0 : amount.value);
   const positionType = configStore.getPositionType(lease.value.protocol);
 
   if (positionType === "Long") {

--- a/src/modules/leases/components/single-lease/TakeProfitDialog.vue
+++ b/src/modules/leases/components/single-lease/TakeProfitDialog.vue
@@ -113,7 +113,8 @@ import { NATIVE_CURRENCY, NATIVE_NETWORK } from "../../../../config/global/netwo
 import type { ExternalCurrency } from "@/common/types";
 import type { AssetBalance } from "@/common/stores/wallet/types";
 import { Dec } from "@keplr-wallet/unit";
-import { NolusClient, NolusWallet } from "@nolus/nolusjs";
+import type { NolusWallet } from "@nolus/nolusjs";
+import { NolusClient } from "@nolus/nolusjs";
 import { useI18n } from "vue-i18n";
 import type { Coin } from "@cosmjs/proto-signing";
 import { Lease } from "@nolus/nolusjs/build/contracts";
@@ -169,7 +170,7 @@ onBeforeUnmount(() => {
 });
 
 const price = computed(() => {
-  return formatPriceUsd(amount.value.length == 0 ? 0 : amount.value);
+  return formatPriceUsd(amount.value.length === 0 ? 0 : amount.value);
 });
 
 const currency = computed(() => {
@@ -187,7 +188,10 @@ const assets = computed(() => {
   const data = [];
 
   if (lease.value) {
-    const asset = getCurrency()!;
+    const asset = getCurrency();
+    if (!asset) {
+      return data;
+    }
     const denom = (asset as ExternalCurrency).ibcData ?? (asset as AssetBalance).from;
 
     data.push({
@@ -197,7 +201,7 @@ const assets = computed(() => {
       label: asset.shortName,
       ibcData: asset.ibcData,
       shortName: asset.shortName,
-      decimal_digits: asset.decimal_digits!,
+      decimal_digits: asset.decimal_digits,
       key: asset.key,
       ticker: asset.ticker
     });
@@ -208,7 +212,7 @@ const assets = computed(() => {
 
 const payout = computed(() => {
   if (!lease.value || !displayData.value) return "0";
-  const end_price = new Dec(amount.value.length == 0 ? 0 : amount.value);
+  const end_price = new Dec(amount.value.length === 0 ? 0 : amount.value);
   const positionType = configStore.getPositionType(lease.value.protocol);
   const debt = displayData.value.totalDebt ?? new Dec(0);
 
@@ -253,7 +257,7 @@ function getCurrency() {
 
   if (positionType === "Long") {
     const ticker = lease.value.amount.ticker;
-    return configStore.currenciesData![`${ticker}@${lease.value.protocol}`];
+    return configStore.currenciesData[`${ticker}@${lease.value.protocol}`];
   } else {
     return getLpnByProtocol(lease.value.protocol);
   }
@@ -271,7 +275,7 @@ const total = computed(() => {
 
 function handleAmountChange(event: string) {
   amount.value = event;
-  if (amount.value != "") {
+  if (amount.value !== "") {
     let percent = new Dec(amount.value).quo(total.value).mul(new Dec(100));
     if (percent.isNegative()) {
       percent = new Dec(0);
@@ -288,8 +292,11 @@ function isAmountValid() {
   amountErrorMsg.value = "";
   if (lease.value && lease.value.status === "opened") {
     const a = new Dec(amount.value.length > 0 ? amount.value : 0);
-    const currencyData = getCurrencyByTicker(lease.value.amount.ticker!);
-    const price = getPrice()!;
+    const currencyData = getCurrencyByTicker(lease.value.amount.ticker);
+    const price = getPrice();
+    if (!price) {
+      return isValid;
+    }
 
     if (amount.value || amount.value !== "") {
       const isLowerThanOrEqualsToZero = a.lte(new Dec(0));
@@ -354,7 +361,7 @@ async function operation() {
 
       const percent = getPercent();
 
-      const takeProfit = Number(percent!.mul(new Dec(PERMILLE)).round().toString());
+      const takeProfit = Number(percent.mul(new Dec(PERMILLE)).round().toString());
       const stopLoss = lease.value.close_policy?.stop_loss;
       const {
         txHash: _txHash,

--- a/src/modules/stake/components/DelegateForm.vue
+++ b/src/modules/stake/components/DelegateForm.vue
@@ -129,7 +129,7 @@ const stable = computed(() => {
 });
 
 const isEmpty = computed(() => {
-  if (input.value.length == 0 || Number(input.value) == 0) {
+  if (input.value.length === 0 || Number(input.value) === 0) {
     return true;
   }
   return false;
@@ -141,7 +141,7 @@ function onInput(data: string) {
 }
 
 async function onNextClick() {
-  if (validateInputs().length == 0) {
+  if (validateInputs().length === 0) {
     disabled.value = true;
     try {
       await walletOperation(delegate);

--- a/src/modules/stake/components/UndelegateForm.vue
+++ b/src/modules/stake/components/UndelegateForm.vue
@@ -137,7 +137,7 @@ const stable = computed(() => {
 });
 
 const isEmpty = computed(() => {
-  if (input.value.length == 0 || Number(input.value) == 0) {
+  if (input.value.length === 0 || Number(input.value) === 0) {
     return true;
   }
   return false;
@@ -149,7 +149,7 @@ function onInput(data: string) {
 }
 
 async function onNextClick() {
-  if (validateInputs().length == 0) {
+  if (validateInputs().length === 0) {
     disabled.value = true;
     try {
       await walletOperation(undelegate);

--- a/src/modules/stats/components/LeasesMonthlyChart.vue
+++ b/src/modules/stats/components/LeasesMonthlyChart.vue
@@ -136,12 +136,16 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
           .attr("fill", hoverColor)
           .node() as Element | null;
         if (barEl) {
-          const bx = +barEl.getAttribute("x")! + +barEl.getAttribute("width")! / 2;
+          const bx = +(barEl.getAttribute("x") ?? 0) + +(barEl.getAttribute("width") ?? 0) / 2;
           crosshair.attr("x1", bx).attr("x2", bx).style("display", null);
         }
 
         tooltip.html(`<strong>${i18n.t("message.amount")}</strong> ${formatUsd(closestData.amount)}`);
-        const node = tooltip.node()!.getBoundingClientRect();
+        const tooltipNode = tooltip.node();
+        if (!tooltipNode) {
+          return;
+        }
+        const node = tooltipNode.getBoundingClientRect();
         tooltip
           .style("opacity", 1)
           .style("left", `${event.pageX - node.width / 2}px`)

--- a/src/modules/stats/components/LoansChart.vue
+++ b/src/modules/stats/components/LoansChart.vue
@@ -143,7 +143,11 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
         rects.filter((_, i) => i === barIndex).style("fill", hoverColor);
 
         tooltip.html(`<strong>${nearestData.ticker}:</strong> ${formatUsd(nearestData.loan)}`);
-        const node = tooltip.node()!.getBoundingClientRect();
+        const tooltipNode = tooltip.node();
+        if (!tooltipNode) {
+          return;
+        }
+        const node = tooltipNode.getBoundingClientRect();
         tooltip
           .style("opacity", 1)
           .style("left", `${event.pageX - node.width / 2}px`)

--- a/src/modules/stats/components/SupplyBorrowedChart.vue
+++ b/src/modules/stats/components/SupplyBorrowedChart.vue
@@ -182,7 +182,13 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
           `<strong>${i18n.t("message.supplied")}:</strong> ${formatUsd(closestData.supplied)}<br><strong>${i18n.t("message.borrowed-chart")}:</strong> ${formatUsd(closestData.borrowed)}`
         );
 
-        const node = tooltip.node()!.getBoundingClientRect();
+        const tooltipNode = tooltip.node();
+
+        if (!tooltipNode) {
+          return;
+        }
+
+        const node = tooltipNode.getBoundingClientRect();
         const height = node.height;
         const width = node.width;
 

--- a/src/modules/vote/components/VoteDialog.vue
+++ b/src/modules/vote/components/VoteDialog.vue
@@ -190,17 +190,18 @@ async function onVoteEmit(vote: VoteOption) {
     isLoading.value = vote;
     isDisabled.value = true;
 
-    if (wallet.wallet) {
+    const connectedWallet = wallet.wallet;
+    if (connectedWallet) {
       const typeUrl = "/cosmos.gov.v1beta1.MsgVote";
       const voteMsg = MsgVote.fromPartial({
         proposalId: BigInt(props.proposal.id),
-        voter: wallet.wallet!.address,
+        voter: connectedWallet.address,
         option: vote
       });
 
-      const { txBytes } = await wallet.wallet!.simulateTx(voteMsg, typeUrl);
+      const { txBytes } = await connectedWallet.simulateTx(voteMsg, typeUrl);
 
-      await wallet.wallet?.broadcastTx(txBytes as Uint8Array);
+      await connectedWallet.broadcastTx(txBytes as Uint8Array);
       hide();
       historyStore.loadActivities();
       onShowToast({

--- a/src/modules/vote/composables/useFetchGovernanceProposals.ts
+++ b/src/modules/vote/composables/useFetchGovernanceProposals.ts
@@ -1,7 +1,7 @@
 import { ref, type Ref } from "vue";
 import { Logger, WalletManager } from "@/common/utils";
 import { type Proposal } from "@/modules/vote/types";
-import { ProposalStatus } from "web-components";
+import type { ProposalStatus } from "web-components";
 import { BackendApi } from "@/common/api";
 import { getProposalsConfig } from "@/common/utils/ConfigService";
 

--- a/src/networks/cosm/BaseWallet.ts
+++ b/src/networks/cosm/BaseWallet.ts
@@ -69,6 +69,9 @@ export class BaseWallet extends SigningCosmWasmClient implements Wallet {
     explorer: string
   ) {
     super(tmClient, signer, options);
+    if (!tmClient) {
+      throw new Error("CometClient is required to construct BaseWallet");
+    }
     this.offlineSigner = signer;
     this.rpc = rpc;
     this.api = api;
@@ -77,7 +80,7 @@ export class BaseWallet extends SigningCosmWasmClient implements Wallet {
     this.gasMultiplier = gasMultiplier;
     this.explorer = explorer;
     this.queryClientBase = QueryClient.withExtensions(
-      tmClient!,
+      tmClient,
       setupAuthExtension,
       setupBankExtension,
       setupStakingExtension,
@@ -133,11 +136,14 @@ export class BaseWallet extends SigningCosmWasmClient implements Wallet {
     pubkey: Secp256k1Pubkey,
     sequence: { sequence?: number; accountNumber?: number }
   ) {
+    if (sequence.sequence == null) {
+      throw new Error("Account sequence not available");
+    }
     const { gasInfo } = await this.queryClientBase.tx.simulate(
       [this.registry.encodeAsAny(msgAny)],
       memo,
       pubkey,
-      sequence.sequence!
+      sequence.sequence
     );
     return gasInfo;
   }
@@ -224,7 +230,10 @@ export class BaseWallet extends SigningCosmWasmClient implements Wallet {
 
   private async sequence() {
     try {
-      const account = await this.getAccount(this.address!);
+      if (!this.address) {
+        throw new Error("Wallet address not available");
+      }
+      const account = await this.getAccount(this.address);
       return { sequence: account?.sequence, accountNumber: account?.accountNumber };
     } catch (error) {
       Logger.error(error);

--- a/src/networks/cosm/NolusWalletOverride.test.ts
+++ b/src/networks/cosm/NolusWalletOverride.test.ts
@@ -146,6 +146,22 @@ describe("NolusWalletOverride", () => {
       const signCalls = (w.sign as ReturnType<typeof vi.fn>).mock.calls;
       expect(signCalls[0][3]).toBe("");
     });
+
+    it("throws when wallet pubKey is missing (fail loudly)", async () => {
+      const w = buildFakeWallet();
+      applyNolusWalletOverrides(w);
+      (w as Record<string, unknown>).pubKey = undefined;
+      const fn = w.simulateTx as Override<"simulateTx">;
+      await expect(fn({} as never, "/cosmos.bank.v1beta1.MsgSend")).rejects.toThrow(/public key not available/);
+    });
+
+    it("throws when wallet address is missing (fail loudly)", async () => {
+      const w = buildFakeWallet();
+      applyNolusWalletOverrides(w);
+      (w as Record<string, unknown>).address = undefined;
+      const fn = w.simulateTx as Override<"simulateTx">;
+      await expect(fn({} as never, "/cosmos.bank.v1beta1.MsgSend")).rejects.toThrow(/address not available/);
+    });
   });
 
   describe("simulateMultiTx override", () => {

--- a/src/networks/cosm/NolusWalletOverride.ts
+++ b/src/networks/cosm/NolusWalletOverride.ts
@@ -31,6 +31,21 @@ function getGasMultiplier(): number {
   return feeConfig.gas_multiplier;
 }
 
+/**
+ * Read the connected wallet's pubKey and address.
+ * Throws if either is missing (fail loudly — a wallet reaching the signing path
+ * without an identity is a broken state, not a recoverable condition).
+ */
+function requireWalletIdentity(wallet: NolusWallet): { pubKey: Uint8Array; address: string } {
+  if (!wallet.pubKey) {
+    throw new Error("Wallet public key not available");
+  }
+  if (!wallet.address) {
+    throw new Error("Wallet address not available");
+  }
+  return { pubKey: wallet.pubKey, address: wallet.address };
+}
+
 export function applyNolusWalletOverrides(wallet: NolusWallet): void {
   // Override gasPrices — use backend-cached gas prices instead of chain query
   wallet.gasPrices = async (): Promise<{ [denom: string]: number }> => {
@@ -51,20 +66,22 @@ export function applyNolusWalletOverrides(wallet: NolusWallet): void {
   // Override simulateTx — use backend gas_multiplier instead of ChainConstants.GAS_MULTIPLIER
   wallet.simulateTx = async function (msg: EncodeObject["value"], msgTypeUrl: string, memo = "") {
     // Ledger/hardware wallet delegation
-    if (wallet.getOfflineSigner().simulateTx) {
-      return wallet.getOfflineSigner().simulateTx!(msg, memo);
+    const offlineSimulateTx = wallet.getOfflineSigner().simulateTx;
+    if (offlineSimulateTx) {
+      return offlineSimulateTx(msg, memo);
     }
 
     const gasMultiplier = getGasMultiplier();
-    const pubkey = encodeSecp256k1Pubkey(wallet.pubKey!);
+    const { pubKey, address } = requireWalletIdentity(wallet);
+    const pubkey = encodeSecp256k1Pubkey(pubKey);
     const msgAny = { typeUrl: msgTypeUrl, value: msg };
-    const { sequence } = await wallet.getSequence(wallet.address!);
+    const { sequence } = await wallet.getSequence(address);
     const { gasInfo } = await wallet
       .forceGetQueryClient()
       .tx.simulate([wallet.registry.encodeAsAny(msgAny)], memo, pubkey, sequence);
     const gas = Math.round(Number(gasInfo?.gasUsed ?? 0) * gasMultiplier);
     const usedFee = await wallet.selectDynamicFee(gas, [{ msg, msgTypeUrl }]);
-    const txRaw = await wallet.sign(wallet.address!, [msgAny], usedFee, memo);
+    const txRaw = await wallet.sign(address, [msgAny], usedFee, memo);
     const txBytes = Uint8Array.from(TxRaw.encode(txRaw).finish());
     const txHash = toHex(sha256(txBytes));
     return { txHash, txBytes, usedFee };
@@ -74,12 +91,14 @@ export function applyNolusWalletOverrides(wallet: NolusWallet): void {
   // @ts-expect-error -- simulateMultiTx is private on NolusWallet but we need to override it
   wallet.simulateMultiTx = async function (messages: MsgWithTypeUrl[], memo = "") {
     // Ledger/hardware wallet delegation
-    if (wallet.getOfflineSigner().simulateMultiTx) {
-      return wallet.getOfflineSigner().simulateMultiTx!(messages, memo);
+    const offlineSimulateMultiTx = wallet.getOfflineSigner().simulateMultiTx;
+    if (offlineSimulateMultiTx) {
+      return offlineSimulateMultiTx(messages, memo);
     }
 
     const gasMultiplier = getGasMultiplier();
-    const pubkey = encodeSecp256k1Pubkey(wallet.pubKey!);
+    const { pubKey, address } = requireWalletIdentity(wallet);
+    const pubkey = encodeSecp256k1Pubkey(pubKey);
     const encodedMSGS: ReturnType<typeof wallet.registry.encodeAsAny>[] = [];
     const msgs: EncodeObject[] = [];
     for (const item of messages) {
@@ -87,11 +106,11 @@ export function applyNolusWalletOverrides(wallet: NolusWallet): void {
       encodedMSGS.push(wallet.registry.encodeAsAny(msgAny));
       msgs.push(msgAny);
     }
-    const { sequence } = await wallet.getSequence(wallet.address!);
+    const { sequence } = await wallet.getSequence(address);
     const { gasInfo } = await wallet.forceGetQueryClient().tx.simulate(encodedMSGS, memo, pubkey, sequence);
     const gas = Math.round(Number(gasInfo?.gasUsed ?? 0) * gasMultiplier);
     const usedFee = await wallet.selectDynamicFee(gas, messages);
-    const txRaw = await wallet.sign(wallet.address!, msgs, usedFee, memo);
+    const txRaw = await wallet.sign(address, msgs, usedFee, memo);
     const txBytes = Uint8Array.from(TxRaw.encode(txRaw).finish());
     const txHash = toHex(sha256(txBytes));
     return { txHash, txBytes, usedFee };
@@ -100,7 +119,7 @@ export function applyNolusWalletOverrides(wallet: NolusWallet): void {
   // Override getGasInfo — also uses gas multiplier for fee estimation.
   // The `pubkey: Pubkey` parameter is load-bearing for the Solana Ed25519 path:
   // SolanaWallet.simulateMultiTx supplies an Ed25519-encoded pubkey here, so a
-  // future refactor that drops the param and inlines `encodeSecp256k1Pubkey(wallet.pubKey!)`
+  // future refactor that drops the param and inlines `encodeSecp256k1Pubkey(wallet.pubKey)`
   // would silently break the Solana flow (chain rejects the wrong pubkey type).
   wallet.getGasInfo = async function (messages: MsgWithTypeUrl[], memo: string, pubkey: Pubkey, sequence: number) {
     const gasMultiplier = getGasMultiplier();

--- a/src/networks/cosm/accountParser.test.ts
+++ b/src/networks/cosm/accountParser.test.ts
@@ -7,7 +7,7 @@ import {
   DelayedVestingAccount,
   PeriodicVestingAccount
 } from "cosmjs-types/cosmos/vesting/v1beta1/vesting";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import type { Any } from "cosmjs-types/google/protobuf/any";
 import { accountFromAny } from "./accountParser";
 import { encodePubkey } from "./encode";
 

--- a/src/networks/cosm/setupTxExtension.ts
+++ b/src/networks/cosm/setupTxExtension.ts
@@ -2,16 +2,11 @@ import type { Pubkey } from "@cosmjs/amino";
 import { createProtobufRpcClient, type QueryClient } from "@cosmjs/stargate";
 import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
 import { AuthInfo, Fee, Tx, TxBody } from "cosmjs-types/cosmos/tx/v1beta1/tx";
-import { Any } from "cosmjs-types/google/protobuf/any";
+import type { Any } from "cosmjs-types/google/protobuf/any";
 import { encodePubkey } from "./encode";
 
-import {
-  GetTxRequest,
-  GetTxResponse,
-  ServiceClientImpl,
-  SimulateRequest,
-  SimulateResponse
-} from "cosmjs-types/cosmos/tx/v1beta1/service";
+import type { GetTxRequest, GetTxResponse, SimulateResponse } from "cosmjs-types/cosmos/tx/v1beta1/service";
+import { ServiceClientImpl, SimulateRequest } from "cosmjs-types/cosmos/tx/v1beta1/service";
 
 export interface TxExtension {
   readonly tx: {

--- a/src/networks/sol/wallet.test.ts
+++ b/src/networks/sol/wallet.test.ts
@@ -230,7 +230,7 @@ describe("SolanaWallet (Solflare provider)", () => {
       })
     });
 
-    const res = await bound.simulateMultiTx!(
+    const res = await bound.simulateMultiTx?.(
       [{ msg: { fromAddress: "a", toAddress: "b" }, msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend" }],
       ""
     );
@@ -262,7 +262,7 @@ describe("SolanaWallet (Solflare provider)", () => {
       })
     });
 
-    await bound.simulateMultiTx!(
+    await bound.simulateMultiTx?.(
       [{ msg: { fromAddress: "a", toAddress: "b" }, msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend" }],
       ""
     );
@@ -307,7 +307,7 @@ describe("SolanaWallet (Solflare provider)", () => {
       })
     });
 
-    await bound.simulateMultiTx!(
+    await bound.simulateMultiTx?.(
       [{ msg: { fromAddress: "a", toAddress: "b" }, msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend" }],
       ""
     );
@@ -332,7 +332,7 @@ describe("SolanaWallet (Solflare provider)", () => {
     const bound = Object.assign(signer, {
       simulateMultiTx: vi.fn().mockResolvedValue({ txHash: "deadbeef", txBytes: new Uint8Array(), usedFee: {} })
     });
-    await bound.simulateTx!({ x: 1 } as never, "/cosmos.bank.v1beta1.MsgSend", "memo");
+    await bound.simulateTx?.({ x: 1 } as never, "/cosmos.bank.v1beta1.MsgSend", "memo");
     expect(bound.simulateMultiTx).toHaveBeenCalledWith(
       [{ msg: { x: 1 }, msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend" }],
       "memo"
@@ -435,7 +435,7 @@ describe("SolanaWallet (Phantom provider)", () => {
       })
     });
 
-    await bound.simulateMultiTx!(
+    await bound.simulateMultiTx?.(
       [{ msg: { fromAddress: "a", toAddress: "b" }, msgTypeUrl: "/cosmos.bank.v1beta1.MsgSend" }],
       ""
     );

--- a/src/networks/sol/wallet.ts
+++ b/src/networks/sol/wallet.ts
@@ -25,12 +25,12 @@ import type { Window } from "../window";
 import { PubKey as Ed25519PubKey } from "cosmjs-types/cosmos/crypto/ed25519/keys";
 import { encodeEd25519Pubkey } from "@cosmjs/amino";
 
-import { MsgExecuteContract } from "cosmjs-types/cosmwasm/wasm/v1/tx";
-import { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
-import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
-import { MsgDelegate, MsgUndelegate, MsgBeginRedelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
-import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
-import { MsgVote } from "cosmjs-types/cosmos/gov/v1beta1/tx";
+import type { MsgExecuteContract } from "cosmjs-types/cosmwasm/wasm/v1/tx";
+import type { MsgSend } from "cosmjs-types/cosmos/bank/v1beta1/tx";
+import type { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
+import type { MsgDelegate, MsgUndelegate, MsgBeginRedelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
+import type { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
+import type { MsgVote } from "cosmjs-types/cosmos/gov/v1beta1/tx";
 import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
 
 export class SolanaWallet implements Wallet {
@@ -48,7 +48,7 @@ export class SolanaWallet implements Wallet {
     this.providerKind = provider;
   }
 
-  private getProvider() {
+  private getProvider(): NonNullable<Window["solflare"]> {
     if (this.providerKind === "solflare") {
       const provider = (window as Window).solflare;
       if (!provider || (provider as { isSolflare?: unknown }).isSolflare !== true) {
@@ -101,12 +101,12 @@ export class SolanaWallet implements Wallet {
   private async getWallet(chainInfo: ChainInfo) {
     const provider = this.getProvider();
 
-    const isConnected = await provider!.connect();
-    if (!isConnected || !provider?.publicKey) {
+    const isConnected = await provider.connect();
+    if (!isConnected || !provider.publicKey) {
       throw new Error("Connection failed—user rejected or no publicKey available.");
     }
 
-    const publicKey = provider!.publicKey;
+    const publicKey = provider.publicKey;
     const ed25519PublicKey = publicKey.toBytes();
     const solAddress = publicKey.toBase58();
 
@@ -222,7 +222,7 @@ export class SolanaWallet implements Wallet {
         });
         const signBytes = SignDoc.encode(signDoc).finish();
 
-        const { signature } = await provider!.signMessage(signBytes);
+        const { signature } = await provider.signMessage(signBytes);
 
         const txRaw = TxRaw.fromPartial({
           bodyBytes: txBodyBytes,

--- a/src/router/index.test.ts
+++ b/src/router/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type * as VueRouter from "vue-router";
 
 // Mock every module the router imports so the router module can be loaded
 // under jsdom without pulling in hundreds of deps.
@@ -51,7 +52,7 @@ vi.mock("@/modules/view.vue", () => ({ default: { name: "MainLayout", template: 
 
 // Force vue-router to use memory history in tests to avoid jsdom/history races.
 vi.mock("vue-router", async () => {
-  const actual = await vi.importActual<typeof import("vue-router")>("vue-router");
+  const actual = await vi.importActual<typeof VueRouter>("vue-router");
   return {
     ...actual,
     createWebHistory: actual.createMemoryHistory

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -16,7 +16,7 @@ import MainLayout from "@/modules/view.vue";
 
 const router = createRouter({
   scrollBehavior(to, from) {
-    if (to.meta.key == from.meta.key) {
+    if (to.meta.key === from.meta.key) {
       return false;
     }
     if (to.hash.length > 0) {


### PR DESCRIPTION
## What

Wires type-aware ESLint that now covers `.vue` `<script setup>` blocks (previously a lint blind spot) and adopts four house rules, fixing all resulting fallout in the same change (each rule fails closed, so rules + fixes land together):

- `parserOptions: { projectService: true }` — `.vue` scripts are now type-aware-linted.
- `eqeqeq` (`{ null: "ignore" }`) — 82 `==`/`!=` → `===`/`!==`; sanctioned `== null` kept.
- `@typescript-eslint/no-non-null-assertion` — non-null assertions replaced with behavior-preserving guards/`??`.
- `@typescript-eslint/consistent-type-imports` (`separate-type-imports`).
- `no-console` (allow `warn`/`error`) + a `Logger.ts` override; `WebSocketClient` lifecycle logs routed through `Logger`.
- The 8 `:any` callbacks in the `*Form.vue` scripts are typed.

## Scope note

The issue estimated "~20" non-null assertions from a `.ts`-only grep. Enabling type-aware parsing correctly surfaced the `.vue` blocks too (the whole point of the issue), so the real count was **256** — many in wallet / signing / routing code. That is faithful to the issue's intent, but it makes this a large diff (65 files); it was reviewed accordingly.

## Behavior preservation

Every `!`→guard site in signing/wallet/route code was checked: throws stay throws, and the two display-only "silent skip" sites (`setSwapFee`, `getRepayment`) cannot affect a transaction because the tx-building paths re-guard price/route/lease independently before broadcast. Two sites are net improvements — the Skip-router and form address loops used to silently insert the string `"undefined"` as a wallet address and now throw; `getProvider()` now enforces wallet-identity validation before Ed25519 signing. The WebMCP scope boundary is untouched.

No `eslint-disable`/`@ts-ignore`/`@ts-expect-error` added. `tsc` net error count is unchanged vs `main` (the project builds via Vite and does not type-check in CI; baseline parity confirmed).

## Verification

`npm run lint` green · `npm run format:check` clean · `npm test` 774 pass · `npm run build` succeeds. Reviewed for correctness and for signing-path security — no findings above informational.

Closes #169