### PR TITLE
test: replace hand-rolled setTimeout waits with flushPromises

### DIFF
--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -97,6 +97,22 @@ jobs:
           fi
           echo "OK — no vi.hoisted + restoreAllMocks() combination."
 
+      - name: Test hygiene guard — no arbitrary setTimeout waits in tests
+        run: |
+          set -e
+          # Policy: tests must not wait on a real-clock setTimeout. The microtask-flush
+          # idiom `await new Promise(r => setTimeout(r, 0))` belongs as flushPromises();
+          # genuine time-dependent behavior uses vi.useFakeTimers() + advanceTimersByTime.
+          # Catches the zero/single-digit (,0) / (,5)) forms as well as multi-digit delays.
+          if grep -rnE --include='*.test.ts' --include='*.spec.ts' \
+                  'setTimeout\([^,]*,[[:space:]]*[0-9]+\)' src; then
+            echo "FAIL: a test schedules a real-clock setTimeout wait."
+            echo "      Use flushPromises() for microtask flushes, or vi.useFakeTimers()"
+            echo "      + vi.advanceTimersByTimeAsync() for time-dependent behavior."
+            exit 1
+          fi
+          echo "OK — no arbitrary setTimeout waits in tests."
+
       - name: Validate .well-known JSON files in dist/
         run: |
           set -e

--- a/src/common/stores/config/index.test.ts
+++ b/src/common/stores/config/index.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/common/api", () => ({
 
 import { BackendApi } from "@/common/api";
 import { useConfigStore } from "./index";
+import { flushPromises } from "@vue/test-utils";
 
 // Minimal typed-any accessor to the mocked BackendApi members.
 // Using `as any` is acceptable in test code to access vi.fn() helpers.
@@ -561,9 +562,9 @@ describe("ConfigStore", () => {
 
       store.setProtocolFilter("SOLANA");
       // Let the watcher run + the rejected promise settle.
-      await new Promise((r) => setTimeout(r, 0));
-      await new Promise((r) => setTimeout(r, 0));
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
+      await flushPromises();
+      await flushPromises();
 
       const callsAfterFirstFail = api.getNetworkAssets.mock.calls.filter((c) => c[0] === "SOLANA").length;
       expect(callsAfterFirstFail).toBe(1);
@@ -571,10 +572,10 @@ describe("ConfigStore", () => {
       // Bounce away and back. The watcher must not re-fetch SOLANA — it has
       // been recorded as failed.
       store.setProtocolFilter("OSMOSIS");
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
       store.setProtocolFilter("SOLANA");
-      await new Promise((r) => setTimeout(r, 0));
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
+      await flushPromises();
 
       const callsAfterBounce = api.getNetworkAssets.mock.calls.filter((c) => c[0] === "SOLANA").length;
       expect(callsAfterBounce).toBe(1);
@@ -591,9 +592,9 @@ describe("ConfigStore", () => {
       api.getNetworkAssets.mockRejectedValueOnce(cause);
 
       store.setProtocolFilter("SOLANA");
-      await new Promise((r) => setTimeout(r, 0));
-      await new Promise((r) => setTimeout(r, 0));
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
+      await flushPromises();
+      await flushPromises();
 
       expect(consoleErr).toHaveBeenCalled();
       // At least one call must mention SOLANA and carry the error.
@@ -628,9 +629,9 @@ describe("ConfigStore", () => {
     try {
       api.getNetworkAssets.mockRejectedValueOnce(new Error("solana down"));
       store.setProtocolFilter("SOLANA");
-      await new Promise((r) => setTimeout(r, 0));
-      await new Promise((r) => setTimeout(r, 0));
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
+      await flushPromises();
+      await flushPromises();
 
       expect(store.assetsResponse).toBeNull();
     } finally {

--- a/src/common/stores/prices/index.test.ts
+++ b/src/common/stores/prices/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 // Shim window.matchMedia before store import: ThemeManager (via @/common/utils)
@@ -67,6 +67,10 @@ describe("usePricesStore", () => {
       return captured.unsubscribe;
     });
     setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("returns initial state defaults", () => {
@@ -194,14 +198,15 @@ describe("usePricesStore", () => {
   });
 
   it("ws callback refreshes lastUpdated", async () => {
+    vi.useFakeTimers();
     getPricesMock.mockResolvedValueOnce({});
     const store = usePricesStore();
     await store.initialize();
 
     const before = store.lastUpdated;
     expect(before).toBeTruthy();
-    // Force a measurable time gap
-    await new Promise((r) => setTimeout(r, 5));
+    // Force a measurable time gap on the faked clock so the refreshed timestamp is strictly later.
+    await vi.advanceTimersByTimeAsync(5);
     emitPrices({ "A@P": "1" });
     expect(store.lastUpdated).not.toBe(before);
     const after = store.lastUpdated;

--- a/src/modules/earn/components/WithdrawForm.test.ts
+++ b/src/modules/earn/components/WithdrawForm.test.ts
@@ -210,7 +210,7 @@ vi.mock("web-components", () => ({
   ToastType: { success: "success", error: "error" }
 }));
 
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import WithdrawForm from "./WithdrawForm.vue";
 
@@ -249,12 +249,12 @@ describe("WithdrawForm.vue", () => {
   it("surfaces a localized message (not a silent stop) when the withdraw flow rejects — finding 8", async () => {
     hoisted.walletOperationMock.mockRejectedValueOnce(new Error("lpp balance fetch failed"));
     const wrapper = factory();
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await nextTick();
     await wrapper.find('[data-test="amount"]').setValue("50");
     await nextTick();
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await nextTick();
     // onNextClick used to only Logger.error a failed pre-check/op, leaving the
     // field blank and the button reset — it now shows a classified message.
@@ -312,7 +312,7 @@ describe("WithdrawForm.vue", () => {
       // onNextClick → validateInputs (bug #5a) → onValidateAmount (bug #5b).
       // Without the guards, either would throw reading `assets[selected].value`.
       await expect(wrapper.find('[data-test="submit"]').trigger("click")).resolves.not.toThrow();
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
       await nextTick();
       expect(hoisted.broadcastTx).not.toHaveBeenCalled();
       wrapper.unmount();
@@ -326,9 +326,9 @@ describe("WithdrawForm.vue", () => {
 
       // Wait for the immediate wallet watcher + fetchDepositBalance to settle,
       // so we can stomp the populated lpnBalances back to [].
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
       await nextTick();
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
       await nextTick();
 
       const vm = wrapper.vm as unknown as {
@@ -341,9 +341,9 @@ describe("WithdrawForm.vue", () => {
 
       await wrapper.find('[data-test="submit"]').trigger("click");
       // Allow microtasks to drain
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
       await nextTick();
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
 
       expect(toast).toHaveBeenCalledWith({
         type: "error",

--- a/src/modules/leases/components/new-lease/LongForm.test.ts
+++ b/src/modules/leases/components/new-lease/LongForm.test.ts
@@ -246,12 +246,8 @@ vi.mock("web-components", () => ({
   ToastType: { success: "success", error: "error" }
 }));
 
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import LongForm from "./LongForm.vue";
-
-function flushMicrotasks() {
-  return new Promise((r) => setTimeout(r, 0));
-}
 
 function factory() {
   return mount(LongForm, {
@@ -292,9 +288,9 @@ describe("LongForm.vue — reactive balance validation", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="amount"]').setValue("0.5");
-    await flushMicrotasks();
+    await flushPromises();
     await wrapper.vm.$nextTick();
-    await flushMicrotasks();
+    await flushPromises();
 
     expect(wrapper.find('[data-test="err"]').text()).toBe("message.invalid-balance-big");
     expect(wrapper.find('[data-test="err"]').text()).not.toBe("message.unexpected-error");
@@ -308,9 +304,9 @@ describe("LongForm.vue — reactive balance validation", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="amount"]').setValue("0");
-    await flushMicrotasks();
+    await flushPromises();
     await wrapper.vm.$nextTick();
-    await flushMicrotasks();
+    await flushPromises();
 
     expect(wrapper.find('[data-test="err"]').text()).toBe("message.invalid-balance-low");
     expect(hoisted.leaseQuote).not.toHaveBeenCalled();
@@ -324,9 +320,9 @@ describe("LongForm.vue — reactive balance validation", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="amount"]').setValue("0.5");
-    await flushMicrotasks();
+    await flushPromises();
     await wrapper.vm.$nextTick();
-    await flushMicrotasks();
+    await flushPromises();
 
     expect(wrapper.find('[data-test="err"]').text()).toBe("");
     expect(hoisted.leaseQuote).toHaveBeenCalled();

--- a/src/modules/leases/components/new-lease/ShortForm.test.ts
+++ b/src/modules/leases/components/new-lease/ShortForm.test.ts
@@ -279,12 +279,8 @@ vi.mock("web-components", () => ({
   ToastType: { success: "success", error: "error" }
 }));
 
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import ShortForm from "./ShortForm.vue";
-
-function flushMicrotasks() {
-  return new Promise((r) => setTimeout(r, 0));
-}
 
 function factory() {
   return mount(ShortForm, {
@@ -322,9 +318,9 @@ describe("ShortForm.vue — leaseQuote ticker resolution", () => {
     await wrapper.vm.$nextTick();
 
     await wrapper.find('[data-test="amount"]').setValue("0.001");
-    await flushMicrotasks();
+    await flushPromises();
     await wrapper.vm.$nextTick();
-    await flushMicrotasks();
+    await flushPromises();
 
     expect(hoisted.leaseQuote).toHaveBeenCalled();
     const args = hoisted.leaseQuote.mock.calls[0];
@@ -343,9 +339,9 @@ describe("ShortForm.vue — leaseQuote ticker resolution", () => {
     // check passes and the quote (the subject of this test) is attempted.
     await wrapper.find('[data-test="pick-usdc"]').trigger("click");
     await wrapper.find('[data-test="amount"]').setValue("1");
-    await flushMicrotasks();
+    await flushPromises();
     await wrapper.vm.$nextTick();
-    await flushMicrotasks();
+    await flushPromises();
 
     expect(hoisted.leaseQuote).toHaveBeenCalled();
     const args = hoisted.leaseQuote.mock.calls[0];
@@ -372,9 +368,9 @@ describe("ShortForm.vue — leaseQuote ticker resolution", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="amount"]').setValue("0.001");
-    await flushMicrotasks();
+    await flushPromises();
     await wrapper.vm.$nextTick();
-    await flushMicrotasks();
+    await flushPromises();
 
     expect(hoisted.leaseQuote).not.toHaveBeenCalled();
     expect(wrapper.find('[data-test="err"]').text()).toBe("message.unexpected-error");
@@ -387,9 +383,9 @@ describe("ShortForm.vue — leaseQuote ticker resolution", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="amount"]').setValue("0.001");
-    await flushMicrotasks();
+    await flushPromises();
     await wrapper.vm.$nextTick();
-    await flushMicrotasks();
+    await flushPromises();
 
     expect(wrapper.find('[data-test="err"]').text()).toBe("message.no-liquidity");
     wrapper.unmount();
@@ -401,9 +397,9 @@ describe("ShortForm.vue — leaseQuote ticker resolution", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="amount"]').setValue("0.001");
-    await flushMicrotasks();
+    await flushPromises();
     await wrapper.vm.$nextTick();
-    await flushMicrotasks();
+    await flushPromises();
 
     expect(wrapper.find('[data-test="err"]').text()).toBe("message.unexpected-error");
     wrapper.unmount();
@@ -414,9 +410,9 @@ describe("ShortForm.vue — leaseQuote ticker resolution", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="amount"]').setValue("1");
-    await flushMicrotasks();
+    await flushPromises();
     await wrapper.vm.$nextTick();
-    await flushMicrotasks();
+    await flushPromises();
 
     expect(wrapper.find('[data-test="err"]').text()).toBe("message.invalid-balance-big");
     expect(hoisted.leaseQuote).not.toHaveBeenCalled();

--- a/src/modules/leases/components/single-lease/CloseDialog.test.ts
+++ b/src/modules/leases/components/single-lease/CloseDialog.test.ts
@@ -380,7 +380,7 @@ describe("CloseDialog.vue", () => {
   it("loads lease position spec via getLeasePositionSpec", async () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     expect(hoisted.getLeasePositionSpec).toHaveBeenCalledWith("osmosis-1");
     wrapper.unmount();
   });
@@ -398,7 +398,7 @@ describe("CloseDialog.vue", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     expect(hoisted.walletOperationMock).toHaveBeenCalledTimes(1);
     wrapper.unmount();
   });
@@ -408,7 +408,7 @@ describe("CloseDialog.vue", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     expect(hoisted.loggerError).toHaveBeenCalled();
     // The raw "boom" must not leak onto the field — it is classified instead.
     expect(wrapper.find('[data-test="err"]').text()).toBe("message.unexpected-error");
@@ -512,7 +512,7 @@ describe("CloseDialog.vue", () => {
     expect(wrapper.exists()).toBe(true);
     // Attempt to submit — action must bail out with error toast, walletOperation must not proceed.
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({ type: "error", message: "message.close-invalid-price" })
     );

--- a/src/modules/leases/components/single-lease/RepayDialog.test.ts
+++ b/src/modules/leases/components/single-lease/RepayDialog.test.ts
@@ -350,7 +350,7 @@ describe("RepayDialog.vue", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     expect(hoisted.walletOperationMock).toHaveBeenCalledTimes(1);
     wrapper.unmount();
   });
@@ -360,7 +360,7 @@ describe("RepayDialog.vue", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     expect(hoisted.loggerError).toHaveBeenCalled();
     // The raw "boom" must not leak onto the field — it is classified instead.
     expect(wrapper.find('[data-test="err"]').text()).toBe("message.unexpected-error");

--- a/src/modules/stake/components/DelegateForm.test.ts
+++ b/src/modules/stake/components/DelegateForm.test.ts
@@ -159,7 +159,7 @@ vi.mock("web-components", () => ({
   ToastType: { success: "success", error: "error" }
 }));
 
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import DelegateForm from "./DelegateForm.vue";
 
@@ -226,7 +226,7 @@ describe("DelegateForm.vue", () => {
     const wrapper = factory();
     await wrapper.find('[data-test="amount"]').setValue("9999999");
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
 
     expect(hoisted.simulateDelegateTx).not.toHaveBeenCalled();
     expect(hoisted.walletOperationMock).not.toHaveBeenCalled();
@@ -237,9 +237,9 @@ describe("DelegateForm.vue", () => {
     const wrapper = factory();
     await wrapper.find('[data-test="amount"]').setValue("100");
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await nextTick();
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
 
     expect(hoisted.walletOperationMock).toHaveBeenCalledTimes(1);
     expect(hoisted.simulateDelegateTx).toHaveBeenCalledTimes(1);
@@ -252,7 +252,7 @@ describe("DelegateForm.vue", () => {
     const wrapper = factory();
     await wrapper.find('[data-test="amount"]').setValue("100");
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await nextTick();
     // The failure used to be swallowed (Logger.error only) — the field now shows
     // a classified message instead of staying blank.
@@ -264,9 +264,9 @@ describe("DelegateForm.vue", () => {
     const wrapper = factory();
     await wrapper.find('[data-test="amount"]').setValue("100");
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await nextTick();
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
 
     expect(hoisted.fetchPositions).toHaveBeenCalled();
     expect(hoisted.fetchBalances).toHaveBeenCalled();
@@ -285,9 +285,9 @@ describe("DelegateForm.vue", () => {
       const wrapper = factory();
       await wrapper.find('[data-test="amount"]').setValue("100");
       await wrapper.find('[data-test="submit"]').trigger("click");
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
       await nextTick();
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
 
       // Form should still be mounted and button re-enabled
       expect(wrapper.find('[data-test="submit"]').exists()).toBe(true);
@@ -298,9 +298,9 @@ describe("DelegateForm.vue", () => {
       const wrapper = factory();
       await wrapper.find('[data-test="amount"]').setValue("100");
       await wrapper.find('[data-test="submit"]').trigger("click");
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
       await nextTick();
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
 
       expect(hoisted.simulateDelegateTx).not.toHaveBeenCalled();
       expect(hoisted.broadcastTx).not.toHaveBeenCalled();
@@ -312,9 +312,9 @@ describe("DelegateForm.vue", () => {
       const wrapper = factory(toast);
       await wrapper.find('[data-test="amount"]').setValue("100");
       await wrapper.find('[data-test="submit"]').trigger("click");
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
       await nextTick();
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
 
       expect(toast).toHaveBeenCalledExactlyOnceWith({
         type: "error",
@@ -327,9 +327,9 @@ describe("DelegateForm.vue", () => {
       const wrapper = factory();
       await wrapper.find('[data-test="amount"]').setValue("100");
       await wrapper.find('[data-test="submit"]').trigger("click");
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
       await nextTick();
-      await new Promise((r) => setTimeout(r, 0));
+      await flushPromises();
 
       expect(hoisted.routerPush).not.toHaveBeenCalled();
       wrapper.unmount();

--- a/src/modules/stake/components/RedelegateButton.test.ts
+++ b/src/modules/stake/components/RedelegateButton.test.ts
@@ -103,7 +103,7 @@ vi.mock("web-components", () => ({
   ToastType: { success: "success", error: "error" }
 }));
 
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import RedelegateButton from "./RedelegateButton.vue";
 
 function factory(props: { src?: string; amount?: string } = {}) {
@@ -176,7 +176,7 @@ describe("RedelegateButton.vue", () => {
     const wrapper = factory({ amount: "1000" });
     await wrapper.find('[data-test="svg-icon"]').trigger("click");
     // allow async chain to settle
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await wrapper.vm.$nextTick();
 
     expect(hoisted.simulateRedelegateTx).toHaveBeenCalledTimes(1);
@@ -201,7 +201,7 @@ describe("RedelegateButton.vue", () => {
 
     const wrapper = factory({ amount: "1000" });
     await wrapper.find('[data-test="svg-icon"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await wrapper.vm.$nextTick();
 
     expect(hoisted.simulateRedelegateTx).not.toHaveBeenCalled();
@@ -226,13 +226,13 @@ describe("RedelegateButton.vue", () => {
     await icon.trigger("click");
     // fire second click while loading — should be ignored
     await icon.trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
 
     expect(hoisted.simulateRedelegateTx).toHaveBeenCalledTimes(1);
 
     // resolve first
     resolveSim({ txBytes: new Uint8Array([1]) });
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     wrapper.unmount();
   });
 
@@ -244,7 +244,7 @@ describe("RedelegateButton.vue", () => {
 
     const wrapper = factory({ amount: "1000" });
     await wrapper.find('[data-test="svg-icon"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await wrapper.vm.$nextTick();
 
     expect(hoisted.loggerError).toHaveBeenCalled();

--- a/src/modules/stake/components/UndelegateForm.test.ts
+++ b/src/modules/stake/components/UndelegateForm.test.ts
@@ -158,7 +158,7 @@ vi.mock("web-components", () => ({
   ToastType: { success: "success", error: "error" }
 }));
 
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import UndelegateForm from "./UndelegateForm.vue";
 
@@ -216,7 +216,7 @@ describe("UndelegateForm.vue", () => {
     const wrapper = factory();
     await wrapper.find('[data-test="amount"]').setValue("999999");
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     expect(hoisted.simulateUndelegateTx).not.toHaveBeenCalled();
     wrapper.unmount();
   });
@@ -226,9 +226,9 @@ describe("UndelegateForm.vue", () => {
     // 800 NLS should hit both delegations (600 + 400)
     await wrapper.find('[data-test="amount"]').setValue("800");
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await nextTick();
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
 
     expect(hoisted.simulateUndelegateTx).toHaveBeenCalledTimes(1);
     const txs = hoisted.simulateUndelegateTx.mock.calls[0][0] as Array<{
@@ -245,9 +245,9 @@ describe("UndelegateForm.vue", () => {
     const wrapper = factory();
     await wrapper.find('[data-test="amount"]').setValue("100");
     await wrapper.find('[data-test="submit"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await nextTick();
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
 
     expect(hoisted.broadcastTx).toHaveBeenCalledTimes(1);
     expect(hoisted.fetchPositions).toHaveBeenCalled();

--- a/src/modules/vote/components/VoteDialog.test.ts
+++ b/src/modules/vote/components/VoteDialog.test.ts
@@ -122,7 +122,7 @@ vi.mock("./VotingLine.vue", () => ({
   default: { name: "VotingLine", props: ["voting", "labels"], template: "<div />" }
 }));
 
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { Dec } from "@keplr-wallet/unit";
 import VoteDialog from "./VoteDialog.vue";
 
@@ -216,7 +216,7 @@ describe("VoteDialog.vue", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="message.yes"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await wrapper.vm.$nextTick();
 
     expect(hoisted.walletOperationMock).toHaveBeenCalledTimes(1);
@@ -229,7 +229,7 @@ describe("VoteDialog.vue", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="message.no"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await wrapper.vm.$nextTick();
 
     expect(hoisted.loadActivities).toHaveBeenCalled();
@@ -242,7 +242,7 @@ describe("VoteDialog.vue", () => {
     const wrapper = factory();
     await wrapper.vm.$nextTick();
     await wrapper.find('[data-test="message.veto"]').trigger("click");
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     await wrapper.vm.$nextTick();
 
     expect(hoisted.loggerError).toHaveBeenCalled();

--- a/src/router/index.test.ts
+++ b/src/router/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type * as VueRouter from "vue-router";
 
 // Mock every module the router imports so the router module can be loaded
@@ -75,6 +75,10 @@ describe("router/index.ts", () => {
     }
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("router module loads and exports RouteNames + router instance", async () => {
     const mod = await import("./index");
     expect(mod.router).toBeDefined();
@@ -110,21 +114,24 @@ describe("router/index.ts", () => {
     // Regression: a rejecting setLang used to bubble through the guard's
     // bare `await`, so next() was never called and navigation hung silently.
     // The guard must now catch and still call next() so the router resolves.
+    vi.useFakeTimers();
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     hoisted.setLangMock.mockRejectedValueOnce(new Error("locale fetch failed"));
 
     const mod = await import("./index");
 
-    // If the guard hangs, this push never resolves — give it a finite race.
+    // Drive the navigation on the faked clock. The it()-level timeout below is the
+    // hang guard: a regressed guard that never calls next() leaves this push pending,
+    // so the test fails fast instead of stalling the suite.
     const push = mod.router.push("/dashboard");
-    const timeout = new Promise((_, reject) => setTimeout(() => reject(new Error("navigation hung")), 1000));
-    await expect(Promise.race([push, timeout])).resolves.not.toThrow();
+    await vi.runAllTimersAsync();
+    await expect(push).resolves.not.toThrow();
 
     expect(hoisted.setLangMock).toHaveBeenCalledWith("en");
     expect(consoleErrorSpy).toHaveBeenCalled();
     // Current route should actually be the target — navigation completed.
     expect(mod.router.currentRoute.value.path).toBe("/dashboard");
-  });
+  }, 1000);
 });
 
 describe("handleChunkLoadError", () => {


### PR DESCRIPTION
## Summary
Replace the hand-rolled microtask-flush idiom `await new Promise(r => setTimeout(r, 0))` across the frontend Vitest suite with `flushPromises()` from `@vue/test-utils`, and convert the two genuinely time-dependent tests to a faked clock. Real-clock waits flake under loaded CI and misrepresent what the code actually waits for. Closes #183.

## Changes
- 12 test files: `setTimeout(r, 0)` microtask flushes (and the `flushMicrotasks` helper in LongForm/ShortForm) now use `flushPromises()`.
- `prices/index.test.ts`: the `lastUpdated`-refresh test that relied on a 5 ms real sleep now uses `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync(5)`; assertions unchanged.
- `router/index.test.ts`: the navigation hang-guard that raced a 1000 ms real timer now drives navigation on a faked clock and uses the `it()`-level timeout as the hang ceiling — no literal `setTimeout` left.
- Both fake-clock files restore real timers in `afterEach` (no `restoreAllMocks`, per the project's `vi.hoisted` teardown rule).
- New `pr-validate.yaml` frontend step rejects `setTimeout(x, <digits>)` in `*.test.ts`/`*.spec.ts`, catching the zero/single-digit forms the prior kit pattern (`\d{2,}`) missed.

## Verification
- Ran `npm run lint` and `npm run format:check` — both clean.
- Ran `npm test` — 54 files, 835 tests pass (down from the prior real-clock waits, suite is faster).
- Ran `npm run build` — production build succeeds.
- Dry-ran the new CI grep against the converted tree — no matches (passes); confirmed it matches the `,0)`/`,5)`/`,1000)` forms.
- A fresh-context review walked the bug + test-style checklists and returned ship, with every existing assertion preserved.