### PR TITLE
fix: refresh lockfile to web-components v2.0.66

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11908,8 +11908,8 @@
       }
     },
     "node_modules/web-components": {
-      "version": "2.0.61",
-      "resolved": "git+ssh://git@github.com/nolus-protocol/web-components.git#425b5ec0a8a2214e4a480b216e3523453cd5f98a",
+      "version": "2.0.66",
+      "resolved": "git+ssh://git@github.com/nolus-protocol/web-components.git#55611dcf99b1bff977ff953259458a167b656226",
       "dependencies": {
         "motion-v": "^1.9.0"
       },


### PR DESCRIPTION
## Summary
Repin the lockfile to web-components v2.0.66 to match the `package.json` pin. The lockfile was never refreshed when the pin was bumped, so it still resolved to v2.0.61 (commit `425b5ec`). Because `pr-validate` and both deploy workflows install with `npm ci`, the app has been built against v2.0.61 the whole time.

## Changes
- `package-lock.json`: web-components `425b5ec` (v2.0.61) → `55611dc` (v2.0.66). Lockfile-only; no source changes.

## Why it matters
v2.0.66 reworked Popover/Dropdown/Input/Dialog to gate rendering on an internal `isOpen` ref, expose `toggle`/`isOpen`, and add Motion enter/leave animations. The app consumes that API. Against v2.0.61 those calls no-op, so popovers, dropdowns and dialogs render permanently open with no animations.

## Verification
- Reinstalled `web-components@v2.0.66`; only the web-components lines in the lockfile changed (no dependency cascade)
- Ran `npm run lint` + `npm test` + `npm run build` via the pre-commit hook — all passed against v2.0.66
- Confirmed the built bundle contains the v2.0.66 popover code (`isOpen` gating + Motion enter/leave)

## Follow-ups
- Verify on app-dev before cutting a production tag — holding prod until a wider regression pass against v2.0.66 is done