### PR TITLE
fix: clear leaked debounce/loading timers on unmount

### DIFF
--- a/src/modules/assets/components/SwapForm.test.ts
+++ b/src/modules/assets/components/SwapForm.test.ts
@@ -464,6 +464,27 @@ describe("SwapForm.vue — defensive guards on .find()", () => {
       wrapper.unmount();
     });
 
+    it("clears the pending route-fetch debounce on unmount (no fetch after teardown)", async () => {
+      const wrapper = factory();
+      await flushPromises();
+
+      const mcc = wrapper.findComponent({ name: "MultipleCurrencyComponent" });
+      mcc.vm.$emit("on-first-change", {
+        input: { value: "5" },
+        currency: { value: "OSMO@OSMOSIS" },
+        type: "select"
+      });
+      await flushPromises();
+
+      // Unmount while the 600ms debounce is still pending, then let the clock
+      // pass the debounce window: the timer must have been cleared on unmount.
+      wrapper.unmount();
+      await vi.advanceTimersByTimeAsync(700);
+      await flushPromises();
+
+      expect(SkipRouter.getRoute).not.toHaveBeenCalled();
+    });
+
     it("updateSwapToRoute: input event on second currency triggers reverted route fetch", async () => {
       const wrapper = factory();
       await flushPromises();

--- a/src/modules/assets/components/SwapForm.vue
+++ b/src/modules/assets/components/SwapForm.vue
@@ -118,7 +118,7 @@
 import MultipleCurrencyComponent from "@/common/components/MultipleCurrencyComponent.vue";
 import { Button, type AssetItemProps, AssetItem, type AdvancedCurrencyFieldOption, ToastType } from "web-components";
 import { NATIVE_NETWORK } from "../../../config/global/network";
-import { computed, inject, ref, watch } from "vue";
+import { computed, inject, onUnmounted, ref, watch } from "vue";
 import { useWalletStore } from "@/common/stores/wallet";
 import { useBalancesStore } from "@/common/stores/balances";
 import { externalWallet, Logger, validateAmountV2, walletOperation, WalletUtils } from "@/common/utils";
@@ -477,6 +477,10 @@ async function setRoute(token: Coin, revert = false) {
     }
   }, timeOut);
 }
+
+onUnmounted(() => {
+  clearTimeout(time);
+});
 
 function validateInputs() {
   const first = selectedFirstCurrencyOption.value;

--- a/src/modules/vote/view.vue
+++ b/src/modules/vote/view.vue
@@ -63,7 +63,7 @@ const pagination = ref({
   total: 0,
   next_key: ""
 });
-const timeout = null as NodeJS.Timeout | null;
+let loadMoreTimer: NodeJS.Timeout | null = null;
 
 const proposals = ref([] as Proposal[]);
 const selectedProposal = ref({
@@ -89,15 +89,15 @@ watch(
 
 async function onInit() {
   await Promise.allSettled([
-    fetchGovernanceProposals({ timeout, pagination, proposals, initialLoad, showSkeleton }),
+    fetchGovernanceProposals({ timeout: null, pagination, proposals, initialLoad, showSkeleton }),
     loadBondedTokens(),
     loadTallying()
   ]);
 }
 
 onUnmounted(() => {
-  if (timeout) {
-    clearTimeout(timeout);
+  if (loadMoreTimer) {
+    clearTimeout(loadMoreTimer);
   }
 });
 
@@ -129,7 +129,7 @@ async function loadMoreProposals() {
   proposals.value = [...proposals.value, ...data.proposals];
   pagination.value = data.pagination;
 
-  setTimeout(() => {
+  loadMoreTimer = setTimeout(() => {
     loading.value = false;
   }, LOAD_TIMEOUT);
 }


### PR DESCRIPTION
## Summary
Clear two component timers that were never cleared on teardown. A timer pending at unmount fires into a torn-down component's stale closure — a resource leak and a known source of suite-order test flakes.

## Changes
- `SwapForm.vue` — register `onUnmounted(() => clearTimeout(time))` for the route-fee debounce; the file previously had no unmount hook at all.
- `vote/view.vue` — capture `loadMoreProposals`' loading `setTimeout` into a live `loadMoreTimer` and clear it in the existing `onUnmounted`. The prior cleanup cleared a `const` that was never reassigned (dead code) while the real timer leaked. Call site passes `timeout: null` — that field is declared in the composable param type but never read.
- `SwapForm.test.ts` — regression test: schedule the debounce, unmount before the 600ms window elapses, advance the fake clock past it, assert `SkipRouter.getRoute` is never called. Paired with the existing non-unmount test so it cannot pass vacuously.

## Verification
- Ran `eslint src` — clean
- Ran `prettier --check src` — clean
- Ran `npm test` — 777 passed (incl. the new unmount test)
- Ran `npm run build` — production build succeeded
- No behavioural change to the debounce/loading flows

Closes #171