### PR TITLE
docs: document web-components UI library bump process

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,34 @@ npm run serve
 | Lint frontend | `npm run lint` |
 | Lint backend | `cd backend && cargo clippy` |
 
+## Updating the web-components UI library
+
+The UI primitives (buttons, inputs, dialogs, dropdowns, toasts) come from [`nolus-protocol/web-components`](https://github.com/nolus-protocol/web-components), pinned by git tag in `package.json`. Because it is a git dependency, the tag and the lockfile must be bumped **together** — a tag bump alone leaves `package-lock.json` (and every `npm ci` in CI and the deploy workflows) on the old commit, silently shipping a stale library whose components can differ from what the app expects.
+
+To bump the library:
+
+1. Edit the pin in `package.json`:
+
+   ```json
+   "web-components": "github:nolus-protocol/web-components#vX.Y.Z"
+   ```
+
+2. Refresh the lockfile (do **not** hand-edit it):
+
+   ```sh
+   npm install
+   ```
+
+3. Commit **both** `package.json` and `package-lock.json` in the same change and open a PR, so `pr-validate` reinstalls from the new lockfile.
+
+4. Verify the installed version matches the pin:
+
+   ```sh
+   npm ls web-components
+   ```
+
+Never float the version at deploy time — both deploy workflows run `npm ci`, which installs strictly from the committed lockfile.
+
 ## License
 
 [Apache-2.0](LICENSE)


### PR DESCRIPTION
## Summary
Add a README section documenting how to bump the `web-components` UI library, so the tag pin and the lockfile are always updated together. The procedure previously lived only in the gitignored root `CLAUDE.md`, so it never reached contributors.

## Why
`web-components` is a git-tag dependency. Bumping the tag in `package.json` without refreshing `package-lock.json` leaves `npm ci` (CI + both deploy workflows) on the old commit, silently shipping a stale library — the root cause of the always-open popover/dialog regression fixed in #212.

## Changes
- New "Updating the web-components UI library" README section: bump the pin → `npm install` to refresh the lockfile → commit both files in one PR → verify with `npm ls web-components`.

## Verification
- Reviewed the rendered markdown diff
- `README.md` is outside `pr-validate`'s `format:check` scope (`src/` only); the added section follows the existing README style