### PR TITLE
fix: guard reactive form validators against missing price/currency entries

### DIFF
--- a/src/modules/earn/components/SupplyForm.test.ts
+++ b/src/modules/earn/components/SupplyForm.test.ts
@@ -343,4 +343,27 @@ describe("SupplyForm.vue", () => {
       wrapper.unmount();
     });
   });
+
+  it("validateSupply does not throw before the per-protocol deposit capacity has loaded — finding 5", () => {
+    const wrapper = factory();
+    const vm = wrapper.vm as unknown as {
+      assets: unknown[];
+      maxSupply: Record<string, unknown>;
+      input: string;
+      validateInputs: () => string;
+    };
+    // One real asset is present, but the async fetchDepositCapacity has not yet
+    // populated maxSupply for its protocol — `max` is undefined. The over-cap
+    // check used to call `max.isNegative()` and throw inside the reactive path.
+    expect(vm.assets.length).toBeGreaterThan(0);
+    vm.maxSupply = {};
+    vm.input = "100";
+    let result = "";
+    expect(() => {
+      result = vm.validateInputs();
+    }).not.toThrow();
+    // Falls through to the mocked validateAmountV2 (empty) — no capacity error.
+    expect(result).toBe("");
+    wrapper.unmount();
+  });
 });

--- a/src/modules/earn/components/SupplyForm.vue
+++ b/src/modules/earn/components/SupplyForm.vue
@@ -343,7 +343,10 @@ function validateSupply() {
   const [_, protocol] = asset.key.split("@");
   const max = maxSupply.value[protocol];
 
-  if (max.isNegative()) {
+  // maxSupply is populated per-protocol by an async fetchDepositCapacity; before
+  // it lands for this protocol `max` is undefined. Treat the not-yet-loaded state
+  // like a negative cap (skip the over-cap check) rather than dereferencing it.
+  if (!max || max.isNegative()) {
     return "";
   }
 

--- a/src/modules/leases/components/single-lease/CloseDialog.test.ts
+++ b/src/modules/leases/components/single-lease/CloseDialog.test.ts
@@ -140,7 +140,10 @@ vi.mock("@/common/stores/config", () => ({
     get lpn() {
       return hoisted.configRef.lpn;
     },
-    getPositionType: hoisted.configRef.getPositionType
+    getPositionType: hoisted.configRef.getPositionType,
+    getCurrencyByKey: (key: string) => (hoisted.configRef.currenciesData as Record<string, unknown>)[key],
+    getCurrencyByTicker: (ticker: string) =>
+      Object.values(hoisted.configRef.currenciesData).find((c) => (c as { ticker: string }).ticker === ticker)
   })
 }));
 
@@ -283,7 +286,7 @@ vi.mock("web-components", () => ({
   ToastType: { success: "success", error: "error" }
 }));
 
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { Dec } from "@keplr-wallet/unit";
 import CloseDialog from "./CloseDialog.vue";
 
@@ -340,6 +343,12 @@ describe("CloseDialog.vue", () => {
       usd_amount_out: "100",
       swap_price_impact_percent: "0"
     });
+    // Reset the shared price fixture every test so a price-feed mutation in one
+    // case cannot leak into the next (no shared mutable fixture state).
+    hoisted.pricesRef.prices = {
+      "USDC@osmosis-1": { price: "1" },
+      "ATOM@osmosis-1": { price: "10" }
+    };
   });
 
   it("renders without throwing when a cached open lease is present", async () => {
@@ -434,6 +443,32 @@ describe("CloseDialog.vue", () => {
     await wrapper.find('[data-test="slider-right"]').trigger("click");
     await wrapper.vm.$nextTick();
     expect(wrapper.exists()).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("surfaces a specific message (no raw throw, no silent freeze) when the close-currency price is missing while typing", async () => {
+    // Late/missing WS price for the position currency: the reactive validator
+    // used to deref `prices[key].price` with no guard and throw inside the watch,
+    // freezing the field. It must now set a specific localized message instead.
+    hoisted.pricesRef.prices = { "USDC@osmosis-1": { price: "1" } } as typeof hoisted.pricesRef.prices;
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("5");
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.find('[data-test="err"]').text()).toBe("message.unexpected-error");
+    wrapper.unmount();
+  });
+
+  it("does not raise the missing-data error for a valid amount when prices are present", async () => {
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("5");
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.find('[data-test="err"]').text()).not.toBe("message.unexpected-error");
     wrapper.unmount();
   });
 

--- a/src/modules/leases/components/single-lease/CloseDialog.vue
+++ b/src/modules/leases/components/single-lease/CloseDialog.vue
@@ -280,7 +280,7 @@ import {
   formatTokenBalance,
   formatPercent
 } from "@/common/utils/NumberFormatUtils";
-import { getLpnByProtocol, getCurrencyByTicker } from "@/common/utils/CurrencyLookup";
+import { getLpnByProtocol } from "@/common/utils/CurrencyLookup";
 import { NATIVE_CURRENCY, NATIVE_NETWORK } from "../../../../config/global/network";
 import type { ExternalCurrency } from "@/common/types";
 import { MAX_DECIMALS, minimumLeaseAmount, PERCENT } from "@/config/global";
@@ -728,46 +728,54 @@ async function setSwapFee() {
     const lease_currency = currency.value;
     const lpnCurrency = getLpnByProtocol(lease.value?.protocol as string);
     const debtValue = debt.value;
-    if (!debtValue || !lpnCurrency) {
+    if (!debtValue || !lpnCurrency || !lease_currency) {
       return;
     }
-    let microAmount = CurrencyUtils.convertDenomToMinimalDenom(
-      debtValue.amount.toDec().toString(),
-      lease_currency.ibcData,
-      lease_currency.decimal_digits
-    ).amount.toString();
-
-    let amountIn = 0;
-    let amountOut = 0;
-
-    const positionType = configStore.getPositionType(lease.value?.protocol as string);
-    if (positionType === "Short") {
-      microAmount = CurrencyUtils.convertDenomToMinimalDenom(
+    // The Skip route call (and the Dec conversions) run inside a debounced timer
+    // detached from the render cycle: an unhandled rejection here would surface
+    // as a console error and leave the preview fee silently stale. Catch and log
+    // so a transient route/price failure degrades gracefully instead.
+    try {
+      let microAmount = CurrencyUtils.convertDenomToMinimalDenom(
         debtValue.amount.toDec().toString(),
-        lpnCurrency.ibcData,
-        lpnCurrency.decimal_digits
+        lease_currency.ibcData,
+        lease_currency.decimal_digits
       ).amount.toString();
+
+      let amountIn = 0;
+      let amountOut = 0;
+
+      const positionType = configStore.getPositionType(lease.value?.protocol as string);
+      if (positionType === "Short") {
+        microAmount = CurrencyUtils.convertDenomToMinimalDenom(
+          debtValue.amount.toDec().toString(),
+          lpnCurrency.ibcData,
+          lpnCurrency.decimal_digits
+        ).amount.toString();
+      }
+
+      await Promise.all([
+        SkipRouter.getRoute(lease_currency.ibcData, lpnCurrency.ibcData, microAmount).then((data) => {
+          amountIn += Number(data.usd_amount_in ?? 0);
+          amountOut += Number(data.usd_amount_out ?? 0);
+
+          return Number(data?.swap_price_impact_percent ?? 0);
+        })
+      ]);
+
+      const out_a = Math.max(amountOut, amountIn);
+      const in_a = Math.min(amountOut, amountIn);
+
+      const diff = out_a - in_a;
+      let fee = 0;
+      if (in_a > 0) {
+        fee = diff / in_a;
+      }
+
+      swapFee.value = fee;
+    } catch (e) {
+      Logger.error(e);
     }
-
-    await Promise.all([
-      SkipRouter.getRoute(lease_currency.ibcData, lpnCurrency.ibcData, microAmount).then((data) => {
-        amountIn += Number(data.usd_amount_in ?? 0);
-        amountOut += Number(data.usd_amount_out ?? 0);
-
-        return Number(data?.swap_price_impact_percent ?? 0);
-      })
-    ]);
-
-    const out_a = Math.max(amountOut, amountIn);
-    const in_a = Math.min(amountOut, amountIn);
-
-    const diff = out_a - in_a;
-    let fee = 0;
-    if (in_a > 0) {
-      fee = diff / in_a;
-    }
-
-    swapFee.value = fee;
   }, timeOut);
 }
 
@@ -776,22 +784,36 @@ function isAmountValid() {
   amountErrorMsg.value = "";
   if (lease.value && lease.value.status === "opened") {
     const a = amount.value;
-    const currencyData = configStore.currenciesData[`${lease.value.amount.ticker}@${lease.value.protocol}`];
-    const debtAmount = new Dec(lease.value.amount.amount, Number(currencyData.decimal_digits));
+    const currencyData = configStore.getCurrencyByKey(`${lease.value.amount.ticker}@${lease.value.protocol}`);
     const minAssetSpec = minAsset.value;
-    if (!minAssetSpec) {
-      throw new Error("Minimum asset spec not available");
-    }
-    const minAssetTicker = minAssetSpec.ticker;
-    const minAmountCurrency = getCurrencyByTicker(minAssetTicker);
-    let minAmont = new Dec(minAssetSpec.amount, Number(minAmountCurrency.decimal_digits));
-
+    const minAmountCurrency = minAssetSpec ? configStore.getCurrencyByTicker(minAssetSpec.ticker) : undefined;
     const positionType = configStore.getPositionType(lease.value.protocol);
-    if (positionType === "Short") {
-      const p = new Dec(pricesStore.prices[`${minAssetTicker}@${lease.value.protocol}`].price);
-      minAmont = minAmont.mul(p);
+    const currencyPriceEntry = currencyData ? pricesStore.prices[currencyData.key as string] : undefined;
+    const shortMinAssetPrice =
+      positionType === "Short" && minAssetSpec
+        ? pricesStore.prices[`${minAssetSpec.ticker}@${lease.value.protocol}`]?.price
+        : undefined;
+
+    // Price/currency feeds can lag the form (late WS price, config skew). Without
+    // them validation cannot run; surface a specific message rather than
+    // force-unwrapping a missing entry and throwing inside the reactive watch.
+    if (
+      !currencyData ||
+      !minAssetSpec ||
+      !minAmountCurrency ||
+      !currencyPriceEntry?.price ||
+      (positionType === "Short" && !shortMinAssetPrice)
+    ) {
+      amountErrorMsg.value = i18n.t("message.unexpected-error");
+      return false;
     }
-    const price = new Dec(pricesStore.prices[currencyData.key as string].price);
+
+    const debtAmount = new Dec(lease.value.amount.amount, Number(currencyData.decimal_digits));
+    let minAmont = new Dec(minAssetSpec.amount, Number(minAmountCurrency.decimal_digits));
+    if (positionType === "Short" && shortMinAssetPrice) {
+      minAmont = minAmont.mul(new Dec(shortMinAssetPrice));
+    }
+    const price = new Dec(currencyPriceEntry.price);
 
     const minAmountTemp = new Dec(minimumLeaseAmount);
     const amountInStable = new Dec(a.length === 0 ? "0" : a).mul(price);
@@ -971,10 +993,19 @@ function getCurrency() {
   };
 }
 
+// Reacts to: the typed amount and the selected close currency.
+// Re-firing on the same input is safe — isAmountValid is idempotent (it resets
+// amountErrorMsg on each run). The try/catch is the backstop for any residual
+// throw from a lagging price/currency feed so the field never silently freezes.
 watch(
   () => [amount.value, selectedCurrency.value],
   () => {
-    isAmountValid();
+    try {
+      isAmountValid();
+    } catch (e) {
+      Logger.error(e);
+      amountErrorMsg.value = i18n.t("message.unexpected-error");
+    }
   }
 );
 

--- a/src/modules/leases/components/single-lease/RepayDialog.test.ts
+++ b/src/modules/leases/components/single-lease/RepayDialog.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type * as VueRouter from "vue-router";
+import type * as NolusJs from "@nolus/nolusjs";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -186,34 +187,18 @@ vi.mock("@/common/utils/CurrencyLookup", () => ({
   })
 }));
 
-vi.mock("@nolus/nolusjs", () => ({
-  CurrencyUtils: {
-    convertDenomToMinimalDenom: (amt: string) => ({
-      amount: {
-        toString: () => (Number(amt || "0") * 1e6).toString(),
-        toDec: () => ({
-          isZero: () => false,
-          lte: () => false,
-          gt: () => false,
-          lt: () => false,
-          toString: () => String(amt)
-        })
-      }
-    }),
-    convertMinimalDenomToDenom: (amt: string) => ({
-      toDec: () => ({
-        mul: () => ({ toString: () => amt, mul: () => ({ toString: () => amt }) }),
-        toString: () => amt
-      })
-    })
-  },
-  NolusClient: {
-    getInstance: () => ({
-      getCosmWasmClient: async () => ({})
-    })
-  },
-  NolusWallet: class {}
-}));
+// Use real CurrencyUtils (Dec math) so the repayment/validation computeds run
+// faithfully when a test drives the reactive input. Only mock NolusClient for
+// the contract call path.
+vi.mock("@nolus/nolusjs", async () => {
+  const actual = await vi.importActual<typeof NolusJs>("@nolus/nolusjs");
+  return {
+    ...actual,
+    NolusClient: {
+      getInstance: () => ({ getCosmWasmClient: async () => ({}) })
+    }
+  };
+});
 
 vi.mock("@nolus/nolusjs/build/contracts", () => ({
   Lease: class {
@@ -278,7 +263,7 @@ vi.mock("web-components", () => ({
   ToastType: { success: "success", error: "error" }
 }));
 
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import RepayDialog from "./RepayDialog.vue";
 
 function makeLease(overrides: Record<string, unknown> = {}) {
@@ -318,6 +303,12 @@ describe("RepayDialog.vue", () => {
     });
     hoisted.getLease.mockReturnValue(makeLease());
     hoisted.getLeaseDisplayData.mockReturnValue({ openingPrice: { toString: () => "1" } });
+    // Reset the shared price fixture every test so a price-feed mutation in one
+    // case cannot leak into the next (no shared mutable fixture state).
+    hoisted.pricesRef.prices = {
+      "USDC@osmosis-1": { price: "1" },
+      "ATOM@osmosis-1": { price: "10" }
+    };
   });
 
   afterEach(() => {
@@ -372,6 +363,21 @@ describe("RepayDialog.vue", () => {
     await wrapper.find('[data-test="submit"]').trigger("click");
     await new Promise((r) => setTimeout(r, 0));
     expect(hoisted.loggerError).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it("surfaces a specific message (no raw throw, no silent freeze) when the price feed is missing while typing", async () => {
+    // Late/missing WS price for the repayment currency: the reactive validator
+    // used to deref `prices[key].price` and throw inside the watch, freezing the
+    // field. It must now set a specific localized message instead.
+    hoisted.pricesRef.prices = {} as typeof hoisted.pricesRef.prices;
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("5");
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.find('[data-test="err"]').text()).toBe("message.unexpected-error");
     wrapper.unmount();
   });
 });

--- a/src/modules/leases/components/single-lease/RepayDialog.test.ts
+++ b/src/modules/leases/components/single-lease/RepayDialog.test.ts
@@ -65,7 +65,7 @@ const hoisted = vi.hoisted(() => {
         native: false
       }
     },
-    getPositionType: (_p: string) => "Long"
+    positionType: "Long" as "Long" | "Short"
   };
 
   const balancesRef = {
@@ -134,7 +134,7 @@ vi.mock("@/common/stores/config", () => ({
     get currenciesData() {
       return hoisted.configRef.currenciesData;
     },
-    getPositionType: hoisted.configRef.getPositionType
+    getPositionType: (_p: string) => hoisted.configRef.positionType
   })
 }));
 
@@ -297,6 +297,7 @@ describe("RepayDialog.vue", () => {
     setActivePinia(createPinia());
     hoisted.walletRef.value = { broadcastTx: hoisted.broadcastTx, address: "nolus1abc" };
     hoisted.configRef.initialized = true;
+    hoisted.configRef.positionType = "Long";
     hoisted.broadcastTx.mockResolvedValue({});
     hoisted.walletOperationMock.mockImplementation(async (op: () => Promise<void> | void) => {
       await op();
@@ -370,6 +371,55 @@ describe("RepayDialog.vue", () => {
     // Late/missing WS price for the repayment currency: the reactive validator
     // used to deref `prices[key].price` and throw inside the watch, freezing the
     // field. It must now set a specific localized message instead.
+    hoisted.pricesRef.prices = {} as typeof hoisted.pricesRef.prices;
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("5");
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.find('[data-test="err"]').text()).toBe("message.unexpected-error");
+    wrapper.unmount();
+  });
+
+  it("clears the error for a within-balance amount when the price feed is present (Long happy path)", async () => {
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    // 5 USDC is within the 10 USDC mocked wallet balance and above zero.
+    await wrapper.find('[data-test="amount"]').setValue("5");
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-test="err"]').text()).toBe("");
+    wrapper.unmount();
+  });
+
+  it("flags an amount over the wallet balance with invalid-balance-big (Long)", async () => {
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    // 20 USDC exceeds the 10 USDC mocked wallet balance.
+    await wrapper.find('[data-test="amount"]').setValue("20");
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-test="err"]').text()).toBe("message.invalid-balance-big");
+    wrapper.unmount();
+  });
+
+  it("validates a short position without throwing when prices are present", async () => {
+    hoisted.configRef.positionType = "Short";
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("5");
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    // The Short branch resolves the price via getLpnByProtocol + the selected
+    // currency; it must compute without throwing and without the missing-data error.
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.find('[data-test="err"]').text()).not.toBe("message.unexpected-error");
+    wrapper.unmount();
+  });
+
+  it("short position surfaces the specific message when the price feed is missing", async () => {
+    hoisted.configRef.positionType = "Short";
     hoisted.pricesRef.prices = {} as typeof hoisted.pricesRef.prices;
     const wrapper = factory();
     await wrapper.vm.$nextTick();

--- a/src/modules/leases/components/single-lease/RepayDialog.vue
+++ b/src/modules/leases/components/single-lease/RepayDialog.vue
@@ -362,8 +362,13 @@ function getRepayment(p: number) {
   if (positionType === "Short") {
     const lpnShort = getLpnByProtocol(lease.value.protocol);
     if (!lpnShort) return undefined;
-    const price = new Dec(pricesStore.prices[lpnShort.key as string].price);
-    const selected_asset_price = new Dec(pricesStore.prices[selectedCurrency.key as string].price);
+    const lpnPriceEntry = pricesStore.prices[lpnShort.key as string];
+    const selectedPriceEntry = pricesStore.prices[selectedCurrency.key as string];
+    // Missing price entries make the conversion undefined (and would divide by
+    // zero); bail so callers render an empty preview instead of throwing.
+    if (!lpnPriceEntry?.price || !selectedPriceEntry?.price) return undefined;
+    const price = new Dec(lpnPriceEntry.price);
+    const selected_asset_price = new Dec(selectedPriceEntry.price);
     const repayment = repaymentInStable.mul(price);
     return {
       repayment: repayment.quo(selected_asset_price),
@@ -403,21 +408,28 @@ function isAmountValid() {
 
   if (coinData && leaseValue) {
     if (amnt || amnt !== "") {
-      const price = pricesStore.prices[coinData.key as string];
+      const priceEntry = pricesStore.prices[coinData.key as string];
+      // The price feed can lag the form (late WS price, config skew). Without it
+      // validation cannot run; surface a specific message rather than dereferencing
+      // a missing entry and throwing inside the reactive watch.
+      if (!priceEntry?.price) {
+        amountErrorMsg.value = i18n.t("message.unexpected-error");
+        return false;
+      }
 
       const amountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(amnt, "", coinData.decimal_digits);
       const balance = CurrencyUtils.calculateBalance(
-        price.price,
+        priceEntry.price,
         amountInMinimalDenom,
         coinData.decimal_digits
       ).toDec();
       const minAmount = new Dec(minimumLeaseAmount);
-      const p = new Dec(price.price);
+      const p = new Dec(priceEntry.price);
       const amountInStable = new Dec(amnt.length === 0 ? "0" : amnt).mul(p);
 
       const debt = getDebtValue();
       const lpn = getLpnByProtocol(leaseValue.protocol);
-      const debtInCurrencies = debt.quo(new Dec(price.price));
+      const debtInCurrencies = debt.quo(new Dec(priceEntry.price));
       const minAmm = new Dec(minimumLeaseAmount).mul(new Dec(10 ** lpn.decimal_digits));
 
       const minAmountCurrency = minAmount.quo(p);
@@ -480,8 +492,11 @@ function getDebtValue() {
     if (!lpn) {
       throw new Error("LPN currency not available");
     }
-    const price = new Dec(pricesStore.prices[lpn.key as string].price);
-    return debt.mul(price);
+    const priceEntry = pricesStore.prices[lpn.key as string];
+    if (!priceEntry?.price) {
+      throw new Error("LPN price not available");
+    }
+    return debt.mul(new Dec(priceEntry.price));
   }
   return debt;
 }
@@ -535,10 +550,19 @@ async function repayLease() {
   }
 }
 
+// Reacts to: the typed amount and the selected repayment currency.
+// Re-firing on the same input is safe — isAmountValid is idempotent (it resets
+// amountErrorMsg on each run). The try/catch is the backstop for any residual
+// throw from a lagging price/currency feed so the field never silently freezes.
 watch(
   () => [amount.value, selectedCurrency.value],
   () => {
-    isAmountValid();
+    try {
+      isAmountValid();
+    } catch (e) {
+      Logger.error(e);
+      amountErrorMsg.value = i18n.t("message.unexpected-error");
+    }
   }
 );
 


### PR DESCRIPTION
## Summary
Harden the reactive input validators in the close, repay, and supply forms so a missing or late price/currency entry no longer throws inside a Vue watch — which froze the field silently while the user typed. Switch force-unwrapped lookups to the non-throwing store getters, guard price derefs before use, and map any residual failure to a localized message instead of swallowing it or leaking raw error text.

## Changes
- CloseDialog: `isAmountValid` uses `getCurrencyByKey`/`getCurrencyByTicker` + a missing-data guard; `setSwapFee` guards the close currency and wraps its debounced Skip-route call in try/catch; the amount watch is wrapped in try/catch.
- RepayDialog: `isAmountValid`, `getRepayment` (Short), and `getDebtValue` guard their price entries; the amount watch is wrapped in try/catch.
- SupplyForm: `validateSupply` tolerates a not-yet-loaded per-protocol deposit cap.
- Added reactive-path validation tests for all three dialogs — drive a real input with a missing/late price and assert the field message plus no throw/freeze. RepayDialog's test now uses the real `CurrencyUtils` Dec math.

The 600ms `setSwapFee` debounce floor and the existing unmount timer cleanup are unchanged.

## Verification
- Ran `eslint` on the changed files — clean
- Ran `prettier --check` on the changed files — clean
- Ran the full `vitest` suite — 781 passed
- Ran `npm run build` — succeeded
- Pre-commit hook (lint + test + build) passed

## Follow-ups
- CloseDialog `getRepayment` Short branch derefs the selected-currency price unguarded (#191 finding 13) — fold into a later PR
- Class B (downstream route/contract/RPC errors shown verbatim) and Class C (submit-only / swallowed checks) remain — #191 PR 2 / PR 3
- #191 stays open; this is PR 1 of 3