### PR TITLE
fix(backend): replace non-test panics with typed errors

### DIFF
--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -123,12 +123,10 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
 
-      - name: Clippy (deny warnings; pending restriction lints allowed until their fix-issues land — #170/#179/#186/#187/#188)
+      - name: Clippy (deny warnings; pending restriction lints allowed until their fix-issues land — #186/#187/#188)
         run: >-
           cargo clippy --all-targets --all-features --
           -D warnings
-          -A clippy::unwrap_used
-          -A clippy::expect_used
           -A clippy::too_many_lines
           -A clippy::cognitive_complexity
           -A clippy::missing_const_for_fn

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -89,8 +89,8 @@ strip = true
 as_conversions = "deny"
 too_many_lines = { level = "warn", priority = -1 }
 cognitive_complexity = { level = "warn", priority = -1 }
-unwrap_used = "warn"
-expect_used = "warn"
+unwrap_used = "deny"
+expect_used = "deny"
 missing_const_for_fn = { level = "warn", priority = -1 }
 redundant_pub_crate = "deny"
 single_char_lifetime_names = "warn"

--- a/backend/clippy.toml
+++ b/backend/clippy.toml
@@ -1,2 +1,4 @@
 too-many-lines-threshold = 40
 cognitive-complexity-threshold = 15
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -277,13 +277,15 @@ impl AppConfig {
             intercom_secret_key: env::var("INTERCOM_SECRET_KEY").unwrap_or_else(|_| String::new()),
         };
 
+        let port: u16 = env::var("PORT")
+            .unwrap_or_else(|_| "3000".to_string())
+            .parse()
+            .map_err(|e| anyhow::anyhow!("PORT must be a valid port number (u16): {e}"))?;
+
         Ok(Self {
             server: ServerConfig {
                 host: env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string()),
-                port: env::var("PORT")
-                    .unwrap_or_else(|_| "3000".to_string())
-                    .parse()
-                    .expect("PORT must be a number"),
+                port,
                 cors_origins: env::var("CORS_ORIGINS").ok().map(|v| {
                     v.split(',')
                         .map(|s| s.trim().to_string())

--- a/backend/src/external/chain.rs
+++ b/backend/src/external/chain.rs
@@ -163,7 +163,14 @@ impl ChainClient {
             backoff_ms *= 2;
         }
 
-        unreachable!()
+        // The `attempt == MAX_RETRIES` branch returns on the final iteration,
+        // so the loop never falls through here in practice. Return a typed
+        // error rather than panicking the request task if that invariant is
+        // ever broken (e.g. MAX_RETRIES being made 0).
+        Err(AppError::ChainRpc {
+            chain: "nolus".to_string(),
+            message: format!("retry loop exhausted after {} retries", MAX_RETRIES),
+        })
     }
 
     /// Query a CosmWasm contract
@@ -1368,6 +1375,35 @@ mod tests {
 
     fn create_test_client(base_url: &str) -> ChainClient {
         ChainClient::new(base_url.to_string(), Client::new())
+    }
+
+    #[tokio::test]
+    async fn chain_get_returns_typed_error_when_retries_exhausted() {
+        // A node that always answers 503 forces the bounded retry loop to
+        // exhaust every attempt. The exhausted path must return a typed
+        // `AppError::ChainRpc`, never panic the request task.
+        let mock_server = setup_mock_server().await;
+        let client = create_test_client(&mock_server.uri());
+
+        Mock::given(method("GET"))
+            .and(path("/always-503"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&mock_server)
+            .await;
+
+        let url = format!("{}/always-503", mock_server.uri());
+        let result = client.chain_get(&url).await;
+
+        match result {
+            Err(AppError::ChainRpc { chain, message }) => {
+                assert_eq!(chain, "nolus");
+                assert!(
+                    message.contains(&format!("{} retries", MAX_RETRIES)),
+                    "expected retry-count in message, got: {message}"
+                );
+            }
+            other => panic!("expected AppError::ChainRpc after retry exhaustion, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/backend/src/external/referral.rs
+++ b/backend/src/external/referral.rs
@@ -120,7 +120,7 @@ impl ReferralClient {
         query: RewardsQuery,
     ) -> Result<RewardsResponse, AppError> {
         let endpoint = format!("api/referrers/{}/rewards", wallet_address);
-        let params = query.to_params();
+        let params = query.to_params()?;
         let param_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
         let wrapper: ApiWrapper<RewardsResponse> = if param_refs.is_empty() {
@@ -139,7 +139,7 @@ impl ReferralClient {
         query: PayoutsQuery,
     ) -> Result<PayoutsResponse, AppError> {
         let endpoint = format!("api/referrers/{}/payouts", wallet_address);
-        let params = query.to_params();
+        let params = query.to_params()?;
         let param_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
         let wrapper: ApiWrapper<PayoutsResponse> = if param_refs.is_empty() {
@@ -158,7 +158,7 @@ impl ReferralClient {
         query: ReferralsQuery,
     ) -> Result<ReferralsResponse, AppError> {
         let endpoint = format!("api/referrers/{}/referrals", wallet_address);
-        let params = query.to_params();
+        let params = query.to_params()?;
         let param_refs: Vec<(&str, &str)> = params.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
         let wrapper: ApiWrapper<ReferralsResponse> = if param_refs.is_empty() {
@@ -442,16 +442,13 @@ pub struct RewardsQuery {
 }
 
 impl RewardsQuery {
-    fn to_params(&self) -> Vec<(&'static str, String)> {
+    fn to_params(&self) -> Result<Vec<(&'static str, String)>, AppError> {
         let mut params = vec![];
         if let Some(status) = &self.status {
-            params.push((
-                "status",
-                serde_json::to_string(status)
-                    .unwrap()
-                    .trim_matches('"')
-                    .to_string(),
-            ));
+            let serialized = serde_json::to_string(status).map_err(|e| {
+                AppError::Internal(format!("failed to serialize status filter: {e}"))
+            })?;
+            params.push(("status", serialized.trim_matches('"').to_string()));
         }
         if let Some(limit) = self.limit {
             params.push(("limit", limit.to_string()));
@@ -459,7 +456,7 @@ impl RewardsQuery {
         if let Some(offset) = self.offset {
             params.push(("offset", offset.to_string()));
         }
-        params
+        Ok(params)
     }
 }
 
@@ -471,16 +468,13 @@ pub struct PayoutsQuery {
 }
 
 impl PayoutsQuery {
-    fn to_params(&self) -> Vec<(&'static str, String)> {
+    fn to_params(&self) -> Result<Vec<(&'static str, String)>, AppError> {
         let mut params = vec![];
         if let Some(status) = &self.status {
-            params.push((
-                "status",
-                serde_json::to_string(status)
-                    .unwrap()
-                    .trim_matches('"')
-                    .to_string(),
-            ));
+            let serialized = serde_json::to_string(status).map_err(|e| {
+                AppError::Internal(format!("failed to serialize status filter: {e}"))
+            })?;
+            params.push(("status", serialized.trim_matches('"').to_string()));
         }
         if let Some(limit) = self.limit {
             params.push(("limit", limit.to_string()));
@@ -488,7 +482,7 @@ impl PayoutsQuery {
         if let Some(offset) = self.offset {
             params.push(("offset", offset.to_string()));
         }
-        params
+        Ok(params)
     }
 }
 
@@ -500,16 +494,13 @@ pub struct ReferralsQuery {
 }
 
 impl ReferralsQuery {
-    fn to_params(&self) -> Vec<(&'static str, String)> {
+    fn to_params(&self) -> Result<Vec<(&'static str, String)>, AppError> {
         let mut params = vec![];
         if let Some(status) = &self.status {
-            params.push((
-                "status",
-                serde_json::to_string(status)
-                    .unwrap()
-                    .trim_matches('"')
-                    .to_string(),
-            ));
+            let serialized = serde_json::to_string(status).map_err(|e| {
+                AppError::Internal(format!("failed to serialize status filter: {e}"))
+            })?;
+            params.push(("status", serialized.trim_matches('"').to_string()));
         }
         if let Some(limit) = self.limit {
             params.push(("limit", limit.to_string()));
@@ -517,7 +508,7 @@ impl ReferralsQuery {
         if let Some(offset) = self.offset {
             params.push(("offset", offset.to_string()));
         }
-        params
+        Ok(params)
     }
 }
 

--- a/backend/src/handlers/gated_admin.rs
+++ b/backend/src/handlers/gated_admin.rs
@@ -339,8 +339,13 @@ pub async fn upsert_currency_display(
     state.config_store.save_currency_display(&config).await?;
     trigger_gated_refresh(&state);
 
-    // Return the updated entry
-    let enrichment = config.currencies.get(&ticker).unwrap();
+    // Return the updated entry — present because it was just inserted above.
+    let enrichment = config
+        .currencies
+        .get(&ticker)
+        .ok_or_else(|| AppError::NotFound {
+            resource: format!("currency display for {ticker}"),
+        })?;
     Ok(Json(AdminCurrencyResponse {
         ticker: ticker.clone(),
         denom: String::new(), // Would need ETL lookup
@@ -436,7 +441,13 @@ pub async fn upsert_network_config(
         .await?;
     trigger_gated_refresh(&state);
 
-    let net_config = config.networks.get(&network).unwrap();
+    // Present because it was just inserted above.
+    let net_config = config
+        .networks
+        .get(&network)
+        .ok_or_else(|| AppError::NotFound {
+            resource: format!("network config for {network}"),
+        })?;
     Ok(Json(AdminNetworkResponse {
         network: network.clone(),
         source: "config".to_string(),

--- a/backend/src/handlers/spa.rs
+++ b/backend/src/handlers/spa.rs
@@ -5,7 +5,7 @@
 
 use axum::{
     body::Body,
-    http::{Request, Response, StatusCode, Uri},
+    http::{HeaderValue, Request, Response, StatusCode, Uri},
 };
 use std::convert::Infallible;
 use std::future::Future;
@@ -36,8 +36,9 @@ impl Service<Request<Body>> for SpaFallback {
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Both `ServeDir` and this service use `Error = Infallible`, so the
+        // readiness result passes through unchanged.
         <ServeDir as Service<Request<Body>>>::poll_ready(&mut self.serve_dir, cx)
-            .map_err(|_| unreachable!())
     }
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
@@ -45,11 +46,13 @@ impl Service<Request<Body>> for SpaFallback {
         let static_dir = self.static_dir.clone();
 
         Box::pin(async move {
-            // Try to serve the static file first
-            let response = serve_dir
-                .call(req)
-                .await
-                .expect("ServeDir::Error is Infallible; cannot fail");
+            // Try to serve the static file first. `ServeDir::Error` is
+            // `Infallible`, so the `Err` arm is uninhabited — `match e {}`
+            // discharges it without an assertion.
+            let response = match serve_dir.call(req).await {
+                Ok(response) => response,
+                Err(e) => match e {},
+            };
 
             // If the file was not found (404) or ServeDir is trying to
             // redirect to a directory with a trailing slash (3xx), serve
@@ -59,29 +62,26 @@ impl Service<Request<Body>> for SpaFallback {
             // stripping trailing slashes causes an infinite loop:
             //   /assets → 307 /assets/ → nginx 301 /assets → …
             if response.status() == StatusCode::NOT_FOUND || response.status().is_redirection() {
-                // Create a new request for index.html
-                let index_req = Request::builder()
-                    .uri(Uri::from_static("/index.html"))
-                    .body(Body::empty())
-                    .expect("static /index.html URI and empty body are always valid");
+                // Build the index.html request directly: `Request::new` is
+                // infallible and `Uri::from_static` validates the static
+                // path at construction, so no builder `Result` to unwrap.
+                let mut index_req = Request::new(Body::empty());
+                *index_req.uri_mut() = Uri::from_static("/index.html");
 
                 // Create a new ServeDir to serve index.html
                 let mut index_serve = ServeDir::new(&static_dir);
-                let index_response = index_serve
-                    .call(index_req)
-                    .await
-                    .expect("ServeDir::Error is Infallible; cannot fail");
+                let index_response = match index_serve.call(index_req).await {
+                    Ok(response) => response,
+                    Err(e) => match e {},
+                };
 
                 // Return with 200 OK status instead of preserving the original status
                 let (mut parts, body) = index_response.into_parts();
                 parts.status = StatusCode::OK;
                 // Add cache control header to prevent caching of the fallback
-                parts.headers.insert(
-                    "cache-control",
-                    "no-cache"
-                        .parse()
-                        .expect("\"no-cache\" is a valid static HeaderValue"),
-                );
+                parts
+                    .headers
+                    .insert("cache-control", HeaderValue::from_static("no-cache"));
 
                 Ok(Response::from_parts(parts, Body::new(body)))
             } else {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -100,7 +100,13 @@ async fn main() -> anyhow::Result<()> {
     }
     let addr: SocketAddr = format!("{}:{}", config.server.host, config.server.port)
         .parse()
-        .expect("Invalid server address");
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "invalid server address {}:{}: {e}",
+                config.server.host,
+                config.server.port
+            )
+        })?;
 
     // Create HTTP client for external APIs with optimized connection pooling
     let http_client = reqwest::Client::builder()
@@ -217,21 +223,24 @@ async fn main() -> anyhow::Result<()> {
     // Build router
     let app = create_router(state);
 
+    // Install the SIGTERM handler before serving so a failure propagates
+    // (and aborts startup) instead of panicking the shutdown task later.
+    let sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .map_err(|e| anyhow::anyhow!("failed to install SIGTERM handler: {e}"))?;
+
     // Start server
     info!("Starting server on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(shutdown_signal(sigterm))
         .await?;
     info!("Server shut down gracefully");
 
     Ok(())
 }
 
-async fn shutdown_signal() {
+async fn shutdown_signal(mut sigterm: tokio::signal::unix::Signal) {
     let ctrl_c = tokio::signal::ctrl_c();
-    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-        .expect("failed to install SIGTERM handler");
 
     tokio::select! {
         _ = ctrl_c => { info!("Received SIGINT, shutting down"); }

--- a/backend/src/middleware/cache_control.rs
+++ b/backend/src/middleware/cache_control.rs
@@ -4,7 +4,7 @@
 
 use axum::{
     body::Body,
-    http::{header, Request, Response},
+    http::{header, HeaderValue, Request, Response},
     middleware::Next,
 };
 
@@ -42,18 +42,26 @@ pub async fn cache_control_middleware(request: Request<Body>, next: Next) -> Res
     if max_age == 0 {
         response
             .headers_mut()
-            .insert(header::CACHE_CONTROL, "no-store".parse().unwrap());
+            .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
     } else {
-        response.headers_mut().insert(
-            header::CACHE_CONTROL,
-            format!(
-                "public, max-age={}, stale-while-revalidate={}",
-                max_age,
-                max_age / 2
-            )
-            .parse()
-            .unwrap(),
+        // The formatted value is always a valid header value (ASCII digits and
+        // a fixed template); skip insertion rather than panic if that ever
+        // changes.
+        let value = format!(
+            "public, max-age={}, stale-while-revalidate={}",
+            max_age,
+            max_age / 2
         );
+        match HeaderValue::from_str(&value) {
+            Ok(header_value) => {
+                response
+                    .headers_mut()
+                    .insert(header::CACHE_CONTROL, header_value);
+            }
+            Err(e) => {
+                tracing::error!("failed to build Cache-Control header from {value:?}: {e}");
+            }
+        }
     }
 
     response

--- a/backend/src/translations/validation.rs
+++ b/backend/src/translations/validation.rs
@@ -3,22 +3,29 @@
 //! Ensures that template variables like {name}, {0}, {{count}} are preserved
 //! in translations.
 
-use lazy_static::lazy_static;
 use regex::Regex;
 use serde::Serialize;
 use std::collections::HashSet;
+use std::sync::LazyLock;
 
-lazy_static! {
-    /// Regex to match placeholders in translation strings
-    /// Matches:
-    /// - {name} - simple placeholder
-    /// - {0}, {1} - numbered placeholder
-    /// - {{name}} - double-braced placeholder
-    /// - %s, %d - printf-style placeholder
-    static ref PLACEHOLDER_REGEX: Regex = Regex::new(
-        r"\{\{?\w+\}?\}|%[sd]|\{[0-9]+\}"
-    ).expect("Invalid placeholder regex");
-}
+/// Source pattern for [`PLACEHOLDER_REGEX`]. A compile-time constant whose
+/// validity is pinned by `placeholder_regex_compiles` below.
+const PLACEHOLDER_PATTERN: &str = r"\{\{?\w+\}?\}|%[sd]|\{[0-9]+\}";
+
+/// Regex to match placeholders in translation strings.
+///
+/// Matches:
+/// - `{name}` - simple placeholder
+/// - `{0}`, `{1}` - numbered placeholder
+/// - `{{name}}` - double-braced placeholder
+/// - `%s`, `%d` - printf-style placeholder
+///
+/// The pattern is a constant, so compilation only fails if the constant
+/// above is edited to something invalid — a bug the compile-guard test
+/// catches. `None` is therefore unreachable at runtime; callers log loudly
+/// and degrade rather than panic if it ever occurs.
+static PLACEHOLDER_REGEX: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(PLACEHOLDER_PATTERN).ok());
 
 /// Result of placeholder validation
 #[derive(Debug, Clone, Serialize)]
@@ -37,7 +44,14 @@ pub struct ValidationResult {
 
 /// Extract all placeholders from a text string
 pub fn extract_placeholders(text: &str) -> Vec<String> {
-    PLACEHOLDER_REGEX
+    let Some(regex) = PLACEHOLDER_REGEX.as_ref() else {
+        tracing::error!(
+            "placeholder regex failed to compile from a constant pattern — \
+             returning no placeholders; this is a build-time bug"
+        );
+        return Vec::new();
+    };
+    regex
         .find_iter(text)
         .map(|m| m.as_str().to_string())
         .collect()
@@ -45,6 +59,20 @@ pub fn extract_placeholders(text: &str) -> Vec<String> {
 
 /// Validate that a translation preserves all placeholders from the source
 pub fn validate_placeholders(source: &str, translation: &str) -> ValidationResult {
+    // Fail closed: if the placeholder regex is unavailable we cannot prove
+    // placeholders were preserved, so report invalid rather than letting an
+    // empty extraction collapse to a spurious "valid". `None` is unreachable
+    // for the constant pattern (guarded by `placeholder_regex_compiles`).
+    if PLACEHOLDER_REGEX.is_none() {
+        return ValidationResult {
+            valid: false,
+            source_placeholders: Vec::new(),
+            translation_placeholders: Vec::new(),
+            missing: Vec::new(),
+            extra: Vec::new(),
+        };
+    }
+
     let source_placeholders = extract_placeholders(source);
     let translation_placeholders = extract_placeholders(translation);
 
@@ -78,6 +106,17 @@ pub fn validate_placeholders(source: &str, translation: &str) -> ValidationResul
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn placeholder_regex_compiles() {
+        // Guards the constant pattern: if an edit makes it invalid, the
+        // `LazyLock` resolves to `None` and this fails CI before the silent
+        // empty-placeholder degradation can ship.
+        assert!(
+            PLACEHOLDER_REGEX.is_some(),
+            "PLACEHOLDER_PATTERN must be a valid regex"
+        );
+    }
 
     #[test]
     fn test_extract_simple_placeholders() {


### PR DESCRIPTION
## Summary

Closes #170. Removes every `.unwrap()` / `.expect()` / `unreachable!()` from
non-test backend code, replacing each with typed-error propagation through
`AppError` (or `anyhow` at the `main`/config startup boundary), then ratchets
the clippy gate so regressions fail the build.

The blocker (#168, clippy gate) is merged, so the issue was unblocked — label
flipped `status:blocked` → `status:ready`.

## What changed

- **`external/chain.rs`** — the `unreachable!()` at the tail of the bounded
  retry loop (which would panic the request task on retry exhaustion, including
  in release builds) now returns a typed `AppError::ChainRpc`. Added a unit test
  driving a mock node that always answers 503 and asserting the typed error.
- **`handlers/gated_admin.rs`** — two post-insert `.get(..).unwrap()` →
  `.ok_or_else(|| AppError::NotFound { .. })?`.
- **`external/referral.rs`** — three `serde_json::to_string(status).unwrap()` →
  `map_err` into `AppError::Internal`; `to_params` is now fallible and threaded
  through the three callers with `?`.
- **`middleware/cache_control.rs`** — static `"no-store"` header via
  `HeaderValue::from_static`; the dynamic value via `HeaderValue::from_str` and
  logs loudly (never panics) on the unreachable parse-failure branch.
- **`config.rs` / `main.rs`** — `PORT` parse, server-addr parse, and the SIGTERM
  handler install now propagate via `anyhow` (`?`) instead of `.expect()`. The
  SIGTERM signal is installed before `axum::serve` and passed into
  `shutdown_signal`; graceful-shutdown semantics are unchanged.
- **`handlers/spa.rs`** — the SPA fallback `Service` impl drops four `.expect()`
  and one `unreachable!()`: `Infallible` errors are discharged via `match e {}`,
  the index request is built with `Request::new` + `uri_mut`, and the no-cache
  header uses `HeaderValue::from_static`. 404/redirect → `index.html` with
  `200 OK` + `no-cache` is preserved (existing tests lock it).
- **`translations/validation.rs`** — the `lazy_static!` regex + `.expect()`
  becomes a `LazyLock<Option<Regex>>` over a named `const` pattern, guarded by a
  new `placeholder_regex_compiles` test. `validate_placeholders` fails **closed**
  (reports invalid) if the regex were ever unavailable, rather than letting an
  empty extraction collapse to a spurious "valid".

### Ratchet

- `Cargo.toml`: `unwrap_used` / `expect_used` → `deny`.
- `pr-validate.yaml`: dropped `-A clippy::unwrap_used` / `-A clippy::expect_used`
  from the clippy step (the other restriction `-A`s remain — #186/#187/#188).
- `clippy.toml`: added `allow-unwrap-in-tests` / `allow-expect-in-tests` so the
  legitimate test-code unwraps stay allowed under `--all-targets`.

## Reviews

A fresh correctness review (zero implementation context, 12-item bug checklist)
returned PASS on all items with a ship verdict. An independent security review
of the error/panic-path changes returned clear, with no findings above medium;
the two medium items it raised were latent fail-open footguns on unreachable,
const-guarded branches — both hardened in this PR (the `validate_placeholders`
fail-closed guard and the loud-degrade log in `cache_control.rs`).

## Testing

From `backend/`: `cargo fmt --check`, `cargo clippy --all-targets` (with
unwrap/expect denied), `cargo build --all-targets`, `cargo test --all-targets`
(470 passed), and `scripts/style-check.sh` — all green. Husky pre-commit
(frontend lint/test/build) passed.
