### PR TITLE
refactor(ts): replace money/wallet boundary casts with guards & schemas

### DIFF
--- a/src/common/api/schemas/index.test.ts
+++ b/src/common/api/schemas/index.test.ts
@@ -7,7 +7,8 @@ import {
   LeasesResponseSchema,
   EarnPoolSchema,
   EarnPositionsResponseSchema,
-  GasFeeConfigResponseSchema
+  GasFeeConfigResponseSchema,
+  SkipRouteConfigSchema
 } from "./index";
 
 // These tests exercise the Zod runtime validation schemas that guard the
@@ -363,6 +364,62 @@ describe("GasFeeConfigResponseSchema", () => {
     const result = GasFeeConfigResponseSchema.safeParse({
       gas_prices: { uusdc: "" },
       gas_multiplier: 1
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ===========================================================================
+// SkipRouteConfigSchema
+// ===========================================================================
+
+describe("SkipRouteConfigSchema", () => {
+  const validConfig = () => ({
+    blacklist: ["BADTKN"],
+    swap_currency_osmosis: "USDC",
+    swap_currency_neutron: "USDC_NOBLE",
+    swap_to_currency: "USDC",
+    fee: 0.001,
+    transfers: {
+      OSMOSIS: {
+        currencies: [{ from: "uatom", to: "uosmo", native: true, visible: "ATOM" }]
+      }
+    }
+  });
+
+  it("should accept a valid swap config", () => {
+    const result = SkipRouteConfigSchema.safeParse(validConfig());
+    expect(result.success).toBe(true);
+  });
+
+  it("should tolerate extra backend fields (passthrough)", () => {
+    const result = SkipRouteConfigSchema.safeParse({ ...validConfig(), new_field: 123 });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept a transfer currency without the optional visible field", () => {
+    const result = SkipRouteConfigSchema.safeParse({
+      ...validConfig(),
+      transfers: { OSMOSIS: { currencies: [{ from: "uatom", to: "uosmo", native: false }] } }
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject when fee is a numeric string instead of a number", () => {
+    const result = SkipRouteConfigSchema.safeParse({ ...validConfig(), fee: "0.001" });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject when blacklist is missing", () => {
+    const { blacklist: _blacklist, ...rest } = validConfig();
+    const result = SkipRouteConfigSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject a malformed transfer currency (native not boolean)", () => {
+    const result = SkipRouteConfigSchema.safeParse({
+      ...validConfig(),
+      transfers: { OSMOSIS: { currencies: [{ from: "a", to: "b", native: "yes" }] } }
     });
     expect(result.success).toBe(false);
   });

--- a/src/common/api/schemas/index.ts
+++ b/src/common/api/schemas/index.ts
@@ -167,3 +167,34 @@ export const BalancesResponseSchema = z
     total_value_usd: numericString
   })
   .passthrough();
+
+// =============================================================================
+// Swap (Skip route) config
+// =============================================================================
+
+const SkipRouteTransferCurrencySchema = z
+  .object({
+    from: z.string(),
+    to: z.string(),
+    native: z.boolean(),
+    visible: z.string().optional()
+  })
+  .passthrough();
+
+export const SkipRouteConfigSchema = z
+  .object({
+    blacklist: z.array(z.string()),
+    swap_currency_osmosis: z.string(),
+    swap_currency_neutron: z.string(),
+    swap_to_currency: z.string(),
+    fee: z.number(),
+    transfers: z.record(
+      z.string(),
+      z
+        .object({
+          currencies: z.array(SkipRouteTransferCurrencySchema)
+        })
+        .passthrough()
+    )
+  })
+  .passthrough();

--- a/src/common/stores/history/index.ts
+++ b/src/common/stores/history/index.ts
@@ -269,18 +269,20 @@ export const useHistoryStore = defineStore("history", () => {
       const currentAddress = address.value ?? "";
 
       // Process each transaction with message formatting
-      const promises = transformedTxs.map(async (d) => {
+      const promises = transformedTxs.map(async (d): Promise<TransactionEntry> => {
         const [msg, coin, route, routeDetails] = await message(d, currentAddress, i18n.global, voteMessages);
-        d.historyData = {
-          msg,
-          coin,
-          action: action(d, i18n.global).toLowerCase(),
-          icon: iconFn(d, i18n.global).toLowerCase(),
-          timestamp: getCreatedAtForHuman(d.timestamp),
-          route,
-          routeDetails
+        return {
+          ...d,
+          historyData: {
+            msg,
+            coin,
+            action: action(d, i18n.global).toLowerCase(),
+            icon: iconFn(d, i18n.global).toLowerCase(),
+            timestamp: getCreatedAtForHuman(d.timestamp),
+            route,
+            routeDetails
+          }
         };
-        return d as unknown as TransactionEntry;
       });
 
       const res = await Promise.all(promises);
@@ -340,18 +342,20 @@ export const useHistoryStore = defineStore("history", () => {
       const transformedTxs = transformTransactions(rawTxs, address.value);
       const currentAddress = address.value ?? "";
 
-      const promises = transformedTxs.map(async (d) => {
+      const promises = transformedTxs.map(async (d): Promise<TransactionEntry> => {
         const [msg, coin, route, routeDetails] = await message(d, currentAddress, i18n.global, voteMessages);
-        d.historyData = {
-          msg,
-          coin,
-          action: action(d, i18n.global).toLowerCase(),
-          icon: iconFn(d, i18n.global).toLowerCase(),
-          timestamp: getCreatedAtForHuman(d.timestamp),
-          route,
-          routeDetails
+        return {
+          ...d,
+          historyData: {
+            msg,
+            coin,
+            action: action(d, i18n.global).toLowerCase(),
+            icon: iconFn(d, i18n.global).toLowerCase(),
+            timestamp: getCreatedAtForHuman(d.timestamp),
+            route,
+            routeDetails
+          }
         };
-        return d as unknown as TransactionEntry;
       });
 
       const res = await Promise.all(promises);

--- a/src/common/stores/leases/index.test.ts
+++ b/src/common/stores/leases/index.test.ts
@@ -456,6 +456,20 @@ describe("useLeasesStore", () => {
     expect(store.leases.find((l) => l.address === "new1")).toBeDefined();
   });
 
+  it("ws callback discards a malformed payload when no existing lease to merge into", async () => {
+    const store = useLeasesStore();
+    BackendApi.getLeases.mockResolvedValueOnce([]);
+    await store.setOwner("nolus1x");
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Incomplete partial (missing required amount/debt/interest) with no prior record.
+    emitLeases({ address: "bad1", status: "opened" });
+
+    expect(store.leases.find((l) => l.address === "bad1")).toBeUndefined();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
   it("refresh calls fetchLeases", async () => {
     const store = useLeasesStore();
     BackendApi.getLeases.mockResolvedValueOnce([]);

--- a/src/common/stores/leases/index.ts
+++ b/src/common/stores/leases/index.ts
@@ -22,6 +22,8 @@ import { useWalletWatcher } from "@/common/composables/useWalletWatcher";
 import { useWebSocketLifecycle } from "@/common/composables/useWebSocketLifecycle";
 import { LeaseCalculator, type LeaseDisplayData } from "@/common/utils";
 import { getLpnByProtocol } from "@/common/utils/CurrencyLookup";
+import { LeaseInfoSchema } from "@/common/api/schemas";
+import type { ZodType } from "zod";
 
 // Re-export LeaseDisplayData from LeaseCalculator for convenience
 export type { LeaseDisplayData } from "@/common/utils";
@@ -296,7 +298,6 @@ export const useLeasesStore = defineStore("leases", () => {
     address: owner,
     subscribe: (addr) =>
       WebSocketClient.subscribeLeases(addr, (wsLease) => {
-        // Merge with existing data (WebSocket sends partial data, no ETL)
         const existing = leaseDetails.value.get(wsLease.address);
 
         // Don't let a stale WebSocket event regress a lease whose status
@@ -305,7 +306,23 @@ export const useLeasesStore = defineStore("leases", () => {
           return;
         }
 
-        const merged = existing ? { ...existing, ...wsLease } : (wsLease as LeaseInfo);
+        let merged: LeaseInfo;
+        if (existing) {
+          // Existing record: WS updates may be partial; merge so ETL-only fields
+          // (not sent over WS) survive. The existing record was already validated.
+          merged = { ...existing, ...wsLease };
+        } else {
+          // No prior record: a brand-new lease must arrive as a complete LeaseInfo
+          // (the same shape the REST path validates) before it reaches the money
+          // path. A malformed payload is dropped, not crashing the subscription.
+          const parsed = (LeaseInfoSchema as ZodType<LeaseInfo>).safeParse(wsLease);
+          if (!parsed.success) {
+            const fields = parsed.error.issues.map((issue) => issue.path.join(".")).join(", ");
+            console.error(`[LeasesStore] Discarding malformed WebSocket lease payload (invalid: ${fields})`);
+            return;
+          }
+          merged = parsed.data;
+        }
 
         // Update in main list, or add if not yet present
         const index = leases.value.findIndex((l) => l.address === merged.address);

--- a/src/common/stores/wallet/actions/connectKeplrLike.ts
+++ b/src/common/stores/wallet/actions/connectKeplrLike.ts
@@ -49,6 +49,10 @@ export async function connectKeplrLike(
       const offlineSigner = extension.getOfflineSignerOnlyAmino(chainId, {
         preferNoSetFee: true
       });
+      // Keplr-like extensions expose an amino-only signer (`OfflineAminoSigner`),
+      // structurally distinct from `OfflineDirectSigner`. NolusWallet handles amino
+      // signers at runtime, but nolusjs types the factory parameter as direct-only —
+      // a third-party signature gap the compiler cannot bridge on its own.
       const nolusWalletOfflineSigner = await NolusWalletFactory.nolusOfflineSigner(
         offlineSigner as unknown as OfflineDirectSigner
       );

--- a/src/common/utils/ConfigService.ts
+++ b/src/common/utils/ConfigService.ts
@@ -8,7 +8,9 @@
  */
 
 import type { SkipRouteConfigType, ProposalsConfigType } from "@/common/types";
+import type { ZodType } from "zod";
 import { BackendApi } from "@/common/api";
+import { SkipRouteConfigSchema } from "@/common/api/schemas";
 import { CONTRACTS } from "@/config/global";
 import { EnvNetworkUtils } from "./EnvNetworkUtils";
 
@@ -74,7 +76,15 @@ export async function fetchNetworkStatus(): Promise<{
 
 async function fetchSkipRouteConfig(): Promise<SkipRouteConfigType> {
   const response = await BackendApi.getSwapConfig();
-  return response as SkipRouteConfigType;
+  // The schema mirrors SkipRouteConfigType, matching how BackendApi bridges its
+  // other endpoints (`Schema as ZodType<T>`); the parse is the real validation.
+  const result = (SkipRouteConfigSchema as ZodType<SkipRouteConfigType>).safeParse(response);
+  if (!result.success) {
+    const fields = result.error.issues.map((issue) => issue.path.join(".")).join(", ");
+    console.error(`[ConfigService] Invalid swap config response (invalid: ${fields})`);
+    throw new Error("Invalid swap config response");
+  }
+  return result.data;
 }
 
 async function fetchProposalsConfig(): Promise<ProposalsConfigType> {

--- a/src/common/utils/SkipRoute.ts
+++ b/src/common/utils/SkipRoute.ts
@@ -1,7 +1,8 @@
 import type { Chain, RouteRequest, RouteResponse, MessagesRequest, MessagesResponse } from "../types/skipRoute";
-import type { SkipRouteRequest, SkipMessagesRequest, SkipMsg } from "@/common/api/types/swap";
+import type { SkipMsg } from "@/common/api/types/swap";
 
 import { fetchNetworkStatus } from "./ConfigService";
+import { assertChainList, assertRouteResponse, assertMessagesResponse } from "./skipResponseGuards";
 import { BackendApi } from "@/common/api";
 import { i18n } from "@/i18n";
 import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
@@ -34,15 +35,20 @@ enum Messages {
 class Swap {
   async getChains(): Promise<Chain[]> {
     const chains = await BackendApi.getSkipChains(true, true);
-    return chains as Chain[];
+    assertChainList(chains);
+    return chains;
   }
 
   async getRoute(request: RouteRequest): Promise<RouteResponse> {
-    return BackendApi.getSkipRoute(request as SkipRouteRequest) as Promise<RouteResponse>;
+    const route = await BackendApi.getSkipRoute(request);
+    assertRouteResponse(route);
+    return route;
   }
 
   async getMessages(request: MessagesRequest): Promise<MessagesResponse> {
-    return BackendApi.getSkipMessages(request as SkipMessagesRequest) as Promise<MessagesResponse>;
+    const messages = await BackendApi.getSkipMessages(request);
+    assertMessagesResponse(messages);
+    return messages;
   }
 
   async getTransactionStatus({
@@ -91,7 +97,7 @@ export class SkipRouter {
     ]);
 
     SkipRouter.chainId = status;
-    SkipRouter.client = client as Swap;
+    SkipRouter.client = client;
 
     return SkipRouter.client;
   }
@@ -119,7 +125,7 @@ export class SkipRouter {
       request.amount_in = amount;
     }
 
-    const route = await client.getRoute(request as RouteRequest);
+    const route = await client.getRoute(request);
     route.revert = true;
     return route;
   }
@@ -185,7 +191,7 @@ export class SkipRouter {
       ...add
     };
 
-    const response = await client.getMessages(request as MessagesRequest);
+    const response = await client.getMessages(request);
 
     for (const tx of response?.txs ?? []) {
       const chainId = tx?.cosmos_tx?.chain_id;
@@ -295,7 +301,7 @@ export class SkipRouter {
       return SkipRouter.chains;
     }
     const client = await SkipRouter.getClient();
-    SkipRouter.chains = client.getChains() as Promise<Chain[]>;
+    SkipRouter.chains = client.getChains();
     return SkipRouter.chains;
   }
 

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -26,3 +26,4 @@ export * from "./walletProtocolFilter";
 export * from "./NetworkUtils";
 export * from "./IntercomService";
 export * from "./classifyError";
+export * from "./typeGuards";

--- a/src/common/utils/skipResponseGuards.test.ts
+++ b/src/common/utils/skipResponseGuards.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { assertRouteResponse, assertMessagesResponse, assertChainList } from "./skipResponseGuards";
+
+const validRoute = () => ({
+  amount_in: "100",
+  amount_out: "99",
+  source_asset_denom: "uatom",
+  dest_asset_denom: "uosmo",
+  source_asset_chain_id: "cosmoshub-4",
+  dest_asset_chain_id: "osmosis-1",
+  chain_ids: ["osmosis-1"],
+  operations: [{}]
+});
+
+describe("assertRouteResponse", () => {
+  it("passes a well-formed route response", () => {
+    expect(() => assertRouteResponse(validRoute())).not.toThrow();
+  });
+
+  it("throws when a required string field is missing", () => {
+    const { amount_in: _amount_in, ...rest } = validRoute();
+    expect(() => assertRouteResponse(rest)).toThrow();
+  });
+
+  it("throws when chain_ids is not an array", () => {
+    expect(() => assertRouteResponse({ ...validRoute(), chain_ids: "osmosis-1" })).toThrow();
+  });
+
+  it("throws when a chain-id field consumed by the swap flow is missing", () => {
+    const { source_asset_chain_id: _src, ...rest } = validRoute();
+    expect(() => assertRouteResponse(rest)).toThrow();
+  });
+
+  it("throws on null or non-object input", () => {
+    expect(() => assertRouteResponse(null)).toThrow();
+    expect(() => assertRouteResponse("nope")).toThrow();
+  });
+});
+
+describe("assertMessagesResponse", () => {
+  it("passes when txs is an array (including empty)", () => {
+    expect(() => assertMessagesResponse({ txs: [] })).not.toThrow();
+    expect(() => assertMessagesResponse({ txs: [{ cosmos_tx: { chain_id: "osmosis-1", msgs: [] } }] })).not.toThrow();
+  });
+
+  it("throws when txs is missing or not an array", () => {
+    expect(() => assertMessagesResponse({})).toThrow();
+    expect(() => assertMessagesResponse({ txs: "x" })).toThrow();
+  });
+});
+
+describe("assertChainList", () => {
+  it("passes a list of chains with string chain_id + chain_name (and an empty list)", () => {
+    expect(() => assertChainList([{ chain_id: "osmosis-1", chain_name: "osmosis" }])).not.toThrow();
+    expect(() => assertChainList([])).not.toThrow();
+  });
+
+  it("throws when an item lacks a string chain_id", () => {
+    expect(() => assertChainList([{ chain_name: "osmosis" }])).toThrow();
+  });
+
+  it("throws when an item lacks chain_name (dereferenced by the swap flow)", () => {
+    expect(() => assertChainList([{ chain_id: "osmosis-1" }])).toThrow();
+  });
+
+  it("throws when the value is not an array", () => {
+    expect(() => assertChainList({})).toThrow();
+  });
+});

--- a/src/common/utils/skipResponseGuards.ts
+++ b/src/common/utils/skipResponseGuards.ts
@@ -1,0 +1,52 @@
+/**
+ * Runtime guards for Skip API responses proxied through the backend.
+ *
+ * The backend types these payloads loosely (e.g. `operations: unknown[]`), while
+ * the frontend consumes a richer shape. Rather than launder the gap with an
+ * `as`-cast, each guard validates the fields the swap flow actually dereferences
+ * and throws on a malformed response — so a bad payload fails before it can drive
+ * transaction construction. Errors are surfaced through the shared form classifier.
+ *
+ * The checks are intentionally minimal: every field asserted here is already
+ * required in the backend response type, so a valid response can never trip them.
+ * They are top-level shape checks only — the nested message contents are validated
+ * downstream where they are decoded (`SkipRouter.getTx` throws on unknown msg types).
+ */
+import type { Chain, RouteResponse, MessagesResponse } from "@/common/types/skipRoute";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function assertRouteResponse(value: unknown): asserts value is RouteResponse {
+  if (
+    !isRecord(value) ||
+    typeof value.amount_in !== "string" ||
+    typeof value.amount_out !== "string" ||
+    typeof value.source_asset_denom !== "string" ||
+    typeof value.dest_asset_denom !== "string" ||
+    typeof value.source_asset_chain_id !== "string" ||
+    typeof value.dest_asset_chain_id !== "string" ||
+    !Array.isArray(value.chain_ids) ||
+    !Array.isArray(value.operations)
+  ) {
+    throw new Error("Malformed Skip route response");
+  }
+}
+
+export function assertMessagesResponse(value: unknown): asserts value is MessagesResponse {
+  if (!isRecord(value) || !Array.isArray(value.txs)) {
+    throw new Error("Malformed Skip messages response");
+  }
+}
+
+export function assertChainList(value: unknown): asserts value is Chain[] {
+  if (
+    !Array.isArray(value) ||
+    !value.every(
+      (chain) => isRecord(chain) && typeof chain.chain_id === "string" && typeof chain.chain_name === "string"
+    )
+  ) {
+    throw new Error("Malformed Skip chains response");
+  }
+}

--- a/src/common/utils/typeGuards.test.ts
+++ b/src/common/utils/typeGuards.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { isEnumValue } from "./typeGuards";
+
+enum Sample {
+  A = "a",
+  B = "b"
+}
+
+describe("isEnumValue", () => {
+  it("returns true for a value that is a member of the enum", () => {
+    expect(isEnumValue(Sample, "a")).toBe(true);
+    expect(isEnumValue(Sample, "b")).toBe(true);
+  });
+
+  it("returns false for a string that is not a member", () => {
+    expect(isEnumValue(Sample, "c")).toBe(false);
+  });
+
+  it("returns false for an enum key rather than its value", () => {
+    expect(isEnumValue(Sample, "A")).toBe(false);
+  });
+
+  it("returns false for non-string inputs (route param array, undefined, number)", () => {
+    expect(isEnumValue(Sample, ["a"])).toBe(false);
+    expect(isEnumValue(Sample, undefined)).toBe(false);
+    expect(isEnumValue(Sample, 1)).toBe(false);
+  });
+});

--- a/src/common/utils/typeGuards.ts
+++ b/src/common/utils/typeGuards.ts
@@ -1,0 +1,10 @@
+/**
+ * Narrows an unknown value to a member of a string enum.
+ *
+ * Use at trust boundaries (route params, external input) in place of an
+ * `as <Enum>` assertion: the membership check both validates and narrows,
+ * so the caller gets a real `Enum` type without laundering an untrusted value.
+ */
+export function isEnumValue<T extends Record<string, string>>(enumObj: T, value: unknown): value is T[keyof T] {
+  return typeof value === "string" && Object.values(enumObj).includes(value);
+}

--- a/src/modules/assets/components/ReceiveForm.vue
+++ b/src/modules/assets/components/ReceiveForm.vue
@@ -284,7 +284,8 @@ function destroyClient() {
 }
 
 function setHistory() {
-  const chains = getChainIds(tempRoute.value as RouteResponse);
+  if (!tempRoute.value) return;
+  const chains = getChainIds(tempRoute.value);
 
   const data = {
     id,
@@ -360,7 +361,7 @@ async function setCosmosNetwork() {
 
   const currencies = [];
   const promises = [];
-  const data = (skipRouteConfig as SkipRouteConfigType)?.transfers?.[network.value.key].currencies;
+  const data = skipRouteConfig?.transfers?.[network.value.key]?.currencies;
   for (const c of data ?? []) {
     if (c.visible && configStore.protocolFilter !== c.visible) continue;
 

--- a/src/modules/assets/components/SendForm.vue
+++ b/src/modules/assets/components/SendForm.vue
@@ -311,7 +311,8 @@ function destroyClient() {
 }
 
 function setHistory() {
-  const chains = getChainIds(tempRoute.value as RouteResponse);
+  if (!tempRoute.value) return;
+  const chains = getChainIds(tempRoute.value);
 
   const data = {
     id,
@@ -400,7 +401,7 @@ async function setCosmosNetwork() {
   disablePicker.value = true;
   const ntwrk = NETWORK_DATA;
   const currencies = [];
-  const data = (skipRouteConfig as SkipRouteConfigType)?.transfers?.[network.value.key].currencies;
+  const data = skipRouteConfig?.transfers?.[network.value.key]?.currencies;
   for (const c of data ?? []) {
     if (c.visible && configStore.protocolFilter !== c.visible) continue;
 

--- a/src/modules/assets/router.ts
+++ b/src/modules/assets/router.ts
@@ -1,6 +1,7 @@
 import type { RouteRecordRaw } from "vue-router";
 import { RouteNames } from "@/router/RouteNames";
 import { AssetsDialog } from "@/modules/assets/enums";
+import { isEnumValue } from "@/common/utils/typeGuards";
 
 export const AssetsRouter: RouteRecordRaw = {
   path: `/${RouteNames.ASSETS}`,
@@ -16,8 +17,7 @@ export const AssetsRouter: RouteRecordRaw = {
       path: ":tab",
       component: () => import("./components/TransferDialog.vue"),
       beforeEnter: (to, from, next) => {
-        const validTabs = Object.values(AssetsDialog);
-        if (validTabs.includes(to.params.tab as AssetsDialog)) {
+        if (isEnumValue(AssetsDialog, to.params.tab)) {
           next();
         } else {
           next({ path: "/" }); // Redirect to home if tab is not valid

--- a/src/modules/dashboard/router.ts
+++ b/src/modules/dashboard/router.ts
@@ -1,6 +1,7 @@
 import type { RouteRecordRaw } from "vue-router";
 import { RouteNames } from "@/router/RouteNames";
 import { AssetsDialog } from "../assets/enums";
+import { isEnumValue } from "@/common/utils/typeGuards";
 
 export const DashboardRouter: RouteRecordRaw = {
   path: "",
@@ -16,8 +17,7 @@ export const DashboardRouter: RouteRecordRaw = {
       path: ":tab",
       component: () => import("../assets/components/TransferDialog.vue"),
       beforeEnter: (to, from, next) => {
-        const validTabs = Object.values(AssetsDialog);
-        if (validTabs.includes(to.params.tab as AssetsDialog)) {
+        if (isEnumValue(AssetsDialog, to.params.tab)) {
           next();
         } else {
           next({ path: "/" }); // Redirect to home if tab is not valid

--- a/src/modules/earn/router.ts
+++ b/src/modules/earn/router.ts
@@ -1,6 +1,7 @@
 import type { RouteRecordRaw } from "vue-router";
 import { RouteNames } from "@/router/RouteNames";
 import { EarnAssetsDialog } from "./enums";
+import { isEnumValue } from "@/common/utils/typeGuards";
 
 export const EarnRouter: RouteRecordRaw = {
   path: `/${RouteNames.EARN}`,
@@ -11,8 +12,7 @@ export const EarnRouter: RouteRecordRaw = {
       path: ":tab",
       component: () => import("./components/EarnAssetsDialog.vue"),
       beforeEnter: (to, from, next) => {
-        const validTabs = Object.values(EarnAssetsDialog);
-        if (validTabs.includes(to.params.tab as EarnAssetsDialog)) {
+        if (isEnumValue(EarnAssetsDialog, to.params.tab)) {
           next();
         } else {
           next({ path: "/" }); // Redirect to home if tab is not valid

--- a/src/modules/history/types/ITransaction.ts
+++ b/src/modules/history/types/ITransaction.ts
@@ -43,6 +43,8 @@ export type HistoryData = {
     route?: SmallStepperProps;
     routeDetails?: MediumStepperProps;
     skipRoute?: IObjectKeys;
-    status: CONFIRM_STEP;
+    // Optional: ETL/history-loaded entries are created without a status (it stays
+    // undefined and renders as "completed"); the live pending-transfer flow sets it.
+    status?: CONFIRM_STEP;
   };
 };

--- a/src/modules/stake/router.ts
+++ b/src/modules/stake/router.ts
@@ -1,6 +1,7 @@
 import type { RouteRecordRaw } from "vue-router";
 import { RouteNames } from "@/router/RouteNames";
 import { StakeDialog } from "@/modules/stake/enums";
+import { isEnumValue } from "@/common/utils/typeGuards";
 
 export const StakeRouter: RouteRecordRaw = {
   path: `/${RouteNames.STAKE}`,
@@ -15,8 +16,7 @@ export const StakeRouter: RouteRecordRaw = {
         key: RouteNames.STAKE
       },
       beforeEnter: (to, from, next) => {
-        const validTabs = Object.values(StakeDialog);
-        if (validTabs.includes(to.params.tab as StakeDialog)) {
+        if (isEnumValue(StakeDialog, to.params.tab)) {
           next();
         } else {
           next({ path: "/" }); // Redirect to home if tab is not valid


### PR DESCRIPTION
## Summary

Replace boundary `as`-cast type assertions on money/wallet paths with Zod parses and runtime type guards, so untrusted HTTP/WebSocket payloads are validated before they reach financial logic. Resolves #177.

## Changes

- Router `:tab` params narrowed via a shared `isEnumValue` guard instead of `as <Dialog>` (4 routers).
- New WebSocket leases validated against `LeaseInfoSchema` (the same schema the REST path uses); malformed payloads are dropped, not crashed. Existing leases keep their partial-update merge.
- `/api/swap/config` parsed with a new `SkipRouteConfigSchema` instead of an unchecked cast.
- SkipRoute: removed redundant casts; added `assertRouteResponse` / `assertMessagesResponse` / `assertChainList` guards over the backend-proxied Skip responses, covering the fields the swap flow dereferences. The transfer forms consume the validated data and no longer re-cast, and a crash when a swap config lacks the active network key is fixed.
- History `TransactionEntry` is built via typed construction instead of `as unknown as`; `historyData.status` is made optional to match runtime reality.
- The Keplr amino-signer cast is documented as a known nolusjs third-party type gap (the one remaining justified `as`).

## Verification

- Ran `npm test` — 835 passed, including new guard / schema / WebSocket-discard unit tests.
- Ran `npx vue-tsc --noEmit -p tsconfig.app.json` — no code errors (only a pre-existing `baseUrl` deprecation).
- Ran `npm run lint` and `prettier --check src` — clean.
- Ran `npm run build` — production build succeeds.
- Two independent reviews (general correctness + security-focused) were run against the diff; their findings were addressed in-branch: widened guard field coverage to every field the swap flow dereferences, stopped logging full payloads (wallet/amount values), and documented the schema casts.

## Follow-ups

- #216 — `ExternalCurrency.balance` type mismatch (carved out: a field-type refactor across consumers, not a cast swap).
- #217 — strictly type and validate Skip responses in the Rust backend at ingress, the primary hardening point; the frontend guards here are defense-in-depth.

A deliberate decision: the WebSocket merge-into-existing path keeps accepting partial updates (its tested contract); only brand-new leases are fully validated.
