### PR TITLE
fix(types): align ExternalCurrency.balance with its runtime shape

### DIFF
--- a/src/common/stores/balances/index.ts
+++ b/src/common/stores/balances/index.ts
@@ -92,13 +92,13 @@ export const useBalancesStore = defineStore("balances", () => {
         continue;
       }
 
-      const entry = {
+      const entry: ExternalCurrency = {
         ...currency,
         balance: {
           denom: balance.denom,
           amount: balance.amount
         }
-      } as ExternalCurrency;
+      };
 
       const existingIndex = seenTickers.get(ticker);
       if (existingIndex !== undefined) {

--- a/src/common/stores/wallet/types/state.ts
+++ b/src/common/stores/wallet/types/state.ts
@@ -1,4 +1,24 @@
 import type { NolusWallet } from "@nolus/nolusjs";
+import type { CoinBalance } from "@/common/types/Currencies";
+
+/**
+ * A currency entry for a non-native (cross-chain) network, sourced from the
+ * Skip transfer config and hydrated with the user's on-chain balance. Mirrors
+ * an `ExternalCurrency` but carries the source denom as `from` (instead of
+ * `ibcData`); the asset forms treat the two as an `ExternalCurrency | AssetBalance`
+ * union and narrow on whichever denom field is present.
+ */
+export type AssetBalance = {
+  balance?: CoinBalance;
+  name: string;
+  shortName: string;
+  symbol: string;
+  ticker: string;
+  icon: string;
+  decimal_digits: number;
+  native: boolean;
+  from: string;
+};
 
 export type State = {
   wallet?: NolusWallet;

--- a/src/common/types/Currencies.ts
+++ b/src/common/types/Currencies.ts
@@ -1,4 +1,7 @@
-import type { Coin as UnitCoin } from "@keplr-wallet/unit";
+export interface CoinBalance {
+  denom: string;
+  amount: string;
+}
 
 export interface ExternalCurrency {
   name: string;
@@ -11,7 +14,7 @@ export interface ExternalCurrency {
   ibcData: string;
   icon: string;
   coingeckoId: string | null;
-  balance?: UnitCoin;
+  balance?: CoinBalance;
 }
 
 export interface ExternalCurrencies {

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -2,7 +2,7 @@ export type { NetworkAddress } from "@/common/types/NetworkAddress";
 export type { Networks } from "@/common/types/Networks";
 export type { Network, NetworkData } from "@/common/types/Network";
 export type { IObjectKeys } from "@/common/types/IObjectKeys";
-export type { ExternalCurrencies, ExternalCurrency } from "@/common/types/Currencies";
+export type { CoinBalance, ExternalCurrencies, ExternalCurrency } from "@/common/types/Currencies";
 export type { NetworkConfig, API, ARCHIVE_NODE, Endpoint, Node, Status } from "@/common/types/NetworkConfig";
 export type { SkipRouteConfigType } from "./SkipRouteConfigType";
 export type { ProposalsConfigType } from "./ProposalsConfigType";

--- a/src/modules/leases/components/single-lease/useCloseLease.ts
+++ b/src/modules/leases/components/single-lease/useCloseLease.ts
@@ -20,9 +20,7 @@ import {
 } from "@/common/utils/NumberFormatUtils";
 import { getLpnByProtocol } from "@/common/utils/CurrencyLookup";
 import { NATIVE_CURRENCY } from "../../../../config/global/network";
-import type { ExternalCurrency } from "@/common/types";
 import { MAX_DECIMALS, minimumLeaseAmount, PERCENT } from "@/config/global";
-import type { AssetBalance } from "@/common/stores/wallet/types";
 import { CoinPretty, Dec, Int } from "@keplr-wallet/unit";
 import type { NolusWallet } from "@nolus/nolusjs";
 import { CurrencyUtils, NolusClient } from "@nolus/nolusjs";
@@ -116,7 +114,7 @@ export function useCloseLease() {
         return data;
       }
 
-      const denom = (asset as ExternalCurrency).ibcData ?? (asset as AssetBalance).from;
+      const denom = asset.ibcData;
 
       data.push({
         name: asset.name,


### PR DESCRIPTION
## Summary

Closes #216. `ExternalCurrency.balance` was typed `Coin` from `@keplr-wallet/unit` (whose `amount` is an `Int`), but every producer populates it with a plain `{ denom: string; amount: string }` — the balances store, and cosmjs `coin()` / `client.getBalance()` in the asset forms. The gap was laundered by an `as ExternalCurrency` cast that the compiler flagged as a non-overlapping conversion.

## Changes

- Introduce a named `CoinBalance { denom: string; amount: string }` type and retype `ExternalCurrency.balance` to it; export it from the types barrel.
- Drop the `as ExternalCurrency` cast in the balances store — the entry now matches the field type.
- Define the `AssetBalance` type that `wallet/types` re-exported but never declared (it resolved to a type error and silently masked shapes in the asset/lease forms).
- Simplify the unreachable `?? (asset as AssetBalance).from` fallback in `useCloseLease.ts`, where the value is always a `CurrencyInfo` with a non-nullable `ibcData`.

This is a type-level change: every consumer already wraps the amount in a fresh `Int`/`Dec` or calls `.toString()` (both accept strings), so runtime behaviour is unchanged.

## Verification

- Ran `tsc --build` before and after: net −2 pre-existing type errors, 0 introduced (verified by a line-normalized before/after comparison of the full error set).
- Ran `eslint src` and `prettier --check src` — clean.
- Ran `vitest run` — 835/835 pass; `vite build` succeeds; coverage floors hold.
- Independent review against the bug checklist confirmed the `useCloseLease.ts` simplification is behaviour-identical and no consumer relies on an `Int`-typed amount.