### PR TITLE
chore(backend): name magic literals as const

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -2,6 +2,9 @@ use serde::Deserialize;
 use std::env;
 use thiserror::Error;
 
+/// Default TCP port the server binds to when `PORT` is unset.
+const DEFAULT_PORT: u16 = 3000;
+
 // ============================================================================
 // Configuration Errors
 // ============================================================================
@@ -65,7 +68,7 @@ impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             host: "0.0.0.0".to_string(),
-            port: 3000,
+            port: DEFAULT_PORT,
             cors_origins: None,
         }
     }
@@ -280,7 +283,7 @@ impl AppConfig {
         };
 
         let port: u16 = env::var("PORT")
-            .unwrap_or_else(|_err| "3000".to_string())
+            .unwrap_or_else(|_err| DEFAULT_PORT.to_string())
             .parse()
             .map_err(|e| anyhow::anyhow!("PORT must be a valid port number (u16): {e}"))?;
 

--- a/backend/src/config_store/storage.rs
+++ b/backend/src/config_store/storage.rs
@@ -13,6 +13,12 @@ use tracing::{debug, error, info, warn};
 
 use super::gated_types::*;
 
+/// Maximum audit log entries retained in memory; older entries are dropped.
+const MAX_AUDIT_LOG_ENTRIES: usize = 1000;
+
+/// Maximum number of audit log entries returned in a single query.
+const MAX_PAGE_LIMIT: usize = 100;
+
 /// Audit log entry for configuration changes
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditLogEntry {
@@ -113,10 +119,10 @@ impl ConfigStore {
             let mut log = self.audit_log.write().await;
             log.push(entry.clone());
 
-            // Keep only the last 1000 entries in memory
+            // Keep only the most recent entries in memory
             let len = log.len();
-            if len > 1000 {
-                log.drain(0..len - 1000);
+            if len > MAX_AUDIT_LOG_ENTRIES {
+                log.drain(0..len - MAX_AUDIT_LOG_ENTRIES);
             }
         }
 
@@ -165,7 +171,7 @@ impl ConfigStore {
         let limit = if query.limit == 0 {
             50
         } else {
-            query.limit.min(100)
+            query.limit.min(MAX_PAGE_LIMIT)
         };
         let offset = query.offset.min(total);
 

--- a/backend/src/external/chain.rs
+++ b/backend/src/external/chain.rs
@@ -35,6 +35,9 @@ const INITIAL_BACKOFF_MS: u64 = 100;
 /// HTTP status codes that trigger retry with backoff.
 const RETRYABLE_STATUS_CODES: [u16; 2] = [429, 503];
 
+/// Milliseconds per second, for `Retry-After` (seconds) → millisecond conversion.
+const MS_PER_SEC: u64 = 1000;
+
 /// Simple jitter using system time nanoseconds (no rand crate needed).
 fn rand_jitter(max: u64) -> u64 {
     if max == 0 {
@@ -144,7 +147,7 @@ impl ChainClient {
                 .get("retry-after")
                 .and_then(|v| v.to_str().ok())
                 .and_then(|v| v.parse::<u64>().ok())
-                .map(|secs| secs * 1000);
+                .map(|secs| secs * MS_PER_SEC);
 
             let wait_ms = retry_after_ms.unwrap_or(backoff_ms);
             let jitter = rand_jitter(wait_ms / 4);


### PR DESCRIPTION
## Summary

Hoist four genuine domain literals in the backend crate to descriptive module-level `const`s. Each was a raw value whose meaning was only clear from context, and the default-port value was duplicated across two sites that could silently drift. Pure value→const renames — thresholds and behavior are unchanged.

## Changes

- `DEFAULT_PORT: u16` (`config.rs`) — replaces the literal `3000` in both `ServerConfig::default` and the `PORT` env-var fallback, so the two cannot diverge.
- `MAX_AUDIT_LOG_ENTRIES: usize` (`config_store/storage.rs`) — the in-memory audit-log retention bound, shared by the length guard and the `drain` range.
- `MAX_PAGE_LIMIT: usize` (`config_store/storage.rs`) — the audit-log query page cap.
- `MS_PER_SEC: u64` (`external/chain.rs`) — the `Retry-After` seconds→milliseconds factor, placed alongside the existing retry consts.

utoipa status annotations, format-string fragments, and test-local literals were left untouched.

## Verification

- Ran `cargo fmt --all -- --check` (clean), `cargo clippy --all-targets --all-features -- -D warnings` (no warnings; `unwrap_used`/`expect_used`/`as_conversions` stay denied).
- Ran `cargo build --all-targets` and `cargo test --all-targets` — 470 passed, 0 failed, including the `test_default_server_config` assertion that the default port is still 3000.
- Ran `scripts/style-check.sh` — passed.
- A fresh correctness review against `origin/main` walked the full 12-item checklist and confirmed every const matches the replaced literal in both value and type (u16/usize/u64), with byte-identical behavior at each site and no out-of-scope edits. Verdict: PASS.

Closes #186