### PR TITLE
chore(backend): name the audit-log default page-size as const

### DIFF
--- a/backend/src/config_store/storage.rs
+++ b/backend/src/config_store/storage.rs
@@ -19,6 +19,9 @@ const MAX_AUDIT_LOG_ENTRIES: usize = 1000;
 /// Maximum number of audit log entries returned in a single query.
 const MAX_PAGE_LIMIT: usize = 100;
 
+/// Number of audit log entries returned when the query omits a limit.
+const DEFAULT_PAGE_LIMIT: usize = 50;
+
 /// Audit log entry for configuration changes
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditLogEntry {
@@ -169,7 +172,7 @@ impl ConfigStore {
 
         let total = filtered.len();
         let limit = if query.limit == 0 {
-            50
+            DEFAULT_PAGE_LIMIT
         } else {
             query.limit.min(MAX_PAGE_LIMIT)
         };


### PR DESCRIPTION
## Summary

Follow-up to #186. `query_audit_log` already named its page cap (`MAX_PAGE_LIMIT`), but the default page size used when a caller passes no limit was still the raw literal `50` next to it. Hoist it to `DEFAULT_PAGE_LIMIT` so the pair reads consistently and the default is documented.

## Changes

- New `DEFAULT_PAGE_LIMIT: usize = 50` const beside `MAX_PAGE_LIMIT`; the `query.limit == 0` branch uses it. Pure value→const rename — the default is unchanged.

## Verification

- Ran `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` (deny lints intact), `cargo build --all-targets`, `cargo test --all-targets` — 470 passed, 0 failed.
- Ran `scripts/style-check.sh` — passes.
- Self-reviewed the one-line diff: value (`50`) and type (`usize`, matching `query.limit`) unchanged; no behavior change; no other code touched.

Closes #204