### PR TITLE
refactor(backend): replace as casts with typed conversions

### DIFF
--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -129,7 +129,6 @@ jobs:
           -D warnings
           -A clippy::unwrap_used
           -A clippy::expect_used
-          -A clippy::as_conversions
           -A clippy::too_many_lines
           -A clippy::cognitive_complexity
           -A clippy::missing_const_for_fn

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -86,7 +86,7 @@ codegen-units = 1
 strip = true
 
 [lints.clippy]
-as_conversions = "warn"
+as_conversions = "deny"
 too_many_lines = { level = "warn", priority = -1 }
 cognitive_complexity = { level = "warn", priority = -1 }
 unwrap_used = "warn"

--- a/backend/src/chain_events.rs
+++ b/backend/src/chain_events.rs
@@ -128,11 +128,13 @@ impl ChainEventClient {
                         e, backoff_secs
                     );
                     // Jitter prevents thundering herd in multi-instance deployments
-                    let jitter = (std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .subsec_nanos()
-                        % 4) as u64;
+                    let jitter = u64::from(
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .subsec_nanos()
+                            % 4,
+                    );
                     tokio::time::sleep(Duration::from_secs(backoff_secs + jitter)).await;
                     backoff_secs = (backoff_secs * 2).min(30);
                 }

--- a/backend/src/external/chain.rs
+++ b/backend/src/external/chain.rs
@@ -40,10 +40,12 @@ fn rand_jitter(max: u64) -> u64 {
     if max == 0 {
         return 0;
     }
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .subsec_nanos() as u64;
+    let nanos = u64::from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos(),
+    );
     nanos % max
 }
 

--- a/backend/src/external/intercom.rs
+++ b/backend/src/external/intercom.rs
@@ -103,10 +103,15 @@ impl IntercomClient {
         }
 
         // Calculate expiration: 15 minutes from now (short-lived for security)
-        let exp = chrono::Utc::now()
-            .checked_add_signed(chrono::Duration::minutes(15))
-            .ok_or_else(|| AppError::Internal("Failed to calculate token expiration".to_string()))?
-            .timestamp() as usize;
+        let exp = usize::try_from(
+            chrono::Utc::now()
+                .checked_add_signed(chrono::Duration::minutes(15))
+                .ok_or_else(|| {
+                    AppError::Internal("Failed to calculate token expiration".to_string())
+                })?
+                .timestamp(),
+        )
+        .map_err(|_| AppError::Internal("Token expiration timestamp out of range".to_string()))?;
 
         // Flatten attributes into a HashMap for the JWT payload
         let attributes_map: HashMap<String, serde_json::Value> = {
@@ -272,7 +277,7 @@ mod tests {
         .unwrap();
 
         // Expiration should be approximately 15 minutes from now
-        let now = chrono::Utc::now().timestamp() as usize;
+        let now = usize::try_from(chrono::Utc::now().timestamp()).unwrap_or(0);
         let fifteen_minutes = 15 * 60;
 
         assert!(token_data.claims.exp > now);

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -6,6 +6,7 @@ use tracing::{debug, warn};
 use utoipa::ToSchema;
 
 use crate::error::AppError;
+use crate::num_utils::u128_to_f64;
 use crate::AppState;
 
 // ============================================================================
@@ -234,6 +235,11 @@ pub async fn detailed_health_check(
         "empty"
     };
 
+    // The cache field set is fixed (the `all_fields` array above), so these
+    // counts never saturate `u32`.
+    let populated = u32::try_from(populated_count).unwrap_or(u32::MAX);
+    let total = u32::try_from(total_count).unwrap_or(u32::MAX);
+
     Json(DetailedHealthResponse {
         status: overall_status.to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -248,9 +254,9 @@ pub async fn detailed_health_check(
         },
         cache: CacheHealth {
             status: cache_status.to_string(),
-            total_entries: populated_count as u64,
+            total_entries: u64::from(populated),
             hit_rate: if total_count > 0 {
-                populated_count as f64 / total_count as f64
+                f64::from(populated) / f64::from(total)
             } else {
                 0.0
             },
@@ -276,7 +282,7 @@ async fn check_etl_health(state: &AppState, timeout_duration: Duration) -> Servi
     .await
     {
         Ok(Ok(response)) => {
-            let latency = start.elapsed().as_millis() as u64;
+            let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
             if response.status().is_success() {
                 ServiceStatus::healthy(latency)
             } else {
@@ -309,7 +315,7 @@ async fn check_nolus_rpc_health(state: &AppState, timeout_duration: Duration) ->
     .await
     {
         Ok(Ok(response)) => {
-            let latency = start.elapsed().as_millis() as u64;
+            let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
             if response.status().is_success() {
                 ServiceStatus::healthy(latency)
             } else {
@@ -342,7 +348,7 @@ async fn check_nolus_rest_health(state: &AppState, timeout_duration: Duration) -
     .await
     {
         Ok(Ok(response)) => {
-            let latency = start.elapsed().as_millis() as u64;
+            let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
             if response.status().is_success() {
                 ServiceStatus::healthy(latency)
             } else {
@@ -376,7 +382,7 @@ async fn check_skip_health(state: &AppState, timeout_duration: Duration) -> Serv
     .await
     {
         Ok(Ok(response)) => {
-            let latency = start.elapsed().as_millis() as u64;
+            let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
             if response.status().is_success() {
                 ServiceStatus::healthy(latency)
             } else {
@@ -414,7 +420,7 @@ async fn check_referral_health(state: &AppState, timeout_duration: Duration) -> 
     .await
     {
         Ok(Ok(response)) => {
-            let latency = start.elapsed().as_millis() as u64;
+            let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
             let status = response.status();
             // 200 = working, 404 = invalid code (expected for dummy), 401 = needs
             // auth (API is reachable). All three confirm connectivity.
@@ -454,7 +460,7 @@ async fn check_zero_interest_health(state: &AppState, timeout_duration: Duration
     .await
     {
         Ok(Ok(response)) => {
-            let latency = start.elapsed().as_millis() as u64;
+            let latency = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
             // 401 means API is reachable but needs auth, which is fine for health check
             if response.status().is_success()
                 || response.status() == reqwest::StatusCode::UNAUTHORIZED
@@ -654,14 +660,14 @@ pub async fn intercom_hash(
         Vec::new()
     });
     let opened_leases: Vec<_> = leases.iter().filter(|l| l.status == "opened").collect();
-    let positions_count = opened_leases.len() as u32;
+    let positions_count = u32::try_from(opened_leases.len()).unwrap_or(u32::MAX);
 
     // Earn
     let (earn_positions, _) = earn_result.unwrap_or_else(|e| {
         warn!("[Intercom] Failed to fetch earn for {}: {}", wallet, e);
         (Vec::new(), "0.00".to_string())
     });
-    let earn_pools_count = earn_positions.len() as u32;
+    let earn_pools_count = u32::try_from(earn_positions.len()).unwrap_or(u32::MAX);
     let earn_deposited_usd = compute_earn_deposited_usd(&earn_positions, &state);
 
     // Staking
@@ -672,15 +678,17 @@ pub async fn intercom_hash(
         );
         Vec::new()
     });
-    let staking_validators_count = delegations.len() as u32;
+    let staking_validators_count = u32::try_from(delegations.len()).unwrap_or(u32::MAX);
     let total_staked_unls: u128 = delegations
         .iter()
         .filter_map(|d| d.balance.amount.parse::<u128>().ok())
         .sum();
-    let staking_delegated_nls = format!("{:.6}", total_staked_unls as f64 / 1_000_000.0);
+    let staking_delegated_nls = format!("{:.6}", u128_to_f64(total_staked_unls) / 1_000_000.0);
     let nls_price = compute_nls_price_usd(&state);
-    let staking_delegated_usd =
-        format!("{:.2}", total_staked_unls as f64 / 1_000_000.0 * nls_price);
+    let staking_delegated_usd = format!(
+        "{:.2}",
+        u128_to_f64(total_staked_unls) / 1_000_000.0 * nls_price
+    );
 
     // Vesting
     let (staking_vested_nls, is_vesting_account) = match account_result {
@@ -747,7 +755,7 @@ async fn compute_total_balance_usd(state: &AppState, address: &str) -> Result<St
                 continue;
             }
             let amount_f64: f64 = bank_balance.amount.parse().unwrap_or(0.0);
-            let decimal_factor = 10_f64.powi(currency.decimal_digits as i32);
+            let decimal_factor = 10_f64.powi(i32::from(currency.decimal_digits));
             let human_amount = amount_f64 / decimal_factor;
             let price_usd = prices_response
                 .prices
@@ -812,7 +820,7 @@ fn compute_earn_deposited_usd(
 
         if let Some(lpn) = lpn_currency {
             let deposited: f64 = position.deposited_lpn.parse().unwrap_or(0.0);
-            let decimal_factor = 10_f64.powi(lpn.decimal_digits as i32);
+            let decimal_factor = 10_f64.powi(i32::from(lpn.decimal_digits));
             let human_amount = deposited / decimal_factor;
             let price_usd = prices
                 .prices
@@ -837,7 +845,7 @@ fn extract_vesting(account: &serde_json::Value) -> (String, bool) {
                 .and_then(|a| a.as_str())
                 .and_then(|a| a.parse::<u128>().ok())
                 .unwrap_or(0);
-            let human_nls = amount as f64 / 1_000_000.0;
+            let human_nls = u128_to_f64(amount) / 1_000_000.0;
             (format!("{:.6}", human_nls), true)
         }
         None => ("0.000000".to_string(), false),

--- a/backend/src/handlers/currencies.rs
+++ b/backend/src/handlers/currencies.rs
@@ -237,7 +237,7 @@ pub async fn get_balances(
                 );
                 0.0
             });
-            let decimal_factor = 10_f64.powi(currency.decimal_digits as i32);
+            let decimal_factor = 10_f64.powi(i32::from(currency.decimal_digits));
             let human_amount = amount_f64 / decimal_factor;
 
             let price_usd = prices
@@ -286,9 +286,9 @@ pub fn calculate_price_with_decimals(
     let mut value = (quote / amt) * lpn;
 
     // Adjust for decimal difference between asset and LPN
-    let decimal_diff = asset_decimals as i16 - lpn_decimals as i16;
+    let decimal_diff = i16::from(asset_decimals) - i16::from(lpn_decimals);
     if decimal_diff != 0 {
-        let power = 10_f64.powi(decimal_diff.abs() as i32);
+        let power = 10_f64.powi(i32::from(decimal_diff.abs()));
         if decimal_diff > 0 {
             value *= power;
         } else {

--- a/backend/src/handlers/earn.rs
+++ b/backend/src/handlers/earn.rs
@@ -18,6 +18,7 @@ use tracing::{debug, warn};
 use utoipa::ToSchema;
 
 use crate::error::AppError;
+use crate::num_utils::u128_to_f64;
 use crate::query_types::AddressQuery;
 use crate::AppState;
 
@@ -113,7 +114,7 @@ pub struct EarnStats {
 // Constants
 // ============================================================================
 
-const INTEREST_DECIMALS: u32 = 7;
+const INTEREST_DECIMALS: i32 = 7;
 
 // ============================================================================
 // Handlers
@@ -466,17 +467,17 @@ pub async fn get_earn_stats(
     // Dispatcher rewards from on-chain (optional - doesn't fail if unavailable)
     let dispatcher_rewards = dispatcher_rewards_result
         .ok()
-        .map(|r| r as f64 / 10f64.powi(INTEREST_DECIMALS as i32));
+        .map(|r| f64::from(r) / 10f64.powi(INTEREST_DECIMALS));
 
     // Calculate pool count and average APY from ETL data
-    let pool_count = etl_pools.len() as u32;
+    let pool_count = u32::try_from(etl_pools.len()).unwrap_or(u32::MAX);
     let total_apy: f64 = etl_pools
         .iter()
         .filter_map(|p| p.apr.as_ref()?.parse::<f64>().ok())
         .sum();
 
     let average_apy = if pool_count > 0 {
-        total_apy / pool_count as f64
+        total_apy / f64::from(pool_count)
     } else {
         0.0
     };
@@ -630,12 +631,21 @@ async fn fetch_position_info(
         ))
     })?;
     let lpp_price_ratio = if price_amount > 0 {
-        price_quote as f64 / price_amount as f64
+        u128_to_f64(price_quote) / u128_to_f64(price_amount)
     } else {
         1.0
     };
 
-    let deposited_lpn = (deposit_amount as f64 * lpp_price_ratio) as u128;
+    // Token amount uses exact integer arithmetic (multiply-before-divide) rather
+    // than the displayed f64 ratio, so the stored nLPN→LPN amount can't drift by
+    // a unit from float rounding. Matches the chain's integer settlement.
+    let deposited_lpn = if price_amount > 0 {
+        deposit_amount
+            .checked_mul(price_quote)
+            .map_or(u128::MAX, |scaled| scaled / price_amount)
+    } else {
+        deposit_amount
+    };
 
     // Get APY from ETL data
     let apy = etl_pools
@@ -765,13 +775,16 @@ async fn fetch_position_for_monitoring(
             protocol, lpp_price.amount.amount
         ))
     })?;
-    let lpp_price_ratio = if price_amount > 0 {
-        price_quote as f64 / price_amount as f64
+    // Exact integer arithmetic (multiply-before-divide) for the token amount —
+    // no f64 round-trip, so it can't drift by a unit. price_amount == 0 keeps
+    // the deposit unscaled, matching the prior 1.0 fallback ratio.
+    let deposited_lpn = if price_amount > 0 {
+        deposit_amount
+            .checked_mul(price_quote)
+            .map_or(u128::MAX, |scaled| scaled / price_amount)
     } else {
-        1.0
+        deposit_amount
     };
-
-    let deposited_lpn = (deposit_amount as f64 * lpp_price_ratio) as u128;
 
     // Calculate rewards (difference between current value and deposited value)
     // For now, rewards tracking would require historical data

--- a/backend/src/handlers/gated_admin.rs
+++ b/backend/src/handlers/gated_admin.rs
@@ -143,7 +143,7 @@ pub async fn list_protocols(
                         .and_then(|config| {
                             config
                                 .currencies
-                                .get(*ticker as &str)
+                                .get(**ticker)
                                 .map(|c| c.is_configured())
                         })
                         .unwrap_or(false)

--- a/backend/src/handlers/gated_admin.rs
+++ b/backend/src/handlers/gated_admin.rs
@@ -141,10 +141,7 @@ pub async fn list_protocols(
                     !currency_config
                         .as_ref()
                         .and_then(|config| {
-                            config
-                                .currencies
-                                .get(**ticker)
-                                .map(|c| c.is_configured())
+                            config.currencies.get(**ticker).map(|c| c.is_configured())
                         })
                         .unwrap_or(false)
                 })

--- a/backend/src/handlers/governance.rs
+++ b/backend/src/handlers/governance.rs
@@ -141,7 +141,7 @@ pub async fn get_proposals(
     State(state): State<Arc<AppState>>,
     Query(query): Query<ProposalsQuery>,
 ) -> Result<(HeaderMap, Json<ProposalsListResponse>), AppError> {
-    let limit = query.limit.unwrap_or(10) as usize;
+    let limit = usize::try_from(query.limit.unwrap_or(10)).unwrap_or(usize::MAX);
     debug!("Fetching proposals from cache, limit: {}", limit);
 
     let cache = &state.data_cache.proposals_with_tally;

--- a/backend/src/handlers/leases.rs
+++ b/backend/src/handlers/leases.rs
@@ -301,7 +301,7 @@ pub async fn get_lease_config(
 // ============================================================================
 
 const PERMILLE: f64 = 1000.0;
-const INTEREST_DECIMALS: u32 = 7;
+const INTEREST_DECIMALS: i32 = 7;
 
 // ============================================================================
 // Handlers
@@ -629,8 +629,8 @@ pub async fn get_lease_quote(
         .await?;
 
     // Convert interest rates to percentage
-    let annual_interest = (quote.annual_interest_rate + quote.annual_interest_rate_margin) as f64
-        / 10f64.powi(INTEREST_DECIMALS as i32)
+    let annual_interest = f64::from(quote.annual_interest_rate + quote.annual_interest_rate_margin)
+        / 10f64.powi(INTEREST_DECIMALS)
         * 100.0;
 
     Ok(Json(LeaseQuoteResponse {
@@ -907,7 +907,7 @@ async fn fetch_lease_info(
             interest: LeaseInterestInfo {
                 loan_rate: opening.opening.loan_interest_rate,
                 margin_rate: 0,
-                annual_rate_percent: opening.opening.loan_interest_rate as f64 / PERMILLE,
+                annual_rate_percent: f64::from(opening.opening.loan_interest_rate) / PERMILLE,
             },
             liquidation_price: None,
             opened_at: etl_data.as_ref().and_then(|d| d.lease.timestamp.clone()),
@@ -1195,8 +1195,8 @@ fn calculate_interest_info(opened: &OpenedLeaseInfo) -> LeaseInterestInfo {
 
 fn calculate_annual_rate(loan_rate: u32, margin_rate: u32) -> f64 {
     // Both loan_rate and margin_rate are in permille (per 1000)
-    let loan_percent = loan_rate as f64 / PERMILLE;
-    let margin_percent = margin_rate as f64 / PERMILLE;
+    let loan_percent = f64::from(loan_rate) / PERMILLE;
+    let margin_percent = f64::from(margin_rate) / PERMILLE;
 
     // Return combined annual rate as percentage
     (loan_percent + margin_percent) * 100.0
@@ -1271,8 +1271,8 @@ fn calculate_pnl(
     let asset_key = format!("{}@{}", asset_ticker, protocol);
     let lpn_key = format!("{}@{}", lpn_ticker, protocol);
 
-    let asset_decimals = currencies.currencies.get(&asset_key)?.decimal_digits as i32;
-    let lpn_decimals = currencies.currencies.get(&lpn_key)?.decimal_digits as i32;
+    let asset_decimals = i32::from(currencies.currencies.get(&asset_key)?.decimal_digits);
+    let lpn_decimals = i32::from(currencies.currencies.get(&lpn_key)?.decimal_digits);
 
     // Look up prices — no price means no PnL (better than wrong PnL)
     let asset_price: f64 = prices
@@ -1305,7 +1305,7 @@ fn calculate_pnl(
             currencies
                 .currencies
                 .get(&cltr_key)
-                .map(|c| c.decimal_digits as i32)
+                .map(|c| i32::from(c.decimal_digits))
         })
         .unwrap_or(lpn_decimals);
 
@@ -1531,7 +1531,7 @@ async fn fetch_lease_monitor_info_internal(
             interest: Some(LeaseInterestInfo {
                 loan_rate: opening.opening.loan_interest_rate,
                 margin_rate: 0,
-                annual_rate_percent: opening.opening.loan_interest_rate as f64 / PERMILLE,
+                annual_rate_percent: f64::from(opening.opening.loan_interest_rate) / PERMILLE,
             }),
             liquidation_price: None,
             pnl: None,
@@ -1565,9 +1565,9 @@ async fn fetch_lease_monitor_info_internal(
                 interest: Some(LeaseInterestInfo {
                     loan_rate: info.loan_interest_rate,
                     margin_rate: info.margin_interest_rate,
-                    annual_rate_percent: (info.loan_interest_rate + info.margin_interest_rate)
-                        as f64
-                        / PERMILLE,
+                    annual_rate_percent: f64::from(
+                        info.loan_interest_rate + info.margin_interest_rate,
+                    ) / PERMILLE,
                 }),
                 liquidation_price: None,
                 pnl: None,
@@ -1603,9 +1603,9 @@ async fn fetch_lease_monitor_info_internal(
                 interest: Some(LeaseInterestInfo {
                     loan_rate: info.loan_interest_rate,
                     margin_rate: info.margin_interest_rate,
-                    annual_rate_percent: (info.loan_interest_rate + info.margin_interest_rate)
-                        as f64
-                        / PERMILLE,
+                    annual_rate_percent: f64::from(
+                        info.loan_interest_rate + info.margin_interest_rate,
+                    ) / PERMILLE,
                 }),
                 liquidation_price: None,
                 pnl: None,

--- a/backend/src/handlers/websocket.rs
+++ b/backend/src/handlers/websocket.rs
@@ -1380,17 +1380,21 @@ async fn check_skip_tx_status(
 
     // Count completed hops
     let transfer_sequence = status_response.transfer_sequence.as_ref();
-    let total_hops = transfer_sequence.map(|s| s.len() as u32).unwrap_or(1);
+    let total_hops = transfer_sequence
+        .map(|s| u32::try_from(s.len()).unwrap_or(u32::MAX))
+        .unwrap_or(1);
     let completed_hops = transfer_sequence
         .map(|seq| {
-            seq.iter()
+            let completed = seq
+                .iter()
                 .filter(|item| {
                     item.ibc_transfer
                         .as_ref()
                         .map(|t| t.state == "TRANSFER_SUCCESS" || t.state == "STATE_COMPLETED")
                         .unwrap_or(false)
                 })
-                .count() as u32
+                .count();
+            u32::try_from(completed).unwrap_or(u32::MAX)
         })
         .unwrap_or(0);
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -29,6 +29,7 @@ mod external;
 mod handlers;
 mod http_utils;
 mod middleware;
+mod num_utils;
 mod propagation;
 mod query_types;
 pub mod refresh;

--- a/backend/src/middleware/rate_limit.rs
+++ b/backend/src/middleware/rate_limit.rs
@@ -74,7 +74,7 @@ struct IpEntry {
 
 impl IpEntry {
     fn new(limiter: IpRateLimiter) -> Self {
-        let ms = epoch().elapsed().as_millis() as u64;
+        let ms = u64::try_from(epoch().elapsed().as_millis()).unwrap_or(u64::MAX);
         Self {
             limiter,
             last_access_ms: AtomicU64::new(ms),
@@ -82,7 +82,7 @@ impl IpEntry {
     }
 
     fn touch(&self) {
-        let ms = epoch().elapsed().as_millis() as u64;
+        let ms = u64::try_from(epoch().elapsed().as_millis()).unwrap_or(u64::MAX);
         self.last_access_ms.store(ms, Ordering::Relaxed);
     }
 
@@ -153,13 +153,15 @@ impl RateLimitState {
     /// Remove entries that haven't been accessed within `max_age`
     pub async fn cleanup_stale(&self, max_age: Duration) {
         let now = epoch().elapsed();
-        let max_age_ms = max_age.as_millis() as u64;
+        let max_age_ms = u64::try_from(max_age.as_millis()).unwrap_or(u64::MAX);
         let mut limiters = self.limiters.write().await;
         let before = limiters.len();
         limiters.retain(|_, entry| {
-            let age_ms = now
-                .as_millis()
-                .saturating_sub(entry.last_access().as_millis()) as u64;
+            let age_ms = u64::try_from(
+                now.as_millis()
+                    .saturating_sub(entry.last_access().as_millis()),
+            )
+            .unwrap_or(u64::MAX);
             age_ms < max_age_ms
         });
         let removed = before - limiters.len();

--- a/backend/src/num_utils.rs
+++ b/backend/src/num_utils.rs
@@ -1,0 +1,45 @@
+//! Numeric conversion helpers that avoid `as` casts.
+//!
+//! `clippy::as_conversions` forbids `as` in this crate. Most casts have a
+//! `From`/`TryFrom` replacement, but `f64` has neither `From<u128>` nor
+//! `TryFrom<u128>` in std (the conversion is lossy above 2^53). This module
+//! holds the one conversion that needs a non-trivial, reviewed strategy.
+
+/// Convert an unsigned 128-bit integer to `f64` without an `as` cast.
+///
+/// Routes through the decimal string, whose `f64` parse is correctly rounded.
+/// For every value that fits f64's 53-bit mantissa — which covers all realistic
+/// token/price amounts (micro-unit balances stay well under 2^53) — this
+/// reproduces the old `value as f64` result bit-for-bit. Values too large for
+/// `f64` parse to `f64::INFINITY`, matching the saturating behavior of `as`,
+/// so the `unwrap_or` fallback is unreachable for any integer string.
+pub fn u128_to_f64(value: u128) -> f64 {
+    value.to_string().parse().unwrap_or(f64::INFINITY)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_for_small_values() {
+        assert_eq!(u128_to_f64(0), 0.0);
+        assert_eq!(u128_to_f64(1), 1.0);
+        assert_eq!(u128_to_f64(1_000_000), 1_000_000.0);
+        assert_eq!(u128_to_f64(123_456_789), 123_456_789.0);
+    }
+
+    #[test]
+    fn exact_at_mantissa_boundary() {
+        // 2^53 is the largest integer with an exact f64 representation.
+        assert_eq!(u128_to_f64(9_007_199_254_740_992), 9_007_199_254_740_992.0);
+    }
+
+    #[test]
+    fn ratio_matches_float_division() {
+        // The earn LPP-price ratio path: quote / amount.
+        let quote = 1_234_567_890_u128;
+        let amount = 1_000_000_u128;
+        assert_eq!(u128_to_f64(quote) / u128_to_f64(amount), 1234.56789);
+    }
+}


### PR DESCRIPTION
## What

Closes #179. Replaces every `as` numeric cast in non-test backend code with a type-safe conversion, then ratchets `clippy::as_conversions` from `warn` to `deny` and removes the `-A clippy::as_conversions` override from the CI clippy step.

After this, `cargo clippy --all-targets --all-features -- -D warnings` (with the remaining pending `-A` flags, `as_conversions` no longer among them) passes — that is the acceptance bar.

## How each cast was handled (judgment per site, not a blanket rewrite)

- **Lossless widening** → `From`/`into`: `u64::from`, `f64::from`, `i32::from`, `i16::from` (e.g. `decimal_digits: u8 → i32`, interest rates `u32 → f64`, `subsec_nanos(): u32 → u64`).
- **Narrowing counts / latency / timestamps** (`usize→u32/u64`, `u128→u64`) → `u32::try_from(...).unwrap_or(u32::MAX)` etc. Saturating is strictly more correct than the old truncating `as` and is unreachable for realistic inputs.
- **`INTEREST_DECIMALS`** changed `u32 → i32` in `earn.rs`/`leases.rs` so `.powi(...)` needs no cast (the const has no other use).
- **JWT `exp`** (`intercom.rs`): `.timestamp() as usize` → `usize::try_from(...).map_err(AppError::Internal)?` — fails closed, never substitutes a garbage `exp`.
- **`u128 → f64`** (std has no `From`/`TryFrom`): new `num_utils::u128_to_f64` routes through the decimal string. It reproduces `value as f64` bit-for-bit for every value within f64's 53-bit mantissa, which covers all realistic micro-unit token/price amounts. Shipped with unit tests.
- **`earn.rs` `deposited_lpn`** (the one deliberate behavior change): the float round-trip `(deposit_amount as f64 * (price_quote as f64 / price_amount as f64)) as u128` becomes exact integer arithmetic `deposit_amount.checked_mul(price_quote).map_or(u128::MAX, |s| s / price_amount)`. There is no `as`-free way to reproduce a `f64 → u128` truncation, and integer multiply-before-divide matches the chain's integer settlement. Multiply-before-divide order preserved; `price_amount == 0` keeps the deposit unscaled (matching the old `1.0` ratio fallback); overflow saturates to `u128::MAX` (matching the old float saturation). The displayed `lpp_price` ratio field is unchanged.

No `#[allow(clippy::as_conversions)]` anywhere — the `-A` is removed, not relocated. No `.unwrap()`/`.expect()` introduced in non-test code.

## Quality gate (run from `backend/`)

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings <remaining -A flags, as_conversions removed>` — clean
- `cargo build --all-targets` — clean
- `cargo test --all-targets` — 468 passed (incl. new `num_utils` tests; openapi snapshot test still green → no API shape change)
- `scripts/style-check.sh` — passed

## Independent reviews (fresh context, diff-only)

**Correctness review — PASS (all 12 bug-checklist items).** Confirmed no converted site changes output for realistic inputs except the intentional `earn.rs deposited_lpn` float→exact-integer migration, which is a sanctioned correctness improvement (differs from the old float by at most a sub-unit rounding error, in the direction of the exact on-chain value). Saturating narrowings verified unreachable for realistic inputs; no logic inversions; no div-by-zero (`hit_rate` guard consistent with its divisor).

**Security review — CLEAR (no findings above informational).** Money-path value integrity confirmed; rate-limiter saturation cannot disable limiting and fails safe (worst case = early eviction → fresh limiter; `age` uses `saturating_sub` over a monotonic clock); JWT `exp` fails closed; no new dependencies; no new panics.

The two reviews agree on shipping, so no further adjudication was required.
