### PR TITLE
refactor(backend): validate Skip route/messages responses at ingress

### DIFF
--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -3351,13 +3351,13 @@
         ],
         "responses": {
           "200": {
-            "description": "Opaque Skip API passthrough (list of chains)",
+            "description": "Supported swap chains",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object"
+                    "$ref": "#/components/schemas/SkipChain"
                   }
                 }
               }
@@ -3414,7 +3414,7 @@
           "swap"
         ],
         "summary": "Get Skip swap messages",
-        "description": "Enriches the slim request with slippage, timeout, and affiliates from\ngated config, then forwards to Skip API. Response is an opaque Skip API\npassthrough — shape is not fixed in this spec.",
+        "description": "Enriches the slim request with slippage, timeout, and affiliates from\ngated config, then forwards to Skip API. The upstream response is validated\nagainst `SkipMessagesResponse` at ingress — down to the cosmos message\nenvelope the frontend broadcasts — so a malformed payload is rejected rather\nthan forwarded. Bridge-specific and extra fields are preserved verbatim.",
         "operationId": "get_messages",
         "requestBody": {
           "content": {
@@ -3428,17 +3428,17 @@
         },
         "responses": {
           "200": {
-            "description": "Opaque Skip API passthrough",
+            "description": "Validated Skip messages response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/SkipMessagesResponse"
                 }
               }
             }
           },
           "502": {
-            "description": "Skip API call failed",
+            "description": "Skip API call failed or returned malformed messages",
             "content": {
               "application/json": {
                 "schema": {
@@ -3466,7 +3466,7 @@
           "swap"
         ],
         "summary": "Get Skip swap route",
-        "description": "Enriches the slim request with gated swap config (affiliates, venues,\nbridges) and forwards to Skip API. Response is an opaque Skip API\npassthrough — shape is not fixed in this spec.",
+        "description": "Enriches the slim request with gated swap config (affiliates, venues,\nbridges) and forwards to Skip API. The upstream response is validated\nagainst `SkipRouteResponse` at ingress — a malformed payload is rejected\nrather than forwarded onto the money path. Fields beyond the typed envelope\n(and the opaque `operations` blob) are preserved verbatim.",
         "operationId": "get_route",
         "requestBody": {
           "content": {
@@ -3480,17 +3480,17 @@
         },
         "responses": {
           "200": {
-            "description": "Opaque Skip API passthrough",
+            "description": "Validated Skip route response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/SkipRouteResponse"
                 }
               }
             }
           },
           "502": {
-            "description": "Skip API call failed",
+            "description": "Skip API call failed or returned a malformed route",
             "content": {
               "application/json": {
                 "schema": {
@@ -7132,6 +7132,210 @@
             ]
           }
         }
+      },
+      "SkipChain": {
+        "type": "object",
+        "required": [
+          "chain_name",
+          "chain_id",
+          "chain_type"
+        ],
+        "properties": {
+          "chain_name": {
+            "type": "string"
+          },
+          "chain_id": {
+            "type": "string"
+          },
+          "chain_type": {
+            "type": "string"
+          },
+          "pfm_enabled": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "cosmos_module_support": {},
+          "supports_memo": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "logo_uri": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bech32_prefix": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "fee_assets": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {}
+          },
+          "is_testnet": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      "SkipCosmosTx": {
+        "allOf": [
+          {
+            "type": "object"
+          },
+          {
+            "type": "object",
+            "required": [
+              "chain_id",
+              "msgs"
+            ],
+            "properties": {
+              "chain_id": {
+                "type": "string"
+              },
+              "msgs": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SkipMsg"
+                }
+              }
+            }
+          }
+        ],
+        "description": "The cosmos transaction envelope the frontend signs and broadcasts."
+      },
+      "SkipMessagesResponse": {
+        "allOf": [
+          {
+            "type": "object"
+          },
+          {
+            "type": "object",
+            "required": [
+              "txs"
+            ],
+            "properties": {
+              "txs": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SkipTx"
+                }
+              }
+            }
+          }
+        ],
+        "description": "Skip `/v2/fungible/msgs` response.\n\n`txs` is validated down to the cosmos message envelope the frontend signs\nand broadcasts; bridge-specific entries (`evm_tx`, `operations_indices`, …)\nand any other top-level keys are preserved through `additional`."
+      },
+      "SkipMsg": {
+        "allOf": [
+          {
+            "type": "object"
+          },
+          {
+            "type": "object",
+            "required": [
+              "msg",
+              "msg_type_url"
+            ],
+            "properties": {
+              "msg": {
+                "type": "string"
+              },
+              "msg_type_url": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "description": "A single cosmos message: the type URL the frontend dispatches on and its\nencoded body."
+      },
+      "SkipRouteResponse": {
+        "allOf": [
+          {
+            "type": "object"
+          },
+          {
+            "type": "object",
+            "required": [
+              "amount_in",
+              "amount_out",
+              "source_asset_denom",
+              "source_asset_chain_id",
+              "dest_asset_denom",
+              "dest_asset_chain_id",
+              "chain_ids",
+              "operations"
+            ],
+            "properties": {
+              "amount_in": {
+                "type": "string"
+              },
+              "amount_out": {
+                "type": "string"
+              },
+              "source_asset_denom": {
+                "type": "string"
+              },
+              "source_asset_chain_id": {
+                "type": "string"
+              },
+              "dest_asset_denom": {
+                "type": "string"
+              },
+              "dest_asset_chain_id": {
+                "type": "string"
+              },
+              "chain_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "operations": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        ],
+        "description": "Skip `/v2/fungible/route` response.\n\nOnly the fields the swap flow consumes are typed and required; every other\nfield Skip returns (price impact, estimated fees, USD amounts, route\nduration, …) is preserved verbatim through `additional` so the frontend\nkeeps its display data. `operations` stays opaque and is echoed back to\n`/v2/fungible/msgs` unchanged, so it must round-trip byte-for-byte."
+      },
+      "SkipTx": {
+        "allOf": [
+          {
+            "type": "object"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "cosmos_tx": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SkipCosmosTx"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "description": "One transaction in a Skip messages response. A cosmos transaction is typed;\nother transaction kinds (e.g. `evm_tx`) and extra fields ride in `additional`."
       },
       "StakingParams": {
         "type": "object",

--- a/backend/src/external/skip.rs
+++ b/backend/src/external/skip.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::error::AppError;
 use crate::external::base_client::ExternalApiClient;
@@ -152,7 +153,7 @@ pub struct SkipChainsResponse {
     pub chains: Vec<SkipChain>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct SkipChain {
     pub chain_name: String,
     pub chain_id: String,
@@ -171,6 +172,74 @@ pub struct SkipTrackResponse {
     pub tx_hash: String,
     #[serde(default)]
     pub explorer_link: Option<String>,
+}
+
+/// Skip `/v2/fungible/route` response.
+///
+/// Only the fields the swap flow consumes are typed and required; every other
+/// field Skip returns (price impact, estimated fees, USD amounts, route
+/// duration, …) is preserved verbatim through `additional` so the frontend
+/// keeps its display data. `operations` stays opaque and is echoed back to
+/// `/v2/fungible/msgs` unchanged, so it must round-trip byte-for-byte.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SkipRouteResponse {
+    pub amount_in: String,
+    pub amount_out: String,
+    pub source_asset_denom: String,
+    pub source_asset_chain_id: String,
+    pub dest_asset_denom: String,
+    pub dest_asset_chain_id: String,
+    pub chain_ids: Vec<String>,
+    #[schema(value_type = Vec<Object>)]
+    pub operations: Vec<serde_json::Value>,
+    #[serde(flatten)]
+    #[schema(value_type = Object)]
+    pub additional: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Skip `/v2/fungible/msgs` response.
+///
+/// `txs` is validated down to the cosmos message envelope the frontend signs
+/// and broadcasts; bridge-specific entries (`evm_tx`, `operations_indices`, …)
+/// and any other top-level keys are preserved through `additional`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SkipMessagesResponse {
+    pub txs: Vec<SkipTx>,
+    #[serde(flatten)]
+    #[schema(value_type = Object)]
+    pub additional: serde_json::Map<String, serde_json::Value>,
+}
+
+/// One transaction in a Skip messages response. A cosmos transaction is typed;
+/// other transaction kinds (e.g. `evm_tx`) and extra fields ride in `additional`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SkipTx {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cosmos_tx: Option<SkipCosmosTx>,
+    #[serde(flatten)]
+    #[schema(value_type = Object)]
+    pub additional: serde_json::Map<String, serde_json::Value>,
+}
+
+/// The cosmos transaction envelope the frontend signs and broadcasts.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SkipCosmosTx {
+    pub chain_id: String,
+    pub msgs: Vec<SkipMsg>,
+    #[serde(flatten)]
+    #[schema(value_type = Object)]
+    pub additional: serde_json::Map<String, serde_json::Value>,
+}
+
+/// A single cosmos message: the type URL the frontend dispatches on and its
+/// encoded body.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SkipMsg {
+    pub msg: String,
+    pub msg_type_url: String,
+    #[serde(flatten)]
+    #[schema(value_type = Object)]
+    pub additional: serde_json::Map<String, serde_json::Value>,
 }
 
 #[cfg(test)]
@@ -433,5 +502,104 @@ mod tests {
         let client = test_client(&server.uri(), None);
         let err = client.get_status("h", "c").await.unwrap_err();
         assert_skip_error(&err);
+    }
+
+    // ---- 107: route response validates envelope, keeps operations + extras ----
+
+    #[test]
+    fn skip_route_response_parses_and_preserves_unconsumed_fields() {
+        let raw = serde_json::json!({
+            "amount_in": "1000",
+            "amount_out": "990",
+            "source_asset_denom": "uatom",
+            "source_asset_chain_id": "cosmoshub-4",
+            "dest_asset_denom": "uosmo",
+            "dest_asset_chain_id": "osmosis-1",
+            "chain_ids": ["cosmoshub-4", "osmosis-1"],
+            "operations": [{ "transfer": { "port": "transfer", "channel": "channel-0" } }],
+            "does_swap": true,
+            "estimated_amount_out": "990",
+            "usd_amount_in": "10.00"
+        });
+
+        let parsed: SkipRouteResponse =
+            serde_json::from_value(raw.clone()).expect("valid route response deserializes");
+
+        assert_eq!(parsed.amount_in, "1000");
+        assert_eq!(parsed.chain_ids, ["cosmoshub-4", "osmosis-1"]);
+        // operations is opaque and echoed back to /msgs — it must round-trip verbatim.
+        assert_eq!(
+            parsed.operations,
+            raw["operations"].as_array().cloned().unwrap()
+        );
+        // Unconsumed display fields survive in `additional`, not dropped.
+        assert_eq!(
+            parsed.additional.get("does_swap"),
+            Some(&serde_json::json!(true))
+        );
+        // Re-serialization is shape-equal to the upstream payload (no field loss).
+        assert_eq!(serde_json::to_value(&parsed).expect("re-serializes"), raw);
+    }
+
+    #[test]
+    fn skip_route_response_rejects_missing_required_field() {
+        // `amount_in` omitted — a partial route must not reach the money path.
+        let raw = serde_json::json!({
+            "amount_out": "990",
+            "source_asset_denom": "uatom",
+            "source_asset_chain_id": "cosmoshub-4",
+            "dest_asset_denom": "uosmo",
+            "dest_asset_chain_id": "osmosis-1",
+            "chain_ids": ["osmosis-1"],
+            "operations": []
+        });
+        let err = serde_json::from_value::<SkipRouteResponse>(raw).unwrap_err();
+        assert!(err.to_string().contains("amount_in"), "err: {err}");
+    }
+
+    // ---- 108: messages response validates cosmos msgs, preserves other tx kinds ----
+
+    #[test]
+    fn skip_messages_response_validates_cosmos_msgs_and_preserves_evm() {
+        let raw = serde_json::json!({
+            "txs": [
+                {
+                    "cosmos_tx": {
+                        "chain_id": "osmosis-1",
+                        "msgs": [{ "msg": "{}", "msg_type_url": "/ibc.applications.transfer.v1.MsgTransfer" }],
+                        "signer_address": "osmo1abc"
+                    },
+                    "operations_indices": [0]
+                },
+                { "evm_tx": { "chain_id": "1", "to": "0xabc", "data": "0x" } }
+            ]
+        });
+
+        let parsed: SkipMessagesResponse =
+            serde_json::from_value(raw.clone()).expect("valid messages response deserializes");
+
+        let cosmos = parsed.txs[0]
+            .cosmos_tx
+            .as_ref()
+            .expect("first tx carries a cosmos_tx");
+        assert_eq!(cosmos.chain_id, "osmosis-1");
+        assert_eq!(
+            cosmos.msgs[0].msg_type_url,
+            "/ibc.applications.transfer.v1.MsgTransfer"
+        );
+        // The evm-only tx has no cosmos_tx but is preserved verbatim via `additional`.
+        assert!(parsed.txs[1].cosmos_tx.is_none());
+        assert!(parsed.txs[1].additional.contains_key("evm_tx"));
+        assert_eq!(serde_json::to_value(&parsed).expect("re-serializes"), raw);
+    }
+
+    #[test]
+    fn skip_messages_response_rejects_cosmos_tx_missing_msg_type_url() {
+        // A cosmos message without its type URL cannot be dispatched — reject it.
+        let raw = serde_json::json!({
+            "txs": [{ "cosmos_tx": { "chain_id": "osmosis-1", "msgs": [{ "msg": "{}" }] } }]
+        });
+        let err = serde_json::from_value::<SkipMessagesResponse>(raw).unwrap_err();
+        assert!(err.to_string().contains("msg_type_url"), "err: {err}");
     }
 }

--- a/backend/src/handlers/openapi.rs
+++ b/backend/src/handlers/openapi.rs
@@ -275,11 +275,18 @@ use crate::handlers::{
         gated_networks::NetworksResponse,
         gated_networks::PoolResponse,
         gated_networks::NetworkPoolsResponse,
-        // Swap typed bodies (responses remain opaque)
+        // Swap typed bodies
         swap::RouteRequest,
         swap::MessagesRequest,
         swap::TrackRequest,
         swap::TrackResponse,
+        // Skip ingress responses validated at the boundary
+        external::skip::SkipRouteResponse,
+        external::skip::SkipMessagesResponse,
+        external::skip::SkipTx,
+        external::skip::SkipCosmosTx,
+        external::skip::SkipMsg,
+        external::skip::SkipChain,
         // ETL batch passthroughs (fields opaque)
         etl_proxy::StatsOverviewBatch,
         etl_proxy::LoansStatsBatch,

--- a/backend/src/handlers/swap.rs
+++ b/backend/src/handlers/swap.rs
@@ -19,7 +19,7 @@ use utoipa::ToSchema;
 
 use crate::error::AppError;
 use crate::external::base_client::ExternalApiClient;
-use crate::external::skip::SkipChain;
+use crate::external::skip::{SkipChain, SkipMessagesResponse, SkipRouteResponse};
 use crate::AppState;
 
 // ============================================================================
@@ -42,23 +42,25 @@ pub struct RouteRequest {
 /// Get Skip swap route
 ///
 /// Enriches the slim request with gated swap config (affiliates, venues,
-/// bridges) and forwards to Skip API. Response is an opaque Skip API
-/// passthrough — shape is not fixed in this spec.
+/// bridges) and forwards to Skip API. The upstream response is validated
+/// against `SkipRouteResponse` at ingress — a malformed payload is rejected
+/// rather than forwarded onto the money path. Fields beyond the typed envelope
+/// (and the opaque `operations` blob) are preserved verbatim.
 #[utoipa::path(
     post,
     path = "/api/swap/route",
     tag = "swap",
     request_body = RouteRequest,
     responses(
-        (status = 200, description = "Opaque Skip API passthrough", content_type = "application/json", body = Object),
+        (status = 200, description = "Validated Skip route response", body = SkipRouteResponse),
         (status = 503, description = "Gated config not yet populated", body = crate::error::ErrorResponse),
-        (status = 502, description = "Skip API call failed", body = crate::error::ErrorResponse),
+        (status = 502, description = "Skip API call failed or returned a malformed route", body = crate::error::ErrorResponse),
     ),
 )]
 pub async fn get_route(
     State(state): State<Arc<AppState>>,
     Json(request): Json<RouteRequest>,
-) -> Result<Json<serde_json::Value>, AppError> {
+) -> Result<Json<SkipRouteResponse>, AppError> {
     debug!(
         "Getting swap route: {} -> {}",
         request.source_asset_denom, request.dest_asset_denom
@@ -117,7 +119,7 @@ pub async fn get_route(
     }
 
     let url = format!("{}/v2/fungible/route", state.skip_client.base_url());
-    let response =
+    let raw =
         state
             .skip_client
             .post_raw(&url, &body)
@@ -125,6 +127,10 @@ pub async fn get_route(
             .map_err(|e| AppError::SwapRouteFailed {
                 message: e.to_string(),
             })?;
+    let response: SkipRouteResponse =
+        serde_json::from_value(raw).map_err(|e| AppError::SwapRouteFailed {
+            message: format!("Malformed Skip route response: {e}"),
+        })?;
     Ok(Json(response))
 }
 
@@ -149,23 +155,25 @@ pub struct MessagesRequest {
 /// Get Skip swap messages
 ///
 /// Enriches the slim request with slippage, timeout, and affiliates from
-/// gated config, then forwards to Skip API. Response is an opaque Skip API
-/// passthrough — shape is not fixed in this spec.
+/// gated config, then forwards to Skip API. The upstream response is validated
+/// against `SkipMessagesResponse` at ingress — down to the cosmos message
+/// envelope the frontend broadcasts — so a malformed payload is rejected rather
+/// than forwarded. Bridge-specific and extra fields are preserved verbatim.
 #[utoipa::path(
     post,
     path = "/api/swap/messages",
     tag = "swap",
     request_body = MessagesRequest,
     responses(
-        (status = 200, description = "Opaque Skip API passthrough", content_type = "application/json", body = Object),
+        (status = 200, description = "Validated Skip messages response", body = SkipMessagesResponse),
         (status = 503, description = "Gated config not yet populated", body = crate::error::ErrorResponse),
-        (status = 502, description = "Skip API call failed", body = crate::error::ErrorResponse),
+        (status = 502, description = "Skip API call failed or returned malformed messages", body = crate::error::ErrorResponse),
     ),
 )]
 pub async fn get_messages(
     State(state): State<Arc<AppState>>,
     Json(request): Json<MessagesRequest>,
-) -> Result<Json<serde_json::Value>, AppError> {
+) -> Result<Json<SkipMessagesResponse>, AppError> {
     debug!(
         "Getting swap messages: {} -> {}",
         request.source_asset_denom, request.dest_asset_denom
@@ -225,7 +233,12 @@ pub async fn get_messages(
     });
 
     let url = format!("{}/v2/fungible/msgs", state.skip_client.base_url());
-    let response = state.skip_client.post_raw(&url, &body).await?;
+    let raw = state.skip_client.post_raw(&url, &body).await?;
+    let response: SkipMessagesResponse =
+        serde_json::from_value(raw).map_err(|e| AppError::ExternalApi {
+            api: "Skip".to_string(),
+            message: format!("Malformed Skip messages response: {e}"),
+        })?;
     Ok(Json(response))
 }
 
@@ -299,7 +312,7 @@ fn default_true() -> bool {
     tag = "swap",
     params(ChainsQuery),
     responses(
-        (status = 200, description = "Opaque Skip API passthrough (list of chains)", content_type = "application/json", body = Vec<Object>),
+        (status = 200, description = "Supported swap chains", body = Vec<SkipChain>),
         (status = 502, description = "Skip API call failed", body = crate::error::ErrorResponse),
     ),
 )]


### PR DESCRIPTION
## Summary

Closes #217. The route and messages handlers forwarded Skip's responses as untyped `serde_json::Value`, so malformed third-party data reached the cross-chain swap money path unchecked and the frontend had to re-validate shapes it could not trust. Parse both at ingress into strict structs, scoped to the fields the app actually consumes.

## Changes

- Add strict `SkipRouteResponse` / `SkipMessagesResponse` (+ `SkipTx` / `SkipCosmosTx` / `SkipMsg`) structs: consumed envelope fields are required, so a missing field is rejected as a 502 rather than forwarded.
- Keep `operations` opaque (`Vec<serde_json::Value>`) — it is echoed back verbatim to `/v2/fungible/msgs`, so it must round-trip byte-for-byte; a typed enum would risk dropping or reordering fields. Every non-consumed field is preserved via `serde(flatten)`, so display data (estimated fees, price impact, `evm_tx`, …) is not lost.
- Register the typed schemas, tighten the chains response body to `Vec<SkipChain>`, and regenerate the OpenAPI snapshot.

Status and `swap_config` are intentionally out of scope — status has a backend/frontend/upstream `transfer_sequence` shape disagreement to reconcile first (#219), and `swap_config` is assembled by the backend rather than received from Skip, so it is not ingress data (#220).

## Verification

- Ran `cargo fmt --check`, `cargo clippy` with the CI lint flags (`-D warnings`), and the full `cargo test` suite — 474/474 pass, including the OpenAPI snapshot drift guard and 4 new tests (valid parse + extras preserved, `operations` round-trip, missing-required rejection, cosmos-msg validation, evm-tx preservation).
- Reviewed for correctness and for money-path/parsing security: confirmed the `operations` round-trip is faithful and unchanged from the prior `Value` passthrough, the parse fails closed, and there is no new panic, DoS, or secret-disclosure surface.

## Follow-ups

- #219 — strictly type the Skip status response (after reconciling `transfer_sequence`)
- #220 — strictly type the backend-assembled `swap_config`