### PR TITLE
fix: localize downstream form errors via a shared classifier

### DIFF
--- a/src/common/utils/classifyError.test.ts
+++ b/src/common/utils/classifyError.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { ApiError } from "@/common/api";
+import { classifyError } from "./classifyError";
+
+describe("classifyError", () => {
+  it("maps a SWAP_ROUTE_FAILED ApiError to the swap-route-failed key", () => {
+    expect(classifyError(new ApiError(400, "SWAP_ROUTE_FAILED", "no route found"))).toBe("message.swap-route-failed");
+  });
+
+  it("maps a 429 ApiError to the rate-limit-exceeded key", () => {
+    expect(classifyError(new ApiError(429, "rate_limited", "Too many requests"))).toBe("message.rate-limit-exceeded");
+  });
+
+  it("prefers the swap-route code over the 429 status when both apply", () => {
+    expect(classifyError(new ApiError(429, "SWAP_ROUTE_FAILED", "throttled route"))).toBe("message.swap-route-failed");
+  });
+
+  it("maps a liquidity error message to no-liquidity (case-insensitive)", () => {
+    expect(classifyError(new Error("query wasm contract failed: No Liquidity for this pair"))).toBe(
+      "message.no-liquidity"
+    );
+  });
+
+  it("classifies a liquidity ApiError without a special code/status via its message", () => {
+    expect(classifyError(new ApiError(500, "unknown_error", "insufficient liquidity"))).toBe("message.no-liquidity");
+  });
+
+  it("maps an unrecognised Error to the generic unexpected-error", () => {
+    expect(classifyError(new Error("invalid downpayment ticker"))).toBe("message.unexpected-error");
+  });
+
+  it("maps a non-Error throwable to unexpected-error", () => {
+    expect(classifyError("boom")).toBe("message.unexpected-error");
+    expect(classifyError(undefined)).toBe("message.unexpected-error");
+  });
+});

--- a/src/common/utils/classifyError.ts
+++ b/src/common/utils/classifyError.ts
@@ -1,0 +1,33 @@
+import { ApiError } from "@/common/api";
+
+const SWAP_ROUTE_FAILED_CODE = "SWAP_ROUTE_FAILED";
+const HTTP_TOO_MANY_REQUESTS = 429;
+
+/**
+ * Map a downstream failure (Skip route, contract simulation, RPC, backend API)
+ * to a cause-specific i18n message key. Returns the key — callers translate it
+ * with their own `i18n.t(...)` so the message stays reactive to locale changes
+ * and this helper stays pure and unit-testable. Never surface a raw chain/RPC
+ * string on a form field.
+ *
+ * Only a message that mentions liquidity maps to "no-liquidity"; every other
+ * unrecognised failure is the generic "unexpected-error", never a mislabel
+ * (see the lease-quote error-classification note in the project CLAUDE.md).
+ */
+export function classifyError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.code === SWAP_ROUTE_FAILED_CODE) {
+      return "message.swap-route-failed";
+    }
+    if (error.status === HTTP_TOO_MANY_REQUESTS) {
+      return "message.rate-limit-exceeded";
+    }
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  if (/liquidity/i.test(message)) {
+    return "message.no-liquidity";
+  }
+
+  return "message.unexpected-error";
+}

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -25,3 +25,4 @@ export * from "./WalletConnect";
 export * from "./walletProtocolFilter";
 export * from "./NetworkUtils";
 export * from "./IntercomService";
+export * from "./classifyError";

--- a/src/modules/assets/components/ReceiveForm.vue
+++ b/src/modules/assets/components/ReceiveForm.vue
@@ -114,7 +114,7 @@ import { useWalletStore } from "@/common/stores/wallet";
 import { useBalancesStore } from "@/common/stores/balances";
 import { computed, onUnmounted, ref, watch, h, inject } from "vue";
 import { useI18n } from "vue-i18n";
-import { externalWallet, Logger, walletOperation, WalletUtils } from "@/common/utils";
+import { classifyError, externalWallet, Logger, walletOperation, WalletUtils } from "@/common/utils";
 import { formatDecAsUsd, formatUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
 import {
   getCurrencyByTickerForNetwork,
@@ -318,7 +318,7 @@ watch(
           try {
             tempRoute.value = await getRoute();
           } catch (e: unknown) {
-            amountErrorMsg.value = e instanceof Error ? e.message : String(e);
+            amountErrorMsg.value = i18n.t(classifyError(e));
           }
         });
       }
@@ -350,7 +350,7 @@ async function onSubmitCosmos() {
       fee.value = coin(networkdata.fees.transfer_amount, currency.ibcData);
     }
   } catch (e: unknown) {
-    amountErrorMsg.value = String(e);
+    amountErrorMsg.value = i18n.t(classifyError(e));
   }
 }
 
@@ -501,7 +501,7 @@ async function onSubmit() {
         walletStore.history[id].historyData.status = CONFIRM_STEP.SUCCESS;
       } catch (error) {
         step.value = CONFIRM_STEP.ERROR;
-        amountErrorMsg.value = error instanceof Error ? error.message : String(error);
+        amountErrorMsg.value = i18n.t(classifyError(error));
 
         if (walletStore.history[id]) {
           walletStore.history[id].historyData.errorMsg = amountErrorMsg.value;

--- a/src/modules/assets/components/SendForm.vue
+++ b/src/modules/assets/components/SendForm.vue
@@ -123,6 +123,7 @@ import { useHistoryStore } from "@/common/stores/history";
 import { computed, onUnmounted, ref, watch, h, inject } from "vue";
 import { useI18n } from "vue-i18n";
 import {
+  classifyError,
   externalWallet,
   Logger,
   transferCurrency,
@@ -335,7 +336,7 @@ watch(
           try {
             tempRoute.value = await getRoute();
           } catch (e: unknown) {
-            amountErrorMsg.value = e instanceof Error ? e.message : String(e);
+            amountErrorMsg.value = i18n.t(classifyError(e));
           }
         });
       }
@@ -376,7 +377,7 @@ async function onSubmitCosmos() {
       await onSwap();
     }
   } catch (e: unknown) {
-    amountErrorMsg.value = String(e);
+    amountErrorMsg.value = i18n.t(classifyError(e));
   } finally {
     isDisabled.value = false;
   }
@@ -582,7 +583,7 @@ async function transferAmount() {
     historyStore.loadActivities();
     onClose();
   } catch (e: unknown) {
-    amountErrorMsg.value = String(e);
+    amountErrorMsg.value = i18n.t(classifyError(e));
   } finally {
     isLoading.value = false;
   }
@@ -626,7 +627,7 @@ async function onSwapCosmos() {
         onClose();
       } catch (error) {
         step.value = CONFIRM_STEP.ERROR;
-        amountErrorMsg.value = error instanceof Error ? error.message : String(error);
+        amountErrorMsg.value = i18n.t(classifyError(error));
         Logger.error(error);
 
         if (walletStore.history[id]) {

--- a/src/modules/assets/components/SwapForm.vue
+++ b/src/modules/assets/components/SwapForm.vue
@@ -121,7 +121,7 @@ import { NATIVE_NETWORK } from "../../../config/global/network";
 import { computed, inject, onUnmounted, ref, watch } from "vue";
 import { useWalletStore } from "@/common/stores/wallet";
 import { useBalancesStore } from "@/common/stores/balances";
-import { externalWallet, Logger, validateAmountV2, walletOperation, WalletUtils } from "@/common/utils";
+import { classifyError, externalWallet, Logger, validateAmountV2, walletOperation, WalletUtils } from "@/common/utils";
 import { getSkipRouteConfig } from "@/common/utils/ConfigService";
 import { getPriceForCurrency, tryGetCurrencyByDenom } from "@/common/utils/CurrencyLookup";
 import { formatDecAsUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
@@ -139,7 +139,6 @@ import { useConfigStore } from "@/common/stores/config";
 import { useHistoryStore } from "@/common/stores/history";
 import type { RouteResponse } from "@/common/types/skipRoute";
 import type { NetworkInfo } from "@/common/api/types/config";
-import { ApiError } from "@/common/api/types/common";
 import { WalletTypes } from "@/networks/types";
 
 let time: NodeJS.Timeout;
@@ -465,11 +464,7 @@ async function setRoute(token: Coin, revert = false) {
       priceImapact.value = Number(route?.swap_price_impact_percent ?? "0");
       setSwapFee();
     } catch (e) {
-      if (e instanceof ApiError && e.code === "SWAP_ROUTE_FAILED") {
-        error.value = i18n.t("message.swap-route-failed");
-      } else {
-        error.value = e instanceof Error ? e.message : String(e);
-      }
+      error.value = i18n.t(classifyError(e));
       route = null;
       Logger.error(e);
     } finally {
@@ -552,7 +547,7 @@ async function onSwap() {
       wallet.history[id].txHashes = txHashes.value;
     }
   } catch (e) {
-    error.value = e instanceof Error ? e.message : String(e);
+    error.value = i18n.t(classifyError(e));
     Logger.error(error);
 
     if (wallet.history[id]) {

--- a/src/modules/earn/components/SupplyForm.vue
+++ b/src/modules/earn/components/SupplyForm.vue
@@ -93,7 +93,7 @@ import { NATIVE_NETWORK } from "../../../config/global/network";
 import { useWalletStore } from "@/common/stores/wallet";
 import { useBalancesStore } from "@/common/stores/balances";
 import { Dec, Int } from "@keplr-wallet/unit";
-import { getMicroAmount, Logger, validateAmountV2, walletOperation } from "@/common/utils";
+import { classifyError, getMicroAmount, Logger, validateAmountV2, walletOperation } from "@/common/utils";
 import { formatDecAsUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
 import { usePricesStore } from "@/common/stores/prices";
 import { useConfigStore } from "@/common/stores/config";
@@ -253,7 +253,7 @@ async function onNextClick() {
       await walletOperation(transferAmount);
     } catch (e) {
       Logger.error(e);
-      error.value = e instanceof Error ? e.message : String(e);
+      error.value = i18n.t(classifyError(e));
     } finally {
       disabled.value = false;
     }
@@ -290,7 +290,7 @@ async function transferAmount() {
       });
     } catch (e: unknown) {
       Logger.error(e);
-      error.value = e instanceof Error ? e.message : String(e);
+      error.value = i18n.t(classifyError(e));
     } finally {
       loading.value = false;
     }

--- a/src/modules/earn/components/WithdrawForm.vue
+++ b/src/modules/earn/components/WithdrawForm.vue
@@ -93,7 +93,14 @@ import { NATIVE_NETWORK } from "../../../config/global/network";
 import { useWalletStore } from "@/common/stores/wallet";
 import { useBalancesStore } from "@/common/stores/balances";
 import { Coin, Dec, Int } from "@keplr-wallet/unit";
-import { getMicroAmount, Logger, validateAmountV2, WalletManager, walletOperation } from "@/common/utils";
+import {
+  classifyError,
+  getMicroAmount,
+  Logger,
+  validateAmountV2,
+  WalletManager,
+  walletOperation
+} from "@/common/utils";
 import { formatDecAsUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
 import { usePricesStore } from "@/common/stores/prices";
 import { useConfigStore } from "@/common/stores/config";
@@ -319,7 +326,7 @@ async function transferAmount() {
       });
     } catch (e) {
       Logger.error(e);
-      error.value = e instanceof Error ? e.message : String(e);
+      error.value = i18n.t(classifyError(e));
     } finally {
       loading.value = false;
     }

--- a/src/modules/leases/components/single-lease/CloseDialog.test.ts
+++ b/src/modules/leases/components/single-lease/CloseDialog.test.ts
@@ -177,7 +177,9 @@ vi.mock("@/common/utils", async () => {
       coinMinimalDenom: "ibc/ATOM"
     }),
     Logger: { error: hoisted.loggerError },
-    walletOperation: hoisted.walletOperationMock
+    walletOperation: hoisted.walletOperationMock,
+    classifyError: (e: unknown) =>
+      e instanceof Error && /liquidity/i.test(e.message) ? "message.no-liquidity" : "message.unexpected-error"
   };
 });
 
@@ -400,13 +402,16 @@ describe("CloseDialog.vue", () => {
     wrapper.unmount();
   });
 
-  it("logs error when walletOperation rejects", async () => {
+  it("logs error and shows a localized message (not raw text) when walletOperation rejects", async () => {
     hoisted.walletOperationMock.mockRejectedValueOnce(new Error("boom"));
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="submit"]').trigger("click");
     await new Promise((r) => setTimeout(r, 0));
     expect(hoisted.loggerError).toHaveBeenCalled();
+    // The raw "boom" must not leak onto the field — it is classified instead.
+    expect(wrapper.find('[data-test="err"]').text()).toBe("message.unexpected-error");
+    expect(wrapper.find('[data-test="err"]').text()).not.toBe("boom");
     wrapper.unmount();
   });
 

--- a/src/modules/leases/components/single-lease/CloseDialog.vue
+++ b/src/modules/leases/components/single-lease/CloseDialog.vue
@@ -272,7 +272,7 @@ import { useConfigStore } from "@/common/stores/config";
 import { usePricesStore } from "@/common/stores/prices";
 import { useHistoryStore } from "@/common/stores/history";
 import { useLeasesStore, type LeaseDisplayData } from "@/common/stores/leases";
-import { getMicroAmount, Logger, walletOperation } from "@/common/utils";
+import { classifyError, getMicroAmount, Logger, walletOperation } from "@/common/utils";
 import {
   formatDecAsUsd,
   formatUsd,
@@ -921,7 +921,7 @@ async function onSendClick() {
     await walletOperation(marketCloseLease);
   } catch (e: unknown) {
     Logger.error(e);
-    amountErrorMsg.value = e instanceof Error ? e.message : String(e);
+    amountErrorMsg.value = i18n.t(classifyError(e));
   } finally {
     disabled.value = false;
   }
@@ -968,7 +968,7 @@ async function marketCloseLease() {
       });
     } catch (e: unknown) {
       Logger.error(e);
-      amountErrorMsg.value = e instanceof Error ? e.message : String(e);
+      amountErrorMsg.value = i18n.t(classifyError(e));
     } finally {
       loading.value = false;
     }

--- a/src/modules/leases/components/single-lease/RepayDialog.test.ts
+++ b/src/modules/leases/components/single-lease/RepayDialog.test.ts
@@ -168,7 +168,9 @@ vi.mock("@/common/utils", () => ({
     calculateLiquidation: () => ({ toString: () => "0" }),
     calculateLiquidationShort: () => ({ toString: () => "0" })
   },
-  walletOperation: hoisted.walletOperationMock
+  walletOperation: hoisted.walletOperationMock,
+  classifyError: (e: unknown) =>
+    e instanceof Error && /liquidity/i.test(e.message) ? "message.no-liquidity" : "message.unexpected-error"
 }));
 
 vi.mock("@/common/utils/NumberFormatUtils", () => ({
@@ -357,13 +359,16 @@ describe("RepayDialog.vue", () => {
     wrapper.unmount();
   });
 
-  it("logs error when walletOperation rejects", async () => {
+  it("logs error and shows a localized message (not raw text) when walletOperation rejects", async () => {
     hoisted.walletOperationMock.mockRejectedValueOnce(new Error("boom"));
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="submit"]').trigger("click");
     await new Promise((r) => setTimeout(r, 0));
     expect(hoisted.loggerError).toHaveBeenCalled();
+    // The raw "boom" must not leak onto the field — it is classified instead.
+    expect(wrapper.find('[data-test="err"]').text()).toBe("message.unexpected-error");
+    expect(wrapper.find('[data-test="err"]').text()).not.toBe("boom");
     wrapper.unmount();
   });
 

--- a/src/modules/leases/components/single-lease/RepayDialog.vue
+++ b/src/modules/leases/components/single-lease/RepayDialog.vue
@@ -137,7 +137,7 @@ import { useConfigStore } from "@/common/stores/config";
 import { usePricesStore } from "@/common/stores/prices";
 import { useHistoryStore } from "@/common/stores/history";
 import { useLeasesStore, type LeaseDisplayData } from "@/common/stores/leases";
-import { getMicroAmount, LeaseUtils, Logger, walletOperation } from "@/common/utils";
+import { classifyError, getMicroAmount, LeaseUtils, Logger, walletOperation } from "@/common/utils";
 import { formatNumber, formatDecAsUsd, formatUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
 import { getLpnByProtocol } from "@/common/utils/CurrencyLookup";
 import { NATIVE_CURRENCY, NATIVE_NETWORK } from "../../../../config/global/network";
@@ -507,7 +507,7 @@ async function onSendClick() {
     await walletOperation(repayLease);
   } catch (e: unknown) {
     Logger.error(e);
-    amountErrorMsg.value = e instanceof Error ? e.message : String(e);
+    amountErrorMsg.value = i18n.t(classifyError(e));
   } finally {
     disabled.value = false;
   }
@@ -542,7 +542,7 @@ async function repayLease() {
         message: i18n.t("message.toast-repaid")
       });
     } catch (e: unknown) {
-      amountErrorMsg.value = e instanceof Error ? e.message : String(e);
+      amountErrorMsg.value = i18n.t(classifyError(e));
       Logger.error(e);
     } finally {
       loading.value = false;

--- a/src/modules/leases/components/single-lease/StopLossDialog.vue
+++ b/src/modules/leases/components/single-lease/StopLossDialog.vue
@@ -106,7 +106,7 @@ import { useHistoryStore } from "@/common/stores/history";
 import { usePricesStore } from "@/common/stores/prices";
 import { useLeasesStore, type LeaseDisplayData } from "@/common/stores/leases";
 import { useConfigStore } from "@/common/stores/config";
-import { Logger, walletOperation } from "@/common/utils";
+import { classifyError, Logger, walletOperation } from "@/common/utils";
 import { formatNumber, formatPriceUsd } from "@/common/utils/NumberFormatUtils";
 import { getLpnByProtocol } from "@/common/utils/CurrencyLookup";
 import { NATIVE_CURRENCY, NATIVE_NETWORK } from "../../../../config/global/network";
@@ -366,7 +366,7 @@ async function operation() {
       });
     } catch (error: unknown) {
       Logger.error(error);
-      amountErrorMsg.value = error instanceof Error ? error.message : String(error);
+      amountErrorMsg.value = i18n.t(classifyError(error));
     } finally {
       loading.value = false;
     }

--- a/src/modules/leases/components/single-lease/TakeProfitDialog.vue
+++ b/src/modules/leases/components/single-lease/TakeProfitDialog.vue
@@ -106,7 +106,7 @@ import { useHistoryStore } from "@/common/stores/history";
 import { usePricesStore } from "@/common/stores/prices";
 import { useLeasesStore, type LeaseDisplayData } from "@/common/stores/leases";
 import { useConfigStore } from "@/common/stores/config";
-import { Logger, walletOperation } from "@/common/utils";
+import { classifyError, Logger, walletOperation } from "@/common/utils";
 import { formatNumber, formatPriceUsd } from "@/common/utils/NumberFormatUtils";
 import { getLpnByProtocol, getCurrencyByTicker } from "@/common/utils/CurrencyLookup";
 import { NATIVE_CURRENCY, NATIVE_NETWORK } from "../../../../config/global/network";
@@ -379,7 +379,7 @@ async function operation() {
       });
     } catch (error: unknown) {
       Logger.error(error);
-      amountErrorMsg.value = error instanceof Error ? error.message : String(error);
+      amountErrorMsg.value = i18n.t(classifyError(error));
     } finally {
       loading.value = false;
     }


### PR DESCRIPTION
## Summary
Replace raw error-string masking on form fields with a shared, cause-specific localized classifier. Downstream route/contract/RPC failures were assigned verbatim to the input field (`amountErrorMsg = e.message` / `error.value = String(e)`), leaking internal details and showing untranslated text. This is PR 2 of 3 for #191 (Class B).

## Changes
- New pure helper `classifyError(error): string` (`src/common/utils/classifyError.ts`) returning an i18n **key** — callers translate via their own `i18n.t(...)`, so the message stays reactive to locale changes and the helper stays unit-testable. Maps `ApiError` code `SWAP_ROUTE_FAILED` → `swap-route-failed`, status 429 → `rate-limit-exceeded`, a `/liquidity/i` message → `no-liquidity`, everything else → `unexpected-error`. No new i18n strings introduced.
- Applied at every raw-mask catch in `SupplyForm`, `WithdrawForm`, `SendForm`, `ReceiveForm`, `SwapForm`, `RepayDialog`, `CloseDialog`. The swap form's inline `ApiError` special-case is subsumed by the helper, and its now-unused `ApiError` import is removed.
- Swept the same pattern in `StopLossDialog` and `TakeProfitDialog` (separate commit).
- The repay/close dialog tests now assert the field shows a localized message, not raw text; `classifyError` has full-branch unit coverage.

## Verification
- Ran eslint on src — clean
- Ran prettier --check on src — clean
- Ran the full vitest coverage suite (test:coverage) — 792 passed; `classifyError.ts` at 100% branch
- Ran npm run build — succeeded
- Pre-commit hook (lint + test + build) passed on both commits

## Follow-ups
- `LongForm` / `ShortForm` still mask raw errors in their `onOpenLease` submit catches and each carry a duplicated `classifyQuoteError`; consolidate both onto the shared `classifyError` (governed by the snapshot tests + the lease-quote classification note in CLAUDE.md) — #191 follow-up
- Class C (WithdrawForm pool-liquidity submit-only + swallowed failures; minor cleanups, findings 8–13) — #191 PR 3
- #191 stays open; this is PR 2 of 3