### PR TITLE
test(backend): fake the clock in time-dependent tests

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -78,6 +78,9 @@ utoipa = { version = "5", features = ["axum_extras", "chrono", "preserve_order"]
 futures = "0.3"
 http-body-util = "0.1"
 tempfile = "3.10"
+# `test-util` (clock pause/advance) is excluded from tokio's `full` feature;
+# enable it for tests only so it never reaches the release binary.
+tokio = { version = "1", features = ["test-util"] }
 wiremock = "0.6"
 
 [profile.release]

--- a/backend/src/data_cache.rs
+++ b/backend/src/data_cache.rs
@@ -359,9 +359,17 @@ mod tests {
 
     #[tokio::test]
     async fn cached_age_secs_returns_elapsed() {
+        // `age_secs` derives from `std::time::Instant::elapsed`, which a tokio
+        // paused clock cannot drive. Stamp a backdated `updated_at` directly so
+        // the elapsed assertion is deterministic and instant — no wall-clock wait.
         let cache: Cached<TestVal> = Cached::new();
-        cache.store(TestVal::new(42, "aged"));
-        tokio::time::sleep(Duration::from_millis(1_100)).await;
+        let aged_at = Instant::now()
+            .checked_sub(Duration::from_secs(2))
+            .expect("test host monotonic clock is at least 2s past its epoch");
+        cache.inner.store(Arc::new(CachedInner {
+            value: Some(TestVal::new(42, "aged")),
+            updated_at: Some(aged_at),
+        }));
         let age = cache.age_secs().expect("age_secs must be Some after store");
         assert!(age >= 1, "expected age >= 1, got {}", age);
     }

--- a/backend/src/middleware/rate_limit.rs
+++ b/backend/src/middleware/rate_limit.rs
@@ -152,7 +152,13 @@ impl RateLimitState {
 
     /// Remove entries that haven't been accessed within `max_age`
     pub async fn cleanup_stale(&self, max_age: Duration) {
-        let now = epoch().elapsed();
+        self.cleanup_stale_at(epoch().elapsed(), max_age).await;
+    }
+
+    /// Eviction core taking an explicit `now` (elapsed since the process epoch).
+    /// `cleanup_stale` supplies `epoch().elapsed()`; splitting it out lets tests
+    /// drive entry ages deterministically without waiting on the wall clock.
+    async fn cleanup_stale_at(&self, now: Duration, max_age: Duration) {
         let max_age_ms = u64::try_from(max_age.as_millis()).unwrap_or(u64::MAX);
         let mut limiters = self.limiters.write().await;
         let before = limiters.len();
@@ -466,15 +472,30 @@ mod tests {
         state.cleanup_stale(Duration::ZERO).await;
         assert_eq!(state.limiters.read().await.len(), 0);
 
-        // Re-create ip2 only, then touch ip1 so it's fresh
+        // Re-create both entries, then stamp their ages directly and drive
+        // eviction through the injectable `now` seam — deterministic and
+        // instant, with no real wall-clock wait.
         state.check_rate_limit(ip1).await;
-        // Small sleep so ip1 ages a tiny bit, then add ip2 which is newer
-        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
         state.check_rate_limit(ip2).await;
+        {
+            let limiters = state.limiters.read().await;
+            limiters
+                .get(&ip1)
+                .expect("ip1 entry exists after check_rate_limit")
+                .last_access_ms
+                .store(0, Ordering::Relaxed);
+            limiters
+                .get(&ip2)
+                .expect("ip2 entry exists after check_rate_limit")
+                .last_access_ms
+                .store(100, Ordering::Relaxed);
+        }
         assert_eq!(state.limiters.read().await.len(), 2);
 
-        // Cleanup with 10ms max age — ip1 (>20ms old) should be evicted, ip2 (fresh) kept
-        state.cleanup_stale(Duration::from_millis(10)).await;
+        // now=105ms, max_age=10ms: ip1 (105ms old) evicted, ip2 (5ms old) kept.
+        state
+            .cleanup_stale_at(Duration::from_millis(105), Duration::from_millis(10))
+            .await;
 
         let limiters = state.limiters.read().await;
         assert_eq!(limiters.len(), 1);

--- a/backend/src/refresh.rs
+++ b/backend/src/refresh.rs
@@ -2893,13 +2893,14 @@ mod tests {
         assert!(!state.data_cache.staking_pool.is_populated());
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn start_all_spawns_tasks_without_panic() {
         let state = crate::test_utils::test_app_state().await;
         let event_channels = crate::chain_events::EventChannels::new();
         start_all(state.clone(), &event_channels);
-        // Give the spawned tasks a chance to register with the runtime.
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // Drive the paused clock so the spawned tasks are polled and reach their
+        // first await — deterministic and instant, no real wall-clock wait.
+        tokio::time::advance(std::time::Duration::from_millis(100)).await;
         // Dropping `state` here (via scope end) is implicit — if any spawned
         // task held a problematic strong ref, clippy/miri would catch it in CI.
     }


### PR DESCRIPTION
## Summary
Replace real `tokio::time::sleep` in three backend tests with deterministic, instant time control, removing ~1.2s of wall-clock wait and load-dependent flake from every CI run. Resolves #176.

## Changes
- **data_cache** — `cached_age_secs_returns_elapsed` stamps a backdated `updated_at` directly. Its age derives from `std::time::Instant`, which a tokio paused clock cannot drive, so a backdated absolute instant is the deterministic equivalent.
- **rate_limit** — extract a behavior-preserving `cleanup_stale_at(now, max_age)` seam; `cleanup_stale` now calls it with `epoch().elapsed()`. The test stamps entry timestamps and passes an explicit `now`, deciding eviction without a real wait. (A pure timestamp trick is impossible here: `cleanup_stale` reads its own `now` from a `std::Instant` process epoch that is ~0 in a unit test, so no stored timestamp can be made "older than" the threshold.)
- **refresh** — run `start_all_spawns_tasks_without_panic` under `#[tokio::test(start_paused = true)]` + `tokio::time::advance`.
- Enable tokio `test-util` in dev-dependencies for clock pause/advance — dev-only, never reaches the release binary.

## Verification
- Ran `cargo fmt --check`, `cargo clippy --all-targets --all-features` with the CI lint allowances (clean), `bash scripts/style-check.sh` (passed), `cargo build --all-targets`, `cargo test --all-targets` — 474 passed, 0 failed.
- Confirmed the three converted tests complete instantly (0.00s) with no real-time wait.
- Mutation-checked both logic tests: zeroing the age computation and inverting the eviction comparison each make the corresponding test fail, confirming they still catch real regressions (not tautologies).
- Confirmed `cleanup_stale_at` is a pure extraction (same `now` source, same comparison) — production behavior unchanged. `Cargo.lock` unchanged (no dependency drift).
- A fresh-context review of the diff against the merge base passed the full bug checklist.