### PR TITLE
fix(swap): validate swap currencies per-network, not globally

### DIFF
--- a/src/common/api/schemas/index.test.ts
+++ b/src/common/api/schemas/index.test.ts
@@ -423,4 +423,28 @@ describe("SkipRouteConfigSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("should accept a config missing a deprecated network's swap currency", () => {
+    // Regression: Neutron was deprecated and swap_currency_neutron deleted from the
+    // backend config. Per-network swap currencies are validated at point of use, not
+    // globally — a single absent network must not reject the whole config and break
+    // every other network's transfer forms.
+    const { swap_currency_neutron: _neutron, ...rest } = validConfig();
+    const result = SkipRouteConfigSchema.safeParse(rest);
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept a config with no per-network swap currencies at all", () => {
+    const { swap_currency_osmosis: _osmosis, swap_currency_neutron: _neutron, ...rest } = validConfig();
+    const result = SkipRouteConfigSchema.safeParse(rest);
+    expect(result.success).toBe(true);
+  });
+
+  it("should preserve per-network swap currency keys through passthrough", () => {
+    const result = SkipRouteConfigSchema.safeParse(validConfig());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).swap_currency_osmosis).toBe("USDC");
+    }
+  });
 });

--- a/src/common/api/schemas/index.ts
+++ b/src/common/api/schemas/index.ts
@@ -181,11 +181,16 @@ const SkipRouteTransferCurrencySchema = z
   })
   .passthrough();
 
+// Per-network swap currencies (`swap_currency_<network>`) are intentionally NOT
+// validated here. They are a per-network resource read only when that network is
+// the selected one; validating them globally lets an absent network (e.g. Neutron,
+// deprecated and deleted from the backend config) reject the entire swap config and
+// break every other network's transfer forms. They pass through and are validated
+// strictly at point of use (SwapForm) for the selected network only. `swap_to_currency`
+// may be empty for the same reason — its presence is checked where the swap is routed.
 export const SkipRouteConfigSchema = z
   .object({
     blacklist: z.array(z.string()),
-    swap_currency_osmosis: z.string(),
-    swap_currency_neutron: z.string(),
     swap_to_currency: z.string(),
     fee: z.number(),
     transfers: z.record(

--- a/src/common/types/SkipRouteConfigType.ts
+++ b/src/common/types/SkipRouteConfigType.ts
@@ -1,7 +1,5 @@
 export interface SkipRouteConfigType {
   blacklist: string[];
-  swap_currency_osmosis: string;
-  swap_currency_neutron: string;
   swap_to_currency: string;
   fee: number;
   transfers: {
@@ -14,4 +12,11 @@ export interface SkipRouteConfigType {
       }[];
     };
   };
+  /**
+   * Per-network default swap-from denom, keyed `swap_currency_<network>` (lowercase
+   * network name). Dynamic and optional: a network absent from the backend config has
+   * no entry, so the value is `string | undefined`. Validated at point of use in
+   * SwapForm, not in SkipRouteConfigSchema — see the schema for why.
+   */
+  [key: `swap_currency_${string}`]: string | undefined;
 }

--- a/src/modules/assets/components/SwapForm.test.ts
+++ b/src/modules/assets/components/SwapForm.test.ts
@@ -329,6 +329,37 @@ describe("SwapForm.vue — defensive guards on .find()", () => {
     wrapper.unmount();
   });
 
+  it("populates Osmosis when the config omits a deprecated network's swap currency", async () => {
+    // Regression: Neutron was deprecated and swap_currency_neutron deleted from the
+    // backend config. The schema no longer requires it, so the Osmosis swap form must
+    // still populate when neutron is absent rather than failing on a global throw.
+    hoisted.getSkipRouteConfigMock.mockResolvedValue({
+      blacklist: [],
+      swap_currency_osmosis: "ibc/OSMO",
+      swap_to_currency: "ibc/USDC",
+      fee: 25,
+      transfers: {
+        OSMOSIS: {
+          currencies: [
+            { from: "ibc/OSMO", to: "ibc/OSMO", native: true },
+            { from: "ibc/USDC", to: "ibc/USDC", native: false }
+          ]
+        }
+      }
+    });
+
+    const toast = vi.fn();
+    const wrapper = factory(toast);
+    await flushPromises();
+
+    const mcc = wrapper.findComponent({ name: "MultipleCurrencyComponent" });
+    expect((mcc.props("currencyOptions") as unknown[]).length).toBe(2);
+    // The selected network's from-currency (swap_currency_osmosis) and swap_to_currency
+    // both resolved — point-of-use validation passed, so no mismatch toast fired.
+    expect(toast).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
   describe("onLoadConfig: swap_to_currency has no match in assets", () => {
     beforeEach(() => {
       hoisted.getSkipRouteConfigMock.mockResolvedValue({


### PR DESCRIPTION
## Summary
Fix the empty token dropdowns in the transfer modal (Swap / Deposit / Withdraw) on app-dev. `SkipRouteConfigSchema` hard-required `swap_currency_osmosis` and `swap_currency_neutron` as fixed fields. After Neutron was deprecated and its config deleted from the backend, `GET /api/swap/config` stopped emitting `swap_currency_neutron`, so the single global parse in `getSkipRouteConfig()` rejected the entire config and threw — emptying every transfer form. Per-network swap currencies are now validated at point of use for the selected network instead of as global required fields, so removing a network can no longer break the others.

## Changes
- `schemas/index.ts`: drop the two required `swap_currency_<net>` fields. The global parse validates only `blacklist`, `fee`, `swap_to_currency` (present, may be empty), and that `transfers` is a record. Per-network denoms pass through and are validated at use.
- `SkipRouteConfigType`: replace the two named fields with a dynamic optional `` `swap_currency_${string}` `` index signature.
- Tests: schema cases (config missing a deprecated network, no per-network currencies, passthrough preserved) and a SwapForm case (Osmosis populates with neutron absent, no mismatch toast).

`SwapForm.vue` is unchanged — its `onInit` already resolves the selected network's from-/to-currency and fails loudly (logs + toast) when a denom does not resolve. The backend is not modified.

## Verification
- Ran `npm test` — 840 tests across 54 files pass.
- Ran `prettier --check src` and `eslint src` — clean.
- Typechecked the changed files clean (the only `vue-tsc` errors are pre-existing toolchain deprecations in unrelated files).
- Traced the money path for fail-open behavior: validation moves from a global required-field check to a strict point-of-use guard in the sole consumer (`SwapForm.onInit`). A missing or empty denom cannot reach swap routing because the currency registry guarantees a non-empty `ibcData`, so the guard rejects it.
- Confirmed production (tag v3.2.9) is unaffected: it still ships the Neutron config and parses unchanged.