### PR TITLE
test: cover CurrencyLookup helpers and fix hoisted-mock teardown flake

### DIFF
--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -76,6 +76,27 @@ jobs:
 
           echo "OK — WebMCP scope guard passed."
 
+      - name: Test hygiene guard — no vi.hoisted + restoreAllMocks() combination
+        run: |
+          set -e
+          # Policy: a spec that re-installs vi.hoisted mocks every beforeEach must
+          # NOT also call vi.restoreAllMocks() in afterEach. restoreAllMocks resets
+          # the hoisted implementations to undefined, so a pending timer firing after
+          # teardown sees undefined where the mock was — an unhandled-rejection flake
+          # that loses deterministically under coverage instrumentation. The
+          # beforeEach re-install + vi.clearAllMocks() is sufficient on its own.
+          bad=0
+          while IFS= read -r f; do
+            if grep -q 'restoreAllMocks' "$f"; then
+              echo "FAIL: $f mixes vi.hoisted mocks with vi.restoreAllMocks() — remove the restoreAllMocks() call."
+              bad=1
+            fi
+          done < <(grep -rlE --include='*.test.ts' --include='*.spec.ts' 'vi\.hoisted' src)
+          if [ "$bad" -ne 0 ]; then
+            exit 1
+          fi
+          echo "OK — no vi.hoisted + restoreAllMocks() combination."
+
       - name: Validate .well-known JSON files in dist/
         run: |
           set -e

--- a/src/common/stores/balances/index.test.ts
+++ b/src/common/stores/balances/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -109,10 +109,6 @@ describe("useBalancesStore", () => {
     configState.getActiveProtocolsForNetwork = vi.fn(() => []);
     configState.getCurrencyByDenom = vi.fn(() => undefined);
     setActivePinia(createPinia());
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("returns initial state defaults", () => {

--- a/src/common/stores/connection/index.test.ts
+++ b/src/common/stores/connection/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -96,10 +96,6 @@ describe("useConnectionStore", () => {
     statsStore.initialize = vi.fn(async () => {});
     statsStore.cleanup = vi.fn();
     setActivePinia(createPinia());
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("returns initial state defaults", () => {

--- a/src/common/stores/earn/index.test.ts
+++ b/src/common/stores/earn/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -82,10 +82,6 @@ describe("useEarnStore", () => {
     connectionState.walletAddress = null;
     connectionState.wsReconnectCount = 0;
     setActivePinia(createPinia());
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("returns initial state defaults", () => {

--- a/src/common/stores/history/index.test.ts
+++ b/src/common/stores/history/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type * as CommonUtils from "@/common/utils";
 import { setActivePinia, createPinia } from "pinia";
 
@@ -88,10 +88,6 @@ beforeEach(() => {
   for (const fn of Object.values(api)) {
     fn.mockReset();
   }
-});
-
-afterEach(() => {
-  vi.restoreAllMocks();
 });
 
 // -----------------------------------------------------------------------------

--- a/src/common/stores/leases/index.test.ts
+++ b/src/common/stores/leases/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -178,10 +178,6 @@ describe("useLeasesStore", () => {
     configState.currenciesData = {};
     configState.getPositionType = vi.fn(() => "Long");
     setActivePinia(createPinia());
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("returns initial state defaults", () => {

--- a/src/common/stores/prices/index.test.ts
+++ b/src/common/stores/prices/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 // Shim window.matchMedia before store import: ThemeManager (via @/common/utils)
@@ -67,10 +67,6 @@ describe("usePricesStore", () => {
       return captured.unsubscribe;
     });
     setActivePinia(createPinia());
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("returns initial state defaults", () => {

--- a/src/common/stores/staking/index.test.ts
+++ b/src/common/stores/staking/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 // ThemeManager needs window.matchMedia at module import time.
@@ -80,10 +80,6 @@ describe("useStakingStore", () => {
     connectionState.walletAddress = null;
     connectionState.wsReconnectCount = 0;
     setActivePinia(createPinia());
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("returns initial state defaults", () => {

--- a/src/common/stores/wallet/index.test.ts
+++ b/src/common/stores/wallet/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 // ThemeManager (pulled in via the utils barrel from wallet actions) reads
@@ -63,10 +63,6 @@ describe("useWalletStore", () => {
     localStorage.clear();
     vi.resetAllMocks();
     setActivePinia(createPinia());
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("should return initial state defaults", () => {

--- a/src/common/utils/CurrencyLookup.test.ts
+++ b/src/common/utils/CurrencyLookup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { Dec } from "@keplr-wallet/unit";
 
@@ -39,7 +39,18 @@ vi.mock("@/common/api", () => ({
 import { BackendApi } from "@/common/api";
 import { useConfigStore } from "../stores/config";
 import { usePricesStore } from "../stores/prices";
-import { getPriceForCurrency } from "./CurrencyLookup";
+import {
+  getCurrencyByTicker,
+  getCurrencyBySymbol,
+  getCurrencyByDenom,
+  getCurrencyByTickerForNetwork,
+  getCurrencyByTickerForProtocol,
+  getProtocolByContract,
+  getLpnByProtocol,
+  tryGetCurrencyByDenom,
+  tryGetCurrencyBySymbol,
+  getPriceForCurrency
+} from "./CurrencyLookup";
 
 const api = BackendApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
 
@@ -150,10 +161,6 @@ describe("getPriceForCurrency", () => {
     }
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("returns the currency's own price when its key is published", async () => {
     await primedStores();
     expect(getPriceForCurrency(USDC_OSMOSIS as any)).toBe("1.0001");
@@ -190,5 +197,155 @@ describe("getPriceForCurrency", () => {
     ].sort((a, b) => Number(b.stable.sub(a.stable).toString(8)));
 
     expect(sorted[0].ticker).toBe("USDC");
+  });
+});
+
+// Distinct per-protocol contract addresses so getProtocolByContract resolves
+// unambiguously (the shared configFixture reuses one address across protocols).
+function helperConfigFixture() {
+  return {
+    protocols: {
+      OSMOSIS: {
+        is_active: true,
+        network: "Osmosis",
+        position_type: "long",
+        contracts: { oracle: "osmo-oracle", lpp: "osmo-lpp", leaser: "osmo-leaser", profit: "osmo-profit" }
+      },
+      NEUTRON: {
+        is_active: true,
+        network: "Neutron",
+        position_type: "short",
+        contracts: { oracle: "ntrn-oracle", lpp: "ntrn-lpp", leaser: "ntrn-leaser", profit: "ntrn-profit" }
+      }
+    },
+    networks: [
+      {
+        key: "OSMOSIS",
+        chain_id: "osmosis-1",
+        name: "Osmosis",
+        prefix: "osmo",
+        value: "osmosis",
+        primary_protocol: "OSMOSIS",
+        icon: "/icons/osmosis.svg",
+        native: false
+      }
+    ],
+    native_asset: { ticker: "NLS", denom: "unls", decimals: 6 }
+  };
+}
+
+async function primeHelpers() {
+  api.getConfig.mockResolvedValueOnce(helperConfigFixture());
+  api.getCurrencies.mockResolvedValueOnce(currenciesFixture());
+
+  const configStore = useConfigStore();
+  await configStore.fetchConfig();
+  await configStore.fetchCurrencies();
+  configStore.setProtocolFilter("OSMOSIS");
+
+  return { configStore };
+}
+
+describe("CurrencyLookup config-store delegation", () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+    for (const fn of Object.values(api)) {
+      fn.mockReset();
+    }
+    await primeHelpers();
+  });
+
+  describe("getCurrencyByTicker", () => {
+    it("returns the active-protocol currency for a known ticker", () => {
+      expect(getCurrencyByTicker("WBTC")).toEqual(WBTC_OSMOSIS);
+    });
+
+    it("throws on an unknown ticker", () => {
+      expect(() => getCurrencyByTicker("NOPE")).toThrow("Currency not found: NOPE");
+    });
+  });
+
+  describe("getCurrencyBySymbol", () => {
+    it("returns the currency for a known symbol", () => {
+      expect(getCurrencyBySymbol("WBTC")).toEqual(WBTC_OSMOSIS);
+    });
+
+    it("throws on an unknown symbol", () => {
+      expect(() => getCurrencyBySymbol("NOPE")).toThrow("Currency not found: NOPE");
+    });
+  });
+
+  describe("getCurrencyByDenom", () => {
+    it("returns the currency for a known IBC denom", () => {
+      expect(getCurrencyByDenom("ibc/WBTC_OSMO")).toEqual(WBTC_OSMOSIS);
+    });
+
+    it("throws on an unknown denom", () => {
+      expect(() => getCurrencyByDenom("ibc/NOPE")).toThrow("Currency not found: ibc/NOPE");
+    });
+  });
+
+  describe("getCurrencyByTickerForNetwork", () => {
+    it("resolves the ticker against the active network filter", () => {
+      expect(getCurrencyByTickerForNetwork("WBTC")).toEqual(WBTC_OSMOSIS);
+    });
+
+    it("throws when the ticker is absent on the active network", () => {
+      expect(() => getCurrencyByTickerForNetwork("NOPE")).toThrow("Currency not found: NOPE for network OSMOSIS");
+    });
+  });
+
+  describe("getCurrencyByTickerForProtocol", () => {
+    it("returns the currency for a resolvable ticker@protocol key", () => {
+      expect(getCurrencyByTickerForProtocol("WBTC", "OSMOSIS")).toEqual(WBTC_OSMOSIS);
+    });
+
+    it("throws when the ticker is not present on the given protocol", () => {
+      expect(() => getCurrencyByTickerForProtocol("WBTC", "NEUTRON")).toThrow(
+        "Currency not found: WBTC for protocol NEUTRON"
+      );
+    });
+  });
+
+  describe("getProtocolByContract", () => {
+    it("returns the protocol owning the contract address", () => {
+      expect(getProtocolByContract("osmo-leaser")).toBe("OSMOSIS");
+      expect(getProtocolByContract("ntrn-oracle")).toBe("NEUTRON");
+    });
+
+    it("throws on an unknown contract address", () => {
+      expect(() => getProtocolByContract("no-such-contract")).toThrow("Contract not found no-such-contract");
+    });
+  });
+
+  describe("getLpnByProtocol", () => {
+    it("returns the LPN currency for a known protocol", () => {
+      expect(getLpnByProtocol("OSMOSIS")).toEqual(USDC_OSMOSIS);
+    });
+
+    it("returns null for a protocol with no LPN", () => {
+      expect(getLpnByProtocol("MARS")).toBeNull();
+    });
+  });
+
+  describe("tryGetCurrencyByDenom", () => {
+    it("returns the currency for a known denom", () => {
+      expect(tryGetCurrencyByDenom("ibc/WBTC_OSMO")).toEqual(WBTC_OSMOSIS);
+    });
+
+    it("returns null instead of throwing on a miss", () => {
+      expect(tryGetCurrencyByDenom("ibc/NOPE")).toBeNull();
+    });
+  });
+
+  describe("tryGetCurrencyBySymbol", () => {
+    it("returns the currency for a known symbol", () => {
+      expect(tryGetCurrencyBySymbol("WBTC")).toEqual(WBTC_OSMOSIS);
+    });
+
+    it("returns null instead of throwing on a miss", () => {
+      expect(tryGetCurrencyBySymbol("NOPE")).toBeNull();
+    });
   });
 });

--- a/src/common/utils/WalletUtils.test.ts
+++ b/src/common/utils/WalletUtils.test.ts
@@ -93,7 +93,6 @@ describe("WalletUtils.getKeplr", () => {
 
   afterEach(() => {
     delete w.keplr;
-    vi.restoreAllMocks();
   });
 
   it("should return window.keplr when extension is already set", async () => {

--- a/src/modules/assets/components/SwapForm.test.ts
+++ b/src/modules/assets/components/SwapForm.test.ts
@@ -289,10 +289,6 @@ describe("SwapForm.vue — defensive guards on .find()", () => {
     });
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("renders without throwing", async () => {
     const wrapper = factory();
     await flushPromises();

--- a/src/modules/earn/components/SupplyForm.test.ts
+++ b/src/modules/earn/components/SupplyForm.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -256,10 +256,6 @@ describe("SupplyForm.vue", () => {
     hoisted.getBalance.mockReturnValue("0");
     hoisted.getProtocolApr.mockReturnValue(5);
     hoisted.validateAmountV2Mock.mockReturnValue("");
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("renders without throwing with at least one asset", () => {

--- a/src/modules/earn/components/WithdrawForm.test.ts
+++ b/src/modules/earn/components/WithdrawForm.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -238,10 +238,6 @@ describe("WithdrawForm.vue", () => {
     });
     hoisted.broadcastTx.mockResolvedValue({});
     hoisted.fetchBalances.mockResolvedValue(undefined);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("renders without throwing with at least one asset", () => {

--- a/src/modules/leases/components/NewLease.test.ts
+++ b/src/modules/leases/components/NewLease.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type * as VueRouter from "vue-router";
 
 vi.hoisted(() => {
@@ -61,10 +61,6 @@ describe("NewLease.vue", () => {
     localStorage.clear();
     vi.clearAllMocks();
     hoisted.routeRef.meta.action = "long";
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("renders without throwing", () => {

--- a/src/modules/leases/components/single-lease/RepayDialog.test.ts
+++ b/src/modules/leases/components/single-lease/RepayDialog.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type * as VueRouter from "vue-router";
 import type * as NolusJs from "@nolus/nolusjs";
 import { setActivePinia, createPinia } from "pinia";
@@ -312,10 +312,6 @@ describe("RepayDialog.vue", () => {
       "USDC@osmosis-1": { price: "1" },
       "ATOM@osmosis-1": { price: "10" }
     };
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("renders without throwing when lease is loaded", async () => {

--- a/src/modules/stake/components/DelegateForm.test.ts
+++ b/src/modules/stake/components/DelegateForm.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -195,10 +195,6 @@ describe("DelegateForm.vue", () => {
     hoisted.walletOperationMock.mockImplementation(async (op: () => Promise<void> | void) => {
       await op();
     });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("renders without throwing", () => {

--- a/src/modules/stake/components/RedelegateButton.test.ts
+++ b/src/modules/stake/components/RedelegateButton.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 // Shim window.matchMedia before any store import: ThemeManager (via @/common/utils)
@@ -136,10 +136,6 @@ describe("RedelegateButton.vue", () => {
     hoisted.loadActivities.mockReturnValue(undefined);
     hoisted.loadDelegatorValidators.mockResolvedValue([]);
     hoisted.loadValidators.mockResolvedValue([]);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("renders without throwing", () => {

--- a/src/modules/stake/components/UndelegateForm.test.ts
+++ b/src/modules/stake/components/UndelegateForm.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -188,10 +188,6 @@ describe("UndelegateForm.vue", () => {
     hoisted.walletOperationMock.mockImplementation(async (op: () => Promise<void> | void) => {
       await op();
     });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("renders without throwing", () => {

--- a/src/modules/vote/components/VoteDialog.test.ts
+++ b/src/modules/vote/components/VoteDialog.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 vi.hoisted(() => {
@@ -172,10 +172,6 @@ describe("VoteDialog.vue", () => {
     hoisted.walletOperationMock.mockImplementation(async (op: () => Promise<void> | void) => {
       await op();
     });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("renders without throwing", () => {

--- a/src/networks/cosm/BaseWallet.test.ts
+++ b/src/networks/cosm/BaseWallet.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Stub window.matchMedia BEFORE any imports (utils barrel pulls in ThemeManager
 // which reads matchMedia at module load in jsdom).
@@ -138,10 +138,6 @@ describe("BaseWallet", () => {
     superGetSequence.mockReset();
     superGetChainId.mockReset();
     withExtensionsMock.mockClear();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe("constructor", () => {

--- a/src/networks/cosm/WalletFactory.test.ts
+++ b/src/networks/cosm/WalletFactory.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Shared state for the mocks — hoisted so they exist before the vi.mock
 // factories (which are themselves hoisted to the top of the module).
@@ -118,10 +118,6 @@ describe("WalletFactory", () => {
     walletUtilsMock.getKeplr.mockReset();
     fetchEndpointsMock.mockReset();
     fetchEndpointsMock.mockResolvedValue({ rpc: "r", api: "a" });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe("authenticateKeplr", () => {

--- a/src/router/index.test.ts
+++ b/src/router/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type * as VueRouter from "vue-router";
 
 // Mock every module the router imports so the router module can be loaded
@@ -73,10 +73,6 @@ describe("router/index.ts", () => {
       meta.setAttribute("content", "");
       document.head.appendChild(meta);
     }
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("router module loads and exports RouteNames + router instance", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -58,6 +58,12 @@ export default mergeConfig(
             functions: 100,
             statements: 100
           },
+          "src/common/utils/CurrencyLookup.ts": {
+            lines: 100,
+            branches: 100,
+            functions: 100,
+            statements: 100
+          },
           "src/common/utils/WalletUtils.ts": {
             lines: 55,
             branches: 45,


### PR DESCRIPTION
## Summary
Bundles two test-hygiene items. Adds direct coverage for `CurrencyLookup.ts`'s throwing helpers (the documented list-rendering footgun) with a per-file coverage floor, and removes the `vi.restoreAllMocks()` + `vi.hoisted` teardown race from 22 specs, guarded by a new pr-validate check.

## Changes
- Cover success + throw-on-miss for every `CurrencyLookup` delegating helper; floor the file at 100% in `vitest.config.ts`.
- Drop `restoreAllMocks()` from afterEach in 22 hoisted-mock specs (keeping `delete w.keplr` / `useRealTimers` where present).
- Add a `pr-validate.yaml` guard failing any spec that pairs `vi.hoisted` with `restoreAllMocks`.

## Verification
- Ran `npm run test:coverage`: 52 files / 813 tests pass; `CurrencyLookup.ts` at 100/100/100/100; no unhandled rejections.
- Ran `eslint` + `prettier --check` on all touched files — clean.
- Dry-ran the new CI guard locally — passes with zero offenders.

Closes #173. Closes #175.