### PR TITLE
fix(assets): repopulate transfer dropdowns on network filter change

### DIFF
--- a/src/modules/assets/components/ReceiveForm.vue
+++ b/src/modules/assets/components/ReceiveForm.vue
@@ -204,8 +204,13 @@ let skipRouteConfig: SkipRouteConfigType | null;
 const id = Date.now();
 const onClose = inject("close", () => {});
 
+// Repopulate when the store is ready AND whenever the wallet-driven network
+// filter changes. protocolFilter starts "" and is set to the owned network
+// (e.g. "OSMOSIS") only after the async wallet reconnect completes — later than
+// `initialized` flips — so reacting to `initialized` alone snapshots an empty
+// list and never recovers.
 watch(
-  () => configStore.initialized,
+  [() => configStore.initialized, () => configStore.protocolFilter],
   () => {
     if (configStore.initialized) {
       onInit();
@@ -357,55 +362,58 @@ async function setCosmosNetwork() {
   destroyClient();
 
   disablePicker.value = true;
-  const ntwrk = NETWORK_DATA;
+  try {
+    const ntwrk = NETWORK_DATA;
 
-  const currencies = [];
-  const promises = [];
-  const data = skipRouteConfig?.transfers?.[network.value.key]?.currencies;
-  for (const c of data ?? []) {
-    if (c.visible && configStore.protocolFilter !== c.visible) continue;
+    const currencies = [];
+    const promises = [];
+    const data = skipRouteConfig?.transfers?.[network.value.key]?.currencies;
+    for (const c of data ?? []) {
+      if (c.visible && configStore.protocolFilter !== c.visible) continue;
 
-    const currency = tryGetCurrencyByDenom(c.from);
-    if (!currency) continue; // Skip deprecated/removed denoms
+      const currency = tryGetCurrencyByDenom(c.from);
+      if (!currency) continue; // Skip deprecated/removed denoms
 
-    currency.balance = coin(0, c.to);
-    currencies.push(currency);
-  }
-
-  const mappedCurrencies = currencies.map((item) => {
-    return {
-      balance: item.balance,
-      shortName: item.shortName,
-      ticker: item.ticker,
-      name: item.shortName,
-      icon: item.icon,
-      decimal_digits: item.decimal_digits,
-      symbol: item.symbol,
-      native: item.native,
-      from: item.ibcData
-    };
-  });
-
-  const networkData = ntwrk?.supportedNetworks[network.value.key];
-  client = await WalletUtils.getWallet(network.value.key);
-  const baseWallet = (await externalWallet(client, networkData)) as BaseWallet;
-  wallet.value = baseWallet?.address as string;
-
-  if (WalletUtils.isAuth()) {
-    for (const c of mappedCurrencies) {
-      async function fn() {
-        const balance = await client.getBalance(wallet.value as string, c.balance.denom);
-        c.balance = balance;
-      }
-      promises.push(fn());
+      currency.balance = coin(0, c.to);
+      currencies.push(currency);
     }
+
+    const mappedCurrencies = currencies.map((item) => {
+      return {
+        balance: item.balance,
+        shortName: item.shortName,
+        ticker: item.ticker,
+        name: item.shortName,
+        icon: item.icon,
+        decimal_digits: item.decimal_digits,
+        symbol: item.symbol,
+        native: item.native,
+        from: item.ibcData
+      };
+    });
+
+    const networkData = ntwrk?.supportedNetworks[network.value.key];
+    client = await WalletUtils.getWallet(network.value.key);
+    const baseWallet = (await externalWallet(client, networkData)) as BaseWallet;
+    wallet.value = baseWallet?.address as string;
+
+    if (WalletUtils.isAuth()) {
+      for (const c of mappedCurrencies) {
+        async function fn() {
+          const balance = await client.getBalance(wallet.value as string, c.balance.denom);
+          c.balance = balance;
+        }
+        promises.push(fn());
+      }
+    }
+
+    await Promise.all(promises);
+
+    networkCurrencies.value = mappedCurrencies;
+    selectedCurrency.value = 0;
+  } finally {
+    disablePicker.value = false;
   }
-
-  await Promise.all(promises);
-
-  networkCurrencies.value = mappedCurrencies;
-  disablePicker.value = false;
-  selectedCurrency.value = 0;
 }
 
 function validateAmount() {

--- a/src/modules/assets/components/SendForm.vue
+++ b/src/modules/assets/components/SendForm.vue
@@ -242,8 +242,14 @@ const walletRef = computed(() => {
   return wallet.value;
 });
 
+// Repopulate when the store is ready AND whenever the wallet-driven network
+// filter changes. protocolFilter starts "" and is set to the owned network
+// (e.g. "OSMOSIS") only after the async wallet reconnect completes — later than
+// `initialized` flips. Reacting to it also lands the form on the destination
+// network so the Recipient resolves to the derived destination address
+// (e.g. osmo1…) instead of falling back to the native Nolus account.
 watch(
-  () => configStore.initialized,
+  [() => configStore.initialized, () => configStore.protocolFilter],
   () => {
     if (configStore.initialized) {
       onInit();
@@ -399,41 +405,44 @@ async function setCosmosNetwork() {
   destroyClient();
 
   disablePicker.value = true;
-  const ntwrk = NETWORK_DATA;
-  const currencies = [];
-  const data = skipRouteConfig?.transfers?.[network.value.key]?.currencies;
-  for (const c of data ?? []) {
-    if (c.visible && configStore.protocolFilter !== c.visible) continue;
+  try {
+    const ntwrk = NETWORK_DATA;
+    const currencies = [];
+    const data = skipRouteConfig?.transfers?.[network.value.key]?.currencies;
+    for (const c of data ?? []) {
+      if (c.visible && configStore.protocolFilter !== c.visible) continue;
 
-    const currency = tryGetCurrencyByDenom(c.from);
-    if (!currency) continue; // Skip deprecated/removed denoms
+      const currency = tryGetCurrencyByDenom(c.from);
+      if (!currency) continue; // Skip deprecated/removed denoms
 
-    const balance = balancesStore.getBalanceInfo(c.from);
-    currency.balance = coin(balance?.amount?.toString() ?? 0, c.to);
-    currencies.push(currency);
+      const balance = balancesStore.getBalanceInfo(c.from);
+      currency.balance = coin(balance?.amount?.toString() ?? 0, c.to);
+      currencies.push(currency);
+    }
+
+    const mappedCurrencies = currencies.map((item) => {
+      return {
+        balance: item.balance,
+        shortName: item.shortName,
+        ticker: item.ticker,
+        name: item.shortName,
+        icon: item.icon,
+        decimal_digits: item.decimal_digits,
+        symbol: item.symbol,
+        native: item.native,
+        from: item.ibcData
+      };
+    });
+    const networkData = ntwrk?.supportedNetworks[network.value.key];
+    client = await WalletUtils.getWallet(network.value.key);
+    const baseWallet = (await externalWallet(client, networkData)) as BaseWallet;
+    wallet.value = baseWallet?.address as string;
+
+    networkCurrencies.value = mappedCurrencies;
+    selectedCurrency.value = 0;
+  } finally {
+    disablePicker.value = false;
   }
-
-  const mappedCurrencies = currencies.map((item) => {
-    return {
-      balance: item.balance,
-      shortName: item.shortName,
-      ticker: item.ticker,
-      name: item.shortName,
-      icon: item.icon,
-      decimal_digits: item.decimal_digits,
-      symbol: item.symbol,
-      native: item.native,
-      from: item.ibcData
-    };
-  });
-  const networkData = ntwrk?.supportedNetworks[network.value.key];
-  client = await WalletUtils.getWallet(network.value.key);
-  const baseWallet = (await externalWallet(client, networkData)) as BaseWallet;
-  wallet.value = baseWallet?.address as string;
-
-  networkCurrencies.value = mappedCurrencies;
-  disablePicker.value = false;
-  selectedCurrency.value = 0;
 }
 
 function validateAmount() {

--- a/src/modules/assets/components/SwapForm.test.ts
+++ b/src/modules/assets/components/SwapForm.test.ts
@@ -33,11 +33,14 @@ const hoisted = vi.hoisted(() => {
     "USDC@OSMOSIS": { price: "1.0" },
     "NLS@NOLUS": { price: "0.5" }
   };
-  const configStoreState: { initialized: boolean; protocolFilter: string; supportedNetworksData: unknown } = {
+  const configStoreState: { initialized: boolean; supportedNetworksData: unknown } = {
     initialized: true,
-    protocolFilter: "OSMOSIS",
     supportedNetworksData: {}
   };
+  // protocolFilter is backed by a real Vue ref (created in the config-store mock
+  // via importActual("vue")) so the component's watch reacts to changes exactly
+  // as it does against the live Pinia store.
+  const protocolFilterControl: { ref: { value: string } | null } = { ref: null };
   const balancesState = { ignoredCurrencies: [] as string[] };
 
   return {
@@ -49,6 +52,7 @@ const hoisted = vi.hoisted(() => {
     walletRef,
     pricesState,
     configStoreState,
+    protocolFilterControl,
     balancesState
   };
 });
@@ -80,19 +84,23 @@ vi.mock("@/common/stores/prices", () => ({
   })
 }));
 
-vi.mock("@/common/stores/config", () => ({
-  useConfigStore: () => ({
-    get initialized() {
-      return hoisted.configStoreState.initialized;
-    },
-    get protocolFilter() {
-      return hoisted.configStoreState.protocolFilter;
-    },
-    get supportedNetworksData() {
-      return hoisted.configStoreState.supportedNetworksData;
-    }
-  })
-}));
+vi.mock("@/common/stores/config", async () => {
+  const { ref } = (await vi.importActual("vue")) as { ref: (value: string) => { value: string } };
+  hoisted.protocolFilterControl.ref = ref("OSMOSIS");
+  return {
+    useConfigStore: () => ({
+      get initialized() {
+        return hoisted.configStoreState.initialized;
+      },
+      get protocolFilter() {
+        return hoisted.protocolFilterControl.ref?.value ?? "";
+      },
+      get supportedNetworksData() {
+        return hoisted.configStoreState.supportedNetworksData;
+      }
+    })
+  };
+});
 
 vi.mock("@/common/stores/history", () => ({
   useHistoryStore: () => ({ loadActivities: vi.fn() })
@@ -240,7 +248,9 @@ describe("SwapForm.vue — defensive guards on .find()", () => {
     setActivePinia(createPinia());
 
     hoisted.configStoreState.initialized = true;
-    hoisted.configStoreState.protocolFilter = "OSMOSIS";
+    if (hoisted.protocolFilterControl.ref) {
+      hoisted.protocolFilterControl.ref.value = "OSMOSIS";
+    }
     hoisted.balancesState.ignoredCurrencies = [];
     hoisted.walletRef.value = { signer: { type: "cosm", chainId: "nolus-1" } };
     hoisted.validateAmountV2Mock.mockReturnValue("");
@@ -293,6 +303,29 @@ describe("SwapForm.vue — defensive guards on .find()", () => {
     const wrapper = factory();
     await flushPromises();
     expect(wrapper.exists()).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("repopulates the currency list when protocolFilter flips from empty to a network", async () => {
+    // Regression: the wallet-driven protocolFilter is "" until the async wallet
+    // reconnect resolves, which lands later than `configStore.initialized`. The
+    // form must repopulate when the filter flips, not snapshot the empty
+    // config.transfers[""] once and stay empty.
+    const pf = hoisted.protocolFilterControl.ref;
+    expect(pf).toBeTruthy();
+    if (!pf) return;
+
+    pf.value = "";
+    const wrapper = factory();
+    await flushPromises();
+
+    const mcc = wrapper.findComponent({ name: "MultipleCurrencyComponent" });
+    expect((mcc.props("currencyOptions") as unknown[]).length).toBe(0);
+
+    pf.value = "OSMOSIS";
+    await flushPromises();
+
+    expect((mcc.props("currencyOptions") as unknown[]).length).toBe(2);
     wrapper.unmount();
   });
 

--- a/src/modules/assets/components/SwapForm.vue
+++ b/src/modules/assets/components/SwapForm.vue
@@ -253,8 +253,13 @@ const selectedAsset = computed(() => {
   );
 });
 
+// Repopulate when the store is ready AND whenever the wallet-driven network
+// filter changes. protocolFilter starts "" and is set to the owned network
+// (e.g. "OSMOSIS") only after the async wallet reconnect completes — later than
+// `initialized` flips — so reacting to `initialized` alone snapshots an empty
+// `config.transfers[""]` and never recovers.
 watch(
-  () => configStore.initialized,
+  [() => configStore.initialized, () => configStore.protocolFilter],
   () => {
     if (configStore.initialized) {
       onInit();


### PR DESCRIPTION
## Summary
Fix the Swap/Deposit/Withdraw transfer modal rendering empty token dropdowns (Swap empty, Deposit stuck on "Loading", Withdraw showing only NLS) — a regression versus production. Also makes the Withdraw recipient resolve to the destination-network address (e.g. `osmo1…`) instead of the user's own Nolus account.

## Root cause
Commit "drive network filter from connected wallet" (#151) made `configStore.protocolFilter` default to `""`, set to the owned network (e.g. `"OSMOSIS"` for Keplr) only after the async wallet reconnect — which resolves later than `configStore.initialized` flips true. Each form's `onInit()` watcher fired on `initialized` only, so it snapshotted `config.transfers[""]` (undefined → empty list) once and never recovered.

## Changes
- `SwapForm.vue`, `ReceiveForm.vue`, `SendForm.vue`: the populate watcher now reacts to `[initialized, protocolFilter]`, so each form repopulates when the filter resolves. For Withdraw this lands the form on the destination network, so the existing cosmos-branch logic fills the recipient with the derived `osmo1…` address.
- `ReceiveForm.vue` / `SendForm.vue`: `setCosmosNetwork()` body wrapped in `try/finally` so a throw during the racy first run can't leave the Deposit picker stuck on "Loading".
- `SwapForm.test.ts`: back the mocked `protocolFilter` with a real Vue `ref` so the component's watch reacts; add a regression test asserting the currency list is empty at `protocolFilter===""` and repopulates (length 2) when it flips to `"OSMOSIS"`.

An empty filter (e.g. a Solana wallet, which maps to `"SOLANA"` with no live transfers) still yields an empty list by design — no `|| "OSMOSIS"` fallback was added.

## Verification
- Ran `npm run lint`, `npm run format:check` — clean.
- Ran `npm test` — 54 files, 836 tests pass (incl. the new repopulation regression test).
- Ran `npm run build` — production build succeeds.
- A fresh-context review walked the bug checklist and returned ship; confirmed no infinite-loop/double-fetch, the try/finally preserves all statements with `disablePicker` reset on both paths, and the Solana fail-loud behavior is intact.

## Follow-ups
- Needs a live wallet-connected check on staging (could not drive a browser+wallet locally). SendForm/ReceiveForm have no unit tests; the watcher change there was verified by inspection against SwapForm's tested version.