### PR TITLE
chore(backend): name error-discarding closures, thread parse errors

### DIFF
--- a/backend/src/chain_events.rs
+++ b/backend/src/chain_events.rs
@@ -149,7 +149,7 @@ impl ChainEventClient {
             tokio_tungstenite::connect_async(&self.ws_url),
         )
         .await
-        .map_err(|_| {
+        .map_err(|_err| {
             format!(
                 "WebSocket connect timed out after {}s",
                 CONNECT_TIMEOUT.as_secs()

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -255,7 +255,7 @@ impl AppConfig {
             // Unauthenticated
             etl_api_url,
             skip_api_url: env::var("SKIP_API_URL")
-                .unwrap_or_else(|_| "https://api.skip.money".to_string()),
+                .unwrap_or_else(|_err| "https://api.skip.money".to_string()),
             skip_api_key: env::var("SKIP_API_KEY").ok(),
 
             // Chain RPCs & REST (only Nolus required)
@@ -263,28 +263,30 @@ impl AppConfig {
             nolus_rest_url,
 
             // Authenticated - Referral
-            referral_api_url: env::var("REFERRAL_API_URL").unwrap_or_else(|_| String::new()),
-            referral_api_token: env::var("REFERRAL_API_TOKEN").unwrap_or_else(|_| String::new()),
+            referral_api_url: env::var("REFERRAL_API_URL").unwrap_or_else(|_err| String::new()),
+            referral_api_token: env::var("REFERRAL_API_TOKEN").unwrap_or_else(|_err| String::new()),
 
             // Authenticated - Zero Interest
             zero_interest_api_url: env::var("ZERO_INTEREST_API_URL")
-                .unwrap_or_else(|_| String::new()),
+                .unwrap_or_else(|_err| String::new()),
             zero_interest_api_token: env::var("ZERO_INTEREST_API_TOKEN")
-                .unwrap_or_else(|_| String::new()),
+                .unwrap_or_else(|_err| String::new()),
 
             // Intercom
-            intercom_app_id: env::var("INTERCOM_APP_ID").unwrap_or_else(|_| "hbjifswh".to_string()),
-            intercom_secret_key: env::var("INTERCOM_SECRET_KEY").unwrap_or_else(|_| String::new()),
+            intercom_app_id: env::var("INTERCOM_APP_ID")
+                .unwrap_or_else(|_err| "hbjifswh".to_string()),
+            intercom_secret_key: env::var("INTERCOM_SECRET_KEY")
+                .unwrap_or_else(|_err| String::new()),
         };
 
         let port: u16 = env::var("PORT")
-            .unwrap_or_else(|_| "3000".to_string())
+            .unwrap_or_else(|_err| "3000".to_string())
             .parse()
             .map_err(|e| anyhow::anyhow!("PORT must be a valid port number (u16): {e}"))?;
 
         Ok(Self {
             server: ServerConfig {
-                host: env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string()),
+                host: env::var("HOST").unwrap_or_else(|_err| "0.0.0.0".to_string()),
                 port,
                 cors_origins: env::var("CORS_ORIGINS").ok().map(|v| {
                     v.split(',')
@@ -296,10 +298,10 @@ impl AppConfig {
             external,
             admin: AdminConfig {
                 enabled: env::var("ADMIN_API_ENABLED")
-                    .unwrap_or_else(|_| "false".to_string())
+                    .unwrap_or_else(|_err| "false".to_string())
                     .parse()
                     .unwrap_or(false),
-                api_key: env::var("ADMIN_API_KEY").unwrap_or_else(|_| String::new()),
+                api_key: env::var("ADMIN_API_KEY").unwrap_or_else(|_err| String::new()),
             },
             protocols: ProtocolsConfig {
                 admin_contract: Self::get_required_env("ADMIN_CONTRACT", "Admin contract address")?,

--- a/backend/src/external/intercom.rs
+++ b/backend/src/external/intercom.rs
@@ -111,7 +111,9 @@ impl IntercomClient {
                 })?
                 .timestamp(),
         )
-        .map_err(|_| AppError::Internal("Token expiration timestamp out of range".to_string()))?;
+        .map_err(|_err| {
+            AppError::Internal("Token expiration timestamp out of range".to_string())
+        })?;
 
         // Flatten attributes into a HashMap for the JWT payload
         let attributes_map: HashMap<String, serde_json::Value> = {

--- a/backend/src/handlers/currencies.rs
+++ b/backend/src/handlers/currencies.rs
@@ -230,7 +230,7 @@ pub async fn get_balances(
             }
 
             // Calculate USD value
-            let amount_f64: f64 = bank_balance.amount.parse().unwrap_or_else(|_| {
+            let amount_f64: f64 = bank_balance.amount.parse().unwrap_or_else(|_err| {
                 warn!(
                     "Failed to parse balance amount for {}: {}",
                     currency.ticker, bank_balance.amount

--- a/backend/src/handlers/earn.rs
+++ b/backend/src/handlers/earn.rs
@@ -543,9 +543,9 @@ pub async fn fetch_pool_info(
         .unwrap_or(0.0);
 
     // Calculate available liquidity — parse failures are chain data errors, not safe to default
-    let total_balance: u128 = lpp_balance.balance.amount.parse().map_err(|_| {
+    let total_balance: u128 = lpp_balance.balance.amount.parse().map_err(|e| {
         AppError::Internal(format!(
-            "Unparseable LPP balance for {}: '{}'",
+            "Unparseable LPP balance for {}: '{}': {e}",
             protocol, lpp_balance.balance.amount
         ))
     })?;
@@ -553,9 +553,9 @@ pub async fn fetch_pool_info(
         .total_principal_due
         .amount
         .parse()
-        .map_err(|_| {
+        .map_err(|e| {
             AppError::Internal(format!(
-                "Unparseable LPP total_principal_due for {}: '{}'",
+                "Unparseable LPP total_principal_due for {}: '{}': {e}",
                 protocol, lpp_balance.total_principal_due.amount
             ))
         })?;
@@ -599,9 +599,9 @@ async fn fetch_position_info(
         .get_lender_deposit(lpp_address, owner)
         .await?;
 
-    let deposit_amount: u128 = deposit.amount.parse().map_err(|_| {
+    let deposit_amount: u128 = deposit.amount.parse().map_err(|e| {
         AppError::Internal(format!(
-            "Unparseable deposit amount for {} owner {}: '{}'",
+            "Unparseable deposit amount for {} owner {}: '{}': {e}",
             protocol, owner, deposit.amount
         ))
     })?;
@@ -618,15 +618,15 @@ async fn fetch_position_info(
     )?;
 
     // Calculate LPN value from nLPN — fallback to 1 inverts the price ratio
-    let price_quote: u128 = lpp_price.amount_quote.amount.parse().map_err(|_| {
+    let price_quote: u128 = lpp_price.amount_quote.amount.parse().map_err(|e| {
         AppError::Internal(format!(
-            "Unparseable LPP price_quote for {}: '{}'",
+            "Unparseable LPP price_quote for {}: '{}': {e}",
             protocol, lpp_price.amount_quote.amount
         ))
     })?;
-    let price_amount: u128 = lpp_price.amount.amount.parse().map_err(|_| {
+    let price_amount: u128 = lpp_price.amount.amount.parse().map_err(|e| {
         AppError::Internal(format!(
-            "Unparseable LPP price_amount for {}: '{}'",
+            "Unparseable LPP price_amount for {}: '{}': {e}",
             protocol, lpp_price.amount.amount
         ))
     })?;
@@ -747,9 +747,9 @@ async fn fetch_position_for_monitoring(
         .get_lender_deposit(lpp_address, owner)
         .await?;
 
-    let deposit_amount: u128 = deposit.amount.parse().map_err(|_| {
+    let deposit_amount: u128 = deposit.amount.parse().map_err(|e| {
         AppError::Internal(format!(
-            "Unparseable WS deposit amount for {} owner {}: '{}'",
+            "Unparseable WS deposit amount for {} owner {}: '{}': {e}",
             protocol, owner, deposit.amount
         ))
     })?;
@@ -763,15 +763,15 @@ async fn fetch_position_for_monitoring(
     let lpp_price = state.chain_client.get_lpp_price(lpp_address).await?;
 
     // Calculate LPN value from nLPN
-    let price_quote: u128 = lpp_price.amount_quote.amount.parse().map_err(|_| {
+    let price_quote: u128 = lpp_price.amount_quote.amount.parse().map_err(|e| {
         AppError::Internal(format!(
-            "Unparseable WS LPP price_quote for {}: '{}'",
+            "Unparseable WS LPP price_quote for {}: '{}': {e}",
             protocol, lpp_price.amount_quote.amount
         ))
     })?;
-    let price_amount: u128 = lpp_price.amount.amount.parse().map_err(|_| {
+    let price_amount: u128 = lpp_price.amount.amount.parse().map_err(|e| {
         AppError::Internal(format!(
-            "Unparseable WS LPP price_amount for {}: '{}'",
+            "Unparseable WS LPP price_amount for {}: '{}': {e}",
             protocol, lpp_price.amount.amount
         ))
     })?;

--- a/backend/src/handlers/gated_admin.rs
+++ b/backend/src/handlers/gated_admin.rs
@@ -232,7 +232,7 @@ pub async fn get_unconfigured(
         .config_store
         .load_currency_display()
         .await
-        .unwrap_or_else(|_| CurrencyDisplayConfig {
+        .unwrap_or_else(|_err| CurrencyDisplayConfig {
             currencies: std::collections::HashMap::new(),
         });
 
@@ -240,7 +240,7 @@ pub async fn get_unconfigured(
         .config_store
         .load_gated_network_config()
         .await
-        .unwrap_or_else(|_| GatedNetworkConfig {
+        .unwrap_or_else(|_err| GatedNetworkConfig {
             networks: std::collections::HashMap::new(),
         });
 
@@ -329,7 +329,7 @@ pub async fn upsert_currency_display(
         .config_store
         .load_currency_display()
         .await
-        .unwrap_or_else(|_| CurrencyDisplayConfig {
+        .unwrap_or_else(|_err| CurrencyDisplayConfig {
             currencies: std::collections::HashMap::new(),
         });
 
@@ -428,7 +428,7 @@ pub async fn upsert_network_config(
         .config_store
         .load_gated_network_config()
         .await
-        .unwrap_or_else(|_| GatedNetworkConfig {
+        .unwrap_or_else(|_err| GatedNetworkConfig {
             networks: std::collections::HashMap::new(),
         });
 

--- a/backend/src/handlers/leases.rs
+++ b/backend/src/handlers/leases.rs
@@ -1152,7 +1152,7 @@ fn build_empty_debt(ticker: &str) -> LeaseDebtInfo {
 /// Parse amount string to u128, returning an error if the value cannot be parsed.
 /// Financial amounts must never silently become 0 — that would understate debt.
 fn parse_amount(amount: &str, field_name: &str) -> Result<u128, AppError> {
-    amount.parse().map_err(|_| {
+    amount.parse().map_err(|_err| {
         AppError::Internal(format!(
             "Failed to parse {} amount: '{}'",
             field_name, amount
@@ -1311,7 +1311,7 @@ fn calculate_pnl(
 
     // None legitimately means 0 (no downpayment recorded); parse failure is a data issue
     let downpayment_raw: f64 = match etl.lease.downpayment_amount.as_deref() {
-        Some(s) => s.parse().unwrap_or_else(|_| {
+        Some(s) => s.parse().unwrap_or_else(|_err| {
             warn!(
                 "Unparseable downpayment for lease {}: '{}'",
                 opened.amount.ticker, s
@@ -1324,7 +1324,7 @@ fn calculate_pnl(
 
     // Fee uses asset decimals (matching frontend behavior)
     let fee_raw: f64 = match etl.fee.as_deref() {
-        Some(s) => s.parse().unwrap_or_else(|_| {
+        Some(s) => s.parse().unwrap_or_else(|_err| {
             warn!(
                 "Unparseable fee for lease {}: '{}'",
                 opened.amount.ticker, s
@@ -1337,7 +1337,7 @@ fn calculate_pnl(
 
     // repayment_value is already formatted as a decimal number
     let repayment_value: f64 = match etl.repayment_value.as_deref() {
-        Some(s) => s.parse().unwrap_or_else(|_| {
+        Some(s) => s.parse().unwrap_or_else(|_err| {
             warn!(
                 "Unparseable repayment_value for lease {}: '{}'",
                 opened.amount.ticker, s

--- a/backend/src/handlers/translations.rs
+++ b/backend/src/handlers/translations.rs
@@ -438,7 +438,7 @@ pub async fn update_active(
 
     // Decode the key (it may be URL encoded with dots as %2E)
     let decoded_key = urlencoding::decode(&key)
-        .map_err(|_| AppError::Validation {
+        .map_err(|_err| AppError::Validation {
             message: "Invalid key encoding".to_string(),
             field: Some("key".to_string()),
             details: None,
@@ -541,7 +541,7 @@ pub async fn get_key_history(
     let storage = get_translation_storage(&state)?;
 
     let decoded_key = urlencoding::decode(&key)
-        .map_err(|_| AppError::Validation {
+        .map_err(|_err| AppError::Validation {
             message: "Invalid key encoding".to_string(),
             field: Some("key".to_string()),
             details: None,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "nolus_backend=debug,tower_http=debug".into()),
+                .unwrap_or_else(|_err| "nolus_backend=debug,tower_http=debug".into()),
         )
         .json()
         .init();
@@ -149,7 +149,7 @@ async fn main() -> anyhow::Result<()> {
     let ws_manager = WebSocketManager::new(ws_max_connections);
 
     // Initialize config store for webapp configuration
-    let config_dir = std::env::var("CONFIG_DIR").unwrap_or_else(|_| "./config".to_string());
+    let config_dir = std::env::var("CONFIG_DIR").unwrap_or_else(|_err| "./config".to_string());
     let config_store = ConfigStore::new(&config_dir);
     config_store.init().await?;
 
@@ -161,7 +161,7 @@ async fn main() -> anyhow::Result<()> {
     // Initialize LLM client for translations (via OpenRouter)
     let llm_api_key = std::env::var("OPENROUTER_API_KEY").unwrap_or_default();
     let llm_model = std::env::var("OPENROUTER_MODEL")
-        .unwrap_or_else(|_| "google/gemini-3-flash-preview".to_string());
+        .unwrap_or_else(|_err| "google/gemini-3-flash-preview".to_string());
     let llm_client = LlmClient::new(LlmConfig {
         api_key: llm_api_key,
         model: llm_model,
@@ -730,7 +730,7 @@ fn create_router(state: Arc<AppState>) -> Router {
     // Static file serving for the frontend SPA
     // Serves files from ../dist (relative to backend directory)
     // Falls back to index.html for SPA routing with 200 OK status
-    let static_dir = std::env::var("STATIC_DIR").unwrap_or_else(|_| "../dist".to_string());
+    let static_dir = std::env::var("STATIC_DIR").unwrap_or_else(|_err| "../dist".to_string());
     let index_path = format!("{}/index.html", static_dir);
 
     if !std::path::Path::new(&index_path).exists() {

--- a/backend/src/translations/storage.rs
+++ b/backend/src/translations/storage.rs
@@ -248,7 +248,7 @@ impl TranslationStorage {
         let initial_content = if let Some(source_lang) = copy_from {
             self.load_active(source_lang)
                 .await
-                .unwrap_or_else(|_| serde_json::json!({}))
+                .unwrap_or_else(|_err| serde_json::json!({}))
         } else {
             serde_json::json!({})
         };
@@ -404,7 +404,7 @@ impl TranslationStorage {
         let mut locale = self
             .load_active(lang)
             .await
-            .unwrap_or_else(|_| serde_json::json!({}));
+            .unwrap_or_else(|_err| serde_json::json!({}));
 
         // Get old value for audit
         let old_value = get_nested_value(&locale, key).map(|v| v.to_string());
@@ -443,7 +443,7 @@ impl TranslationStorage {
         let target_locale = self
             .load_active(lang)
             .await
-            .unwrap_or_else(|_| serde_json::json!({}));
+            .unwrap_or_else(|_err| serde_json::json!({}));
 
         let source_keys = flatten_json(&source_locale, "");
         let target_keys = flatten_json(&target_locale, "");
@@ -842,7 +842,7 @@ impl TranslationStorage {
         let mut locale = self
             .load_active(lang)
             .await
-            .unwrap_or_else(|_| serde_json::json!({}));
+            .unwrap_or_else(|_err| serde_json::json!({}));
         set_nested_value(&mut locale, key, Value::String(value.to_string()))?;
         self.save_active(lang, &locale).await
     }

--- a/backend/src/validation.rs
+++ b/backend/src/validation.rs
@@ -12,7 +12,7 @@ pub fn validate_bech32_address(address: &str, field_name: &str) -> Result<(), Ap
             details: None,
         });
     }
-    bech32::decode(address).map_err(|_| AppError::Validation {
+    bech32::decode(address).map_err(|_err| AppError::Validation {
         message: format!("Invalid {} format", field_name),
         field: Some(field_name.to_string()),
         details: None,


### PR DESCRIPTION
## Summary

Rename every bare `|_|` closure with a non-unit discarded parameter to a descriptive `|_err|` in non-test backend code (41 sites across 11 files), per the house Rust style guide. In `handlers/earn.rs`, additionally thread the previously-dropped `ParseIntError` into the returned `AppError` message.

Closes #187.

## Changes

- Renamed 33 rename-only sites to `|_err|`: `config.rs` (11, env-var defaults), `main.rs` (4), `translations/storage.rs` (4), `handlers/gated_admin.rs` (4), `handlers/leases.rs` (4), `handlers/translations.rs` (2), `validation.rs` (1), `handlers/currencies.rs` (1), `external/intercom.rs` (1), `chain_events.rs` (1). The discarded error at these sites is genuinely irrelevant (env absent → default, load-or-empty-default, timeout/validation messages already self-describing), so the value is named but not used.
- `handlers/earn.rs` (8 sites): the `.parse().map_err(|_| AppError::Internal(format!(...)))` cluster named the offending value but dropped the `ParseIntError`. Changed to `|e|` and appended `: {e}` so a parse failure distinguishes empty / overflow / bad-digit. `AppError::Internal` surfaces the body verbatim by design (locked by `error.rs` tests), so the richer text is observable on the already-failing path. Success path, return values, and control flow are unchanged; nothing substitutes a default and continues.

## Verification

- Ran `cargo fmt --all -- --check` — clean.
- Ran `cargo clippy --all-targets --all-features -- -D warnings` (with the project's documented `-A` set) — clean; `unwrap_used`/`expect_used`/`as_conversions` stay denied.
- Ran `cargo build --all-targets` — clean.
- Ran `cargo test --all-targets` — 470 passed, 0 failed.
- Ran `backend/scripts/style-check.sh` — passed.
- Re-grepped `backend/src` for bare `|_|` — zero remaining.
- Husky pre-commit (frontend lint/test/build) — passed.

A separate correctness review (fresh context, 12-item bug checklist) returned PASS on all items: all 41 closures converted, the 8 earn.rs sites thread `e` and alter no control flow, no edits landed in `#[cfg(test)]` modules, and all default/fallback values are byte-for-byte preserved.

A separate security review of the earn.rs error-message change returned CLEAR (no findings above informational): the threaded `{e}` is a fixed std `ParseIntError`/`ParseFloatError` Display string carrying no caller-controlled secret material; protocol/owner/amount were already in the prior message; the change stays within the repo's intentionally non-sanitized `AppError` contract, introduces no new panic, injection, or attack surface, and changes no behavior on inputs that occur in practice.