### PR TITLE
fix(wallet): seed network filter from stored mechanism on load

### DIFF
--- a/src/common/composables/useWalletEvents.ts
+++ b/src/common/composables/useWalletEvents.ts
@@ -3,7 +3,8 @@ import { useWalletStore } from "@/common/stores/wallet";
 import { useConfigStore } from "@/common/stores/config";
 import { useConnectionStore } from "@/common/stores/connection";
 import { useEarnStore } from "@/common/stores/earn";
-import { IntercomService, Logger, walletOperation } from "@/common/utils";
+import { IntercomService, Logger, WalletManager, walletOperation, applyWalletProtocolFilter } from "@/common/utils";
+import type { WalletConnectMechanism } from "@/common/types";
 
 /**
  * Composable that manages wallet lifecycle events:
@@ -54,6 +55,12 @@ export function useWalletEvents(): void {
     () => configStore.initialized,
     async (initialized) => {
       if (!initialized) return;
+      // Seed the wallet-owned network filter from the stored mechanism before the
+      // (slow) reconnect chain resolves. Otherwise protocolFilter stays "" — and
+      // the transfer forms key config.transfers[""] → empty — until a later tx
+      // submit eventually runs a full connect. A null mechanism (disconnected)
+      // maps to "", which the config-store watcher treats as a no-op.
+      applyWalletProtocolFilter(WalletManager.getWalletConnectMechanism() as WalletConnectMechanism | null);
       await walletOperation(() => {});
       if (wallet.wallet?.address) {
         await connectionStore.connectWallet(wallet.wallet.address);


### PR DESCRIPTION
## Summary
Follow-up to #226. The transfer dropdowns were still empty after #226 because `protocolFilter` is never actually set on a normal page load — it stays `""` until a transaction submit. Seed it from the stored wallet mechanism the moment the config store initializes, so the owned network (e.g. `OSMOSIS` for Keplr) is in place before any form reads it.

## Root cause (the half #226 missed)
`protocolFilter` is wallet-owned and starts `""`. It is set only inside the connect actions (`applyWalletProtocolFilter`). On load, those run via the slow `walletOperation()` reconnect chain inside `useWalletEvents`, so the value lands late — and `connectionStore.connectWallet()` (the auto-reconnect entry point) only stores the address, never sets the filter. #226 made the forms *react* to `protocolFilter`, but with nothing ever setting it on load, there was nothing to react to.

## Change
In `useWalletEvents`, when `configStore.initialized` flips, synchronously call `applyWalletProtocolFilter(WalletManager.getWalletConnectMechanism())` before the async reconnect. `getWalletConnectMechanism()` validates the stored value against the enum and returns `null` for anything else, so the only outcomes are `OSMOSIS` (Keplr), `SOLANA` (Phantom/Solflare — empty dropdowns by design), or `""` (disconnected → no-op). Setting the same value again during the later reconnect is a guaranteed no-op (Vue ref-equality + the watcher's `fetchedNetworks` dedup).

## Verification
- Ran `npm run lint`, `npm run format:check` — clean.
- Ran `npm test` — 54 files, 836 tests pass.
- `npx tsc --noEmit` — 0 errors.
- Ran `npm run build` — succeeds.
- Fresh-context review walked the bug checklist + verified the cast is backed by runtime validation, the redundant second set is a no-op, and Solana stays fail-loud — returned ship.

## Follow-ups
- Needs a live wallet-connected check on staging (cannot drive a browser+wallet locally; app-dev is behind Cloudflare Access so it can't be probed headlessly). `useWalletEvents` has no unit test (heavy store deps); change is safe-by-inspection and the companion reactive-forms behavior is unit-tested in #226.