### PR TITLE
fix: route lease-form catches through the shared error classifier

### DIFF
--- a/src/modules/leases/components/new-lease/LongForm.test.ts
+++ b/src/modules/leases/components/new-lease/LongForm.test.ts
@@ -153,7 +153,9 @@ vi.mock("@/common/utils", async () => {
       coinMinimalDenom: "ibc/WETH"
     }),
     Logger: { error: hoisted.loggerError },
-    walletOperation: vi.fn()
+    walletOperation: vi.fn(),
+    classifyError: (e: unknown) =>
+      e instanceof Error && /liquidity/i.test(e.message) ? "message.no-liquidity" : "message.unexpected-error"
   };
 });
 

--- a/src/modules/leases/components/new-lease/LongForm.vue
+++ b/src/modules/leases/components/new-lease/LongForm.vue
@@ -193,7 +193,7 @@ import { useBalancesStore } from "@/common/stores/balances";
 import { useConfigStore } from "@/common/stores/config";
 import { usePricesStore } from "@/common/stores/prices";
 import { useHistoryStore } from "@/common/stores/history";
-import { getMicroAmount, Logger, walletOperation } from "@/common/utils";
+import { classifyError, getMicroAmount, Logger, walletOperation } from "@/common/utils";
 import { formatDecAsUsd, formatUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
 import { getDownpaymentRange } from "@/common/utils/LeaseConfigService";
 import { NATIVE_NETWORK } from "../../../../config/global/network";
@@ -590,18 +590,9 @@ async function calculate() {
     }
   } catch (error) {
     Logger.error("LongForm calculate error:", error);
-    amountErrorMsg.value = classifyQuoteError(error);
+    amountErrorMsg.value = i18n.t(classifyError(error));
     leaseApply.value = null;
   }
-}
-
-// Only errors whose message references liquidity map to the "no-liquidity"
-// user message. Every other failure (RPC error, invalid ticker, contract
-// rejection) is surfaced as a generic error instead of being mislabelled —
-// historically this masked the root cause of bugs.
-function classifyQuoteError(error: unknown): string {
-  const msg = error instanceof Error ? error.message : String(error);
-  return /liquidity/i.test(msg) ? i18n.t("message.no-liquidity") : i18n.t("message.unexpected-error");
 }
 
 async function onOpenLease() {
@@ -609,7 +600,7 @@ async function onOpenLease() {
     isDisabled.value = true;
     await walletOperation(openLease);
   } catch (error: unknown) {
-    amountErrorMsg.value = String(error);
+    amountErrorMsg.value = i18n.t(classifyError(error));
     Logger.error(error);
   } finally {
     isDisabled.value = false;
@@ -660,7 +651,7 @@ async function openLease() {
 
       router.push(`/${RouteNames.LEASES}/${data.value}`);
     } catch (error: unknown) {
-      amountErrorMsg.value = String(error);
+      amountErrorMsg.value = i18n.t(classifyError(error));
       Logger.error(error);
     } finally {
       isLoading.value = false;

--- a/src/modules/leases/components/new-lease/ShortForm.test.ts
+++ b/src/modules/leases/components/new-lease/ShortForm.test.ts
@@ -182,7 +182,9 @@ vi.mock("@/common/utils", async () => {
       coinMinimalDenom: "ibc/ALLBTC"
     }),
     Logger: { error: hoisted.loggerError },
-    walletOperation: vi.fn()
+    walletOperation: vi.fn(),
+    classifyError: (e: unknown) =>
+      e instanceof Error && /liquidity/i.test(e.message) ? "message.no-liquidity" : "message.unexpected-error"
   };
 });
 

--- a/src/modules/leases/components/new-lease/ShortForm.vue
+++ b/src/modules/leases/components/new-lease/ShortForm.vue
@@ -194,7 +194,7 @@ import { useBalancesStore } from "@/common/stores/balances";
 import { useConfigStore } from "@/common/stores/config";
 import { usePricesStore } from "@/common/stores/prices";
 import { useHistoryStore } from "@/common/stores/history";
-import { getMicroAmount, Logger, walletOperation } from "@/common/utils";
+import { classifyError, getMicroAmount, Logger, walletOperation } from "@/common/utils";
 import { formatDecAsUsd, formatUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
 import { getDownpaymentRange } from "@/common/utils/LeaseConfigService";
 import { NATIVE_NETWORK } from "../../../../config/global/network";
@@ -576,18 +576,9 @@ async function calculate() {
     }
   } catch (error) {
     Logger.error("ShortForm calculate error:", error);
-    amountErrorMsg.value = classifyQuoteError(error);
+    amountErrorMsg.value = i18n.t(classifyError(error));
     leaseApply.value = null;
   }
-}
-
-// Only errors whose message references liquidity map to the "no-liquidity"
-// user message. Every other failure (config drift, RPC error, invalid ticker,
-// contract rejection) is surfaced as a generic error instead of being
-// mislabelled — historically this masked the root cause of bugs.
-function classifyQuoteError(error: unknown): string {
-  const msg = error instanceof Error ? error.message : String(error);
-  return /liquidity/i.test(msg) ? i18n.t("message.no-liquidity") : i18n.t("message.unexpected-error");
 }
 
 async function onOpenLease() {
@@ -595,7 +586,7 @@ async function onOpenLease() {
     isDisabled.value = true;
     await walletOperation(openLease);
   } catch (error: unknown) {
-    amountErrorMsg.value = String(error);
+    amountErrorMsg.value = i18n.t(classifyError(error));
     Logger.error(error);
   } finally {
     isDisabled.value = false;
@@ -652,7 +643,7 @@ async function openLease() {
 
       router.push(`/${RouteNames.LEASES}/${data.value}`);
     } catch (error: unknown) {
-      amountErrorMsg.value = String(error);
+      amountErrorMsg.value = i18n.t(classifyError(error));
       Logger.error(error);
     } finally {
       isLoading.value = false;


### PR DESCRIPTION
## Summary
Consolidate the open-lease forms onto the shared `classifyError` helper and close the last raw-error leaks. `LongForm`/`ShortForm` still masked raw downstream errors on the input field via `String(error)` in their `onOpenLease`/`openLease` submit catches, and each carried a duplicated `classifyQuoteError`. Follow-up to #191 Class B; resolves the variant-analysis findings raised on #209.

## Changes
- Removed the duplicated per-form `classifyQuoteError`; the `calculate()` catch now uses `i18n.t(classifyError(error))`.
- Routed both submit catches per form (`onOpenLease` and the inner `openLease`) through `classifyError`, eliminating four raw-string leaks.
- Behavior preserved: only `/liquidity/i` → `no-liquidity`, everything else → `unexpected-error`; `classifyError` is a superset (adds `ApiError` code/status mapping). A single classifier now governs every form catch in the app.
- Test mocks export a faithful `classifyError` stub; ShortForm's existing no-liquidity / unexpected-error assertions still hold.

## Verification
- Ran eslint on src — clean
- Ran prettier --check on src — clean
- Ran the full vitest coverage suite (test:coverage) — 792 passed; LongForm.vue and ShortForm.vue above their per-file floors
- Ran npm run build — succeeded
- Pre-commit hook (lint + test + build) passed

## Follow-ups
- Class C (WithdrawForm pool-liquidity submit-only + swallowed failures; minor cleanups, findings 8–13) — #191 PR 3
- #191 stays open