### PR TITLE
fix: surface swallowed form failures and guard short close repayment

### DIFF
--- a/src/modules/assets/components/ReceiveForm.vue
+++ b/src/modules/assets/components/ReceiveForm.vue
@@ -298,15 +298,10 @@ function setHistory() {
   historyStore.addPendingTransfer(data, i18n);
 }
 
-watch(
-  () => [selectedCurrency.value, amount.value],
-  () => {
-    if (amount.value.length > 0) {
-      validateAmount();
-    }
-  }
-);
-
+// Reacts to: selected currency, amount, and wallet address. validateAmount()
+// runs first (idempotent — resets amountErrorMsg each call) and gates the
+// debounced route fetch. This subsumes the previous amount/currency-only watch,
+// which fired validateAmount() redundantly on the same dependency changes.
 watch(
   () => [selectedCurrency.value, amount.value, wallet.value],
   () => {

--- a/src/modules/earn/components/WithdrawForm.test.ts
+++ b/src/modules/earn/components/WithdrawForm.test.ts
@@ -119,7 +119,9 @@ vi.mock("@/common/utils", () => ({
   getMicroAmount: hoisted.getMicroAmountMock,
   validateAmountV2: hoisted.validateAmountV2Mock,
   walletOperation: hoisted.walletOperationMock,
-  WalletManager: { getWalletAddress: () => "nolus1fallback" }
+  WalletManager: { getWalletAddress: () => "nolus1fallback" },
+  classifyError: (e: unknown) =>
+    e instanceof Error && /liquidity/i.test(e.message) ? "message.no-liquidity" : "message.unexpected-error"
 }));
 
 vi.mock("@/common/utils/NumberFormatUtils", () => ({
@@ -245,6 +247,22 @@ describe("WithdrawForm.vue", () => {
   it("renders without throwing with at least one asset", () => {
     const wrapper = factory();
     expect(wrapper.exists()).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("surfaces a localized message (not a silent stop) when the withdraw flow rejects — finding 8", async () => {
+    hoisted.walletOperationMock.mockRejectedValueOnce(new Error("lpp balance fetch failed"));
+    const wrapper = factory();
+    await new Promise((r) => setTimeout(r, 0));
+    await nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("50");
+    await nextTick();
+    await wrapper.find('[data-test="submit"]').trigger("click");
+    await new Promise((r) => setTimeout(r, 0));
+    await nextTick();
+    // onNextClick used to only Logger.error a failed pre-check/op, leaving the
+    // field blank and the button reset — it now shows a classified message.
+    expect(wrapper.find('[data-test="error"]').text()).toBe("message.unexpected-error");
     wrapper.unmount();
   });
 

--- a/src/modules/earn/components/WithdrawForm.vue
+++ b/src/modules/earn/components/WithdrawForm.vue
@@ -163,7 +163,13 @@ const onShowToast = inject("onShowToast", (_data: { type: ToastType; message: st
 
 const input = ref("0");
 const error = ref("");
-const errorInsufficientBalance = computed(() => error.value === i18n.t("message.invalid-balance-big"));
+const errorInsufficientBalance = computed(() =>
+  [
+    i18n.t("message.invalid-balance-big"),
+    i18n.t("message.withdraw-lpp-balance-error"),
+    i18n.t("message.invalid-amount")
+  ].includes(error.value)
+);
 const loading = ref(false);
 const disabled = ref(false);
 const selectedCurrency = ref(0);
@@ -254,6 +260,9 @@ async function onNextClick() {
       await walletOperation(transferAmount);
     } catch (e) {
       Logger.error(e);
+      // Don't swallow: a failed liquidity pre-check (onValidateAmount) or wallet
+      // op must leave a localized message on the field, not just stop the button.
+      error.value = i18n.t(classifyError(e));
     } finally {
       disabled.value = false;
     }

--- a/src/modules/leases/components/single-lease/CloseDialog.test.ts
+++ b/src/modules/leases/components/single-lease/CloseDialog.test.ts
@@ -68,7 +68,7 @@ const hoisted = vi.hoisted(() => {
       }
     },
     lpn: [{ key: "USDC@osmosis-1", shortName: "USDC" }],
-    getPositionType: (_p: string) => "Long"
+    positionType: "Long" as "Long" | "Short"
   };
 
   const balancesRef = {
@@ -140,7 +140,7 @@ vi.mock("@/common/stores/config", () => ({
     get lpn() {
       return hoisted.configRef.lpn;
     },
-    getPositionType: hoisted.configRef.getPositionType,
+    getPositionType: (_p: string) => hoisted.configRef.positionType,
     getCurrencyByKey: (key: string) => (hoisted.configRef.currenciesData as Record<string, unknown>)[key],
     getCurrencyByTicker: (ticker: string) =>
       Object.values(hoisted.configRef.currenciesData).find((c) => (c as { ticker: string }).ticker === ticker)
@@ -351,6 +351,7 @@ describe("CloseDialog.vue", () => {
       "USDC@osmosis-1": { price: "1" },
       "ATOM@osmosis-1": { price: "10" }
     };
+    hoisted.configRef.positionType = "Long";
   });
 
   it("renders without throwing when a cached open lease is present", async () => {
@@ -463,6 +464,20 @@ describe("CloseDialog.vue", () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.exists()).toBe(true);
     expect(wrapper.find('[data-test="err"]').text()).toBe("message.unexpected-error");
+    wrapper.unmount();
+  });
+
+  it("does not throw/freeze on a short position when the selected-currency price is missing (finding 13)", async () => {
+    // Short getRepayment force-derefed prices[selectedCurrency.key].price; a
+    // missing entry threw inside the debt/preview computeds and froze them.
+    hoisted.configRef.positionType = "Short";
+    hoisted.pricesRef.prices = { "USDC@osmosis-1": { price: "1" } } as typeof hoisted.pricesRef.prices;
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("5");
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.exists()).toBe(true);
     wrapper.unmount();
   });
 

--- a/src/modules/leases/components/single-lease/CloseDialog.vue
+++ b/src/modules/leases/components/single-lease/CloseDialog.vue
@@ -894,7 +894,14 @@ function getRepayment(p: number) {
     const SHORT_PRICE_BUFFER = new Dec("1.01");
     const debtTicker = lease.value.debt.ticker;
     const debtAssetPrice = new Dec(pricesStore.prices[`${debtTicker}@${lease.value.protocol}`]?.price ?? "1");
-    const selected_asset_price = new Dec(pricesStore.prices[selectedCurrency.key as string].price);
+    const selectedPriceEntry = pricesStore.prices[selectedCurrency.key as string];
+    // A missing selected-currency price would divide by zero and throw inside a
+    // render computed, freezing it. Bail so callers render an empty preview —
+    // mirrors the Long branch below and the guarded RepayDialog.
+    if (!selectedPriceEntry?.price) {
+      return undefined;
+    }
+    const selected_asset_price = new Dec(selectedPriceEntry.price);
     const repayment = repaymentInStable.mul(debtAssetPrice).mul(SHORT_PRICE_BUFFER);
     return {
       repayment: repayment.quo(selected_asset_price),

--- a/src/modules/stake/components/DelegateForm.test.ts
+++ b/src/modules/stake/components/DelegateForm.test.ts
@@ -97,7 +97,9 @@ vi.mock("@/common/utils", () => ({
   },
   Utils: { getRandomInt: () => 0 },
   validateAmountV2: hoisted.validateAmountV2Mock,
-  walletOperation: hoisted.walletOperationMock
+  walletOperation: hoisted.walletOperationMock,
+  classifyError: (e: unknown) =>
+    e instanceof Error && /liquidity/i.test(e.message) ? "message.no-liquidity" : "message.unexpected-error"
 }));
 
 vi.mock("@/common/utils/NumberFormatUtils", () => ({
@@ -246,6 +248,19 @@ describe("DelegateForm.vue", () => {
     expect(hoisted.walletOperationMock).toHaveBeenCalledTimes(1);
     expect(hoisted.simulateDelegateTx).toHaveBeenCalledTimes(1);
     expect(hoisted.broadcastTx).toHaveBeenCalledTimes(1);
+    wrapper.unmount();
+  });
+
+  it("surfaces a localized message (not a silent stop) when delegate rejects — finding 9", async () => {
+    hoisted.walletOperationMock.mockRejectedValueOnce(new Error("validator fetch failed"));
+    const wrapper = factory();
+    await wrapper.find('[data-test="amount"]').setValue("100");
+    await wrapper.find('[data-test="submit"]').trigger("click");
+    await new Promise((r) => setTimeout(r, 0));
+    await nextTick();
+    // The failure used to be swallowed (Logger.error only) — the field now shows
+    // a classified message instead of staying blank.
+    expect(wrapper.find('[data-test="error"]').text()).toBe("message.unexpected-error");
     wrapper.unmount();
   });
 

--- a/src/modules/stake/components/DelegateForm.vue
+++ b/src/modules/stake/components/DelegateForm.vue
@@ -77,7 +77,7 @@ import { useWalletStore } from "@/common/stores/wallet";
 import { useBalancesStore } from "@/common/stores/balances";
 import { useHistoryStore } from "@/common/stores/history";
 import { Dec } from "@keplr-wallet/unit";
-import { Logger, NetworkUtils, Utils, validateAmountV2, walletOperation } from "@/common/utils";
+import { classifyError, Logger, NetworkUtils, Utils, validateAmountV2, walletOperation } from "@/common/utils";
 import { useStakingStore } from "@/common/stores/staking";
 import { useRouter } from "vue-router";
 import { RouteNames } from "@/router";
@@ -147,6 +147,9 @@ async function onNextClick() {
       await walletOperation(delegate);
     } catch (e) {
       Logger.error(e);
+      // Don't swallow: a delegate failure after validation (validator fetch /
+      // simulation / broadcast) must surface a localized message on the field.
+      validationError.value = i18n.t(classifyError(e));
     } finally {
       disabled.value = false;
     }


### PR DESCRIPTION
## Summary
Final cleanup for #191 (Class C — submit-only checks / swallowed failures + minor fixes). Several form catches stopped the button without showing any message, and the close dialog's short-position repayment preview dereferenced a price entry that can be missing.

Closes #191.

## Changes
- **WithdrawForm / DelegateForm (findings 8, 9):** the `onNextClick` catches logged the error only, leaving the field blank and the button reset. They now also set a localized message via the shared `classifyError` helper, so a failed liquidity pre-check, validator fetch, or broadcast is visible.
- **WithdrawForm (finding 12):** error styling now covers `withdraw-lpp-balance-error` and `invalid-amount`, not only `invalid-balance-big`.
- **ReceiveForm (finding 11):** removed a redundant reactive validation watch fully subsumed by the route-fetch watch (superset deps; runs the same idempotent `validateAmount` first).
- **CloseDialog (finding 13):** guarded the short `getRepayment` price deref to return `undefined` on a missing entry — matching the long branch and `RepayDialog` — so a missing price no longer throws inside the render computeds and freezes the preview. All callers already tolerate `undefined`.
- **Finding 10 (delegate minimum):** verified non-actionable — Cosmos SDK enforces no protocol-level minimum delegation and no such constant exists; no check added.
- Added tests for findings 8, 9, and 13 (Short missing-price path).

## Verification
- Ran eslint on src — clean
- Ran prettier --check on src — clean
- Ran the full vitest coverage suite (test:coverage) — 795 passed
- Ran npm run build — succeeded
- Pre-commit hook (lint + test + build) passed

## Follow-ups
- Optional enhancement (not required by the finding, which accepted "or at least don't swallow"): surface the Lpp pool-liquidity check reactively rather than at submit time. Left for a future pass.