### PR TITLE
chore(backend): move inline durations module into its own file

### DIFF
--- a/backend/src/middleware/cache_control.rs
+++ b/backend/src/middleware/cache_control.rs
@@ -8,21 +8,7 @@ use axum::{
     middleware::Next,
 };
 
-/// Cache durations for different data types
-pub mod durations {
-    /// Prices change frequently - very short cache
-    pub const PRICES: u32 = 10;
-    /// Config rarely changes - long cache
-    pub const CONFIG: u32 = 3600;
-    /// Webapp config (admin settings) - medium cache
-    pub const WEBAPP_CONFIG: u32 = 300;
-    /// Validators list - medium cache
-    pub const VALIDATORS: u32 = 300;
-    /// Earn pools - short cache
-    pub const EARN_POOLS: u32 = 60;
-    /// Default for unspecified endpoints
-    pub const DEFAULT: u32 = 30;
-}
+pub mod durations;
 
 /// Middleware that adds Cache-Control headers based on the request path
 pub async fn cache_control_middleware(request: Request<Body>, next: Next) -> Response<Body> {

--- a/backend/src/middleware/cache_control/durations.rs
+++ b/backend/src/middleware/cache_control/durations.rs
@@ -1,0 +1,14 @@
+//! Cache durations for different data types
+
+/// Prices change frequently - very short cache
+pub const PRICES: u32 = 10;
+/// Config rarely changes - long cache
+pub const CONFIG: u32 = 3600;
+/// Webapp config (admin settings) - medium cache
+pub const WEBAPP_CONFIG: u32 = 300;
+/// Validators list - medium cache
+pub const VALIDATORS: u32 = 300;
+/// Earn pools - short cache
+pub const EARN_POOLS: u32 = 60;
+/// Default for unspecified endpoints
+pub const DEFAULT: u32 = 30;


### PR DESCRIPTION
## Summary

Move the backend's only non-test inline `mod` block — the cache-duration constants `pub mod durations { … }` in `middleware/cache_control.rs` — into a sibling file `middleware/cache_control/durations.rs`, so module structure mirrors the filesystem as the house style requires.

## Changes

- New `backend/src/middleware/cache_control/durations.rs` holding the six `pub const` cache durations (edition-2021 file + submodule-directory layout).
- `cache_control.rs` now declares `pub mod durations;` in place of the inline block.

Constants, types, visibility, doc comments, and every `durations::` call site are unchanged — this only relocates the declaration.

## Verification

- Ran `cargo fmt --all -- --check` (clean), `cargo clippy --all-targets --all-features -- -D warnings` (no warnings; the deny lints stay denied), `cargo build --all-targets`, and `cargo test --all-targets` — 470 passed, 0 failed.
- Ran `scripts/style-check.sh` — passes; the module-mirrors-filesystem grep no longer flags `cache_control.rs`.
- A fresh correctness review against `origin/main` confirmed the relocation is byte-identical (all six consts same name/value/type/visibility/doc) with every call site resolving and no adjacent code touched. Verdict: PASS.

Closes #188