### PR TITLE
docs(vue): document external-state watcher contracts

### DIFF
--- a/src/modules/assets/components/ReceiveForm.vue
+++ b/src/modules/assets/components/ReceiveForm.vue
@@ -209,6 +209,10 @@ const onClose = inject("close", () => {});
 // (e.g. "OSMOSIS") only after the async wallet reconnect completes — later than
 // `initialized` flips — so reacting to `initialized` alone snapshots an empty
 // list and never recovers.
+//
+// Reacts to: configStore.initialized + configStore.protocolFilter.
+// Idempotency: onInit() recomputes the receive currency list from the current
+// store snapshot, so the immediate run and every re-fire are safe.
 watch(
   [() => configStore.initialized, () => configStore.protocolFilter],
   () => {

--- a/src/modules/assets/components/SendForm.vue
+++ b/src/modules/assets/components/SendForm.vue
@@ -248,6 +248,10 @@ const walletRef = computed(() => {
 // `initialized` flips. Reacting to it also lands the form on the destination
 // network so the Recipient resolves to the derived destination address
 // (e.g. osmo1…) instead of falling back to the native Nolus account.
+//
+// Reacts to: configStore.initialized + configStore.protocolFilter.
+// Idempotency: onInit() recomputes form/network state from the current store
+// snapshot, so the immediate run and every re-fire are safe.
 watch(
   [() => configStore.initialized, () => configStore.protocolFilter],
   () => {
@@ -332,6 +336,10 @@ function setHistory() {
   historyStore.addPendingTransfer(data, i18n);
 }
 
+// Reacts to: selected currency, amount, and wallet address.
+// Idempotency: validateAmount() runs first (resets amountErrorMsg each call) and
+// gates a debounced route fetch; the clearTimeout collapses rapid re-fires into a
+// single getRoute() call.
 watch(
   () => [selectedCurrency.value, amount.value, wallet.value],
   () => {
@@ -351,6 +359,9 @@ watch(
   }
 );
 
+// Reacts to: receiverAddress (user input).
+// Idempotency: recomputes amountErrorMsg via validateAddress on each change; pure
+// validation, safe to re-fire.
 watch(
   () => receiverAddress.value,
   () => {

--- a/src/modules/assets/components/SwapForm.vue
+++ b/src/modules/assets/components/SwapForm.vue
@@ -258,6 +258,10 @@ const selectedAsset = computed(() => {
 // (e.g. "OSMOSIS") only after the async wallet reconnect completes — later than
 // `initialized` flips — so reacting to `initialized` alone snapshots an empty
 // `config.transfers[""]` and never recovers.
+//
+// Reacts to: configStore.initialized + configStore.protocolFilter.
+// Idempotency: onInit() recomputes the full swap currency/blacklist set from the
+// current store snapshot, so the immediate run and every re-fire are safe.
 watch(
   [() => configStore.initialized, () => configStore.protocolFilter],
   () => {

--- a/src/modules/history/components/History.vue
+++ b/src/modules/history/components/History.vue
@@ -153,7 +153,10 @@ const txsSkip = computed(() => {
   });
 });
 
-// Initialize when config is ready
+// Reacts to: configStore.initialized.
+// Idempotency: initializeHistory() only loads when a wallet address is present and
+// re-seeds the address each call; the immediate run covers the already-initialized
+// case. Safe to re-fire.
 watch(
   () => configStore.initialized,
   () => {
@@ -164,7 +167,10 @@ watch(
   { immediate: true }
 );
 
-// Reset and reload when wallet changes
+// Reacts to: wallet.wallet (connect / disconnect / account switch).
+// Side effect: resets pagination and clears the history store, then reloads for the
+// new address. Idempotency: the reset runs unconditionally so a re-fire rebuilds
+// from a clean slate; the load only runs when an address is present.
 watch(
   () => wallet.wallet,
   () => {

--- a/src/modules/leases/components/SingleLease.vue
+++ b/src/modules/leases/components/SingleLease.vue
@@ -193,14 +193,19 @@ onUnmounted(() => {
   clearInterval(timeOut);
 });
 
-// On route params change, fetch the new lease into the store.
-// The watchEffect handles syncing store → lease.value.
+// Reacts to: route.params.id (navigation between leases).
+// Idempotency: fetchLease() reads the current id and replaces the store entry, so
+// re-firing on the same id is harmless. The watchEffect syncs store → lease.value.
 watch(
   () => route.params.id,
   () => fetchLease()
 );
 
-// Redirect to positions list when lease reaches a terminal state
+// Reacts to: lease.value?.status (polled via the store refresh interval).
+// Side effect: on a terminal status it refetches balances + leases and navigates
+// away (router.replace). Idempotency: the terminal-status guard makes a repeat of
+// the same non-terminal status a no-op; reaching a terminal status redirects once,
+// after which the component unmounts so it cannot re-fire.
 watch(
   () => lease.value?.status,
   (newStatus) => {

--- a/src/modules/stake/view.vue
+++ b/src/modules/stake/view.vue
@@ -88,7 +88,10 @@ const walletConnected = useWalletConnected();
 
 const vestedTokens = ref([] as { endTime: string; amount: { amount: string; denom: string } }[]);
 
-// Watch for wallet connection changes (staking store is managed by connectionStore)
+// Reacts to: wallet.wallet?.address (wallet connect / disconnect).
+// Idempotency: loads vested tokens when an address is present, clears them when
+// absent; re-firing with the same address re-loads idempotently, and the immediate
+// run seeds the initial state. (Staking store itself is managed by connectionStore.)
 watch(
   () => wallet.wallet?.address,
   async (address) => {

--- a/src/modules/stats/components/LeasesMonthlyChart.vue
+++ b/src/modules/stats/components/LeasesMonthlyChart.vue
@@ -41,7 +41,9 @@ const i18n = useI18n();
 const loans = ref<{ amount: number; date: Date }[]>([]);
 const statsStore = useStatsStore();
 
-// Watch for monthlyLeases changes from store
+// Reacts to: statsStore.monthlyLeases (polled store data).
+// Idempotency: rebuilds the local loans series from the response each fire and
+// repaints the chart; safe to re-fire.
 watch(
   () => statsStore.monthlyLeases,
   (response) => {
@@ -58,7 +60,9 @@ watch(
   { immediate: true }
 );
 
-// Re-fetch when period changes from parent
+// Reacts to: props.period (user-selected range from parent).
+// Side effect: setStats() fetches monthly leases for the new period. Idempotency:
+// each fire issues one fetch for the current period; the store replaces its data.
 watch(
   () => props.period,
   () => setStats()

--- a/src/modules/stats/components/LoansChart.vue
+++ b/src/modules/stats/components/LoansChart.vue
@@ -30,8 +30,10 @@ const loans = ref<{ ticker: string; loan: number }[]>([]);
 const configStore = useConfigStore();
 const statsStore = useStatsStore();
 
-// Watch both leasedAssets and configStore.initialized — currency names
-// require the config store to be populated for friendly name resolution
+// Reacts to: statsStore.leasedAssets (polled) + configStore.initialized — currency
+// names require the config store populated for friendly-name resolution.
+// Idempotency: processLeasedAssets() rebuilds the local list from the current items
+// each fire; safe on the immediate run and re-fires.
 watch(
   [() => statsStore.leasedAssets, () => configStore.initialized],
   ([items]) => {

--- a/src/modules/stats/components/LoansProvided.vue
+++ b/src/modules/stats/components/LoansProvided.vue
@@ -47,6 +47,9 @@ const openPositionValue = computed(() => statsStore.loansStats.openPositionValue
 const openInterest = computed(() => statsStore.loansStats.openInterest?.open_interest ?? "0");
 const loading = computed(() => statsStore.loansStatsLoading && !statsStore.hasLoansStats);
 
+// Reacts to: configStore.initialized.
+// Idempotency: the `!statsStore.initialized` guard means initialize() runs at most
+// once; the immediate run handles the already-initialized case.
 watch(
   () => configStore.initialized,
   () => {

--- a/src/modules/stats/components/Overview.vue
+++ b/src/modules/stats/components/Overview.vue
@@ -129,6 +129,9 @@ const realized_pnl = computed(() => statsStore.overview.realizedPnlStats);
 const protocolRevenue = computed(() => statsStore.overview.revenue);
 const loading = computed(() => statsStore.overviewLoading && !statsStore.hasOverviewData);
 
+// Reacts to: configStore.initialized.
+// Idempotency: the `!statsStore.initialized` guard means initialize() runs at most
+// once; the immediate run handles the already-initialized case.
 watch(
   () => configStore.initialized,
   () => {

--- a/src/modules/stats/components/SupplyBorrowedChart.vue
+++ b/src/modules/stats/components/SupplyBorrowedChart.vue
@@ -45,7 +45,9 @@ const i18n = useI18n();
 const chart = ref<typeof Chart>();
 const statsStore = useStatsStore();
 
-// Watch for supplyBorrowHistory changes from store
+// Reacts to: statsStore.supplyBorrowHistory (polled store data).
+// Idempotency: rebuilds the local series from the response each fire and repaints
+// the chart; safe to re-fire.
 watch(
   () => statsStore.supplyBorrowHistory,
   (response) => {
@@ -63,7 +65,9 @@ watch(
   { immediate: true }
 );
 
-// Re-fetch when period changes from parent
+// Reacts to: props.period (user-selected range from parent).
+// Side effect: loadData() fetches supply/borrow history for the new period.
+// Idempotency: each fire issues one fetch for the current period.
 watch(
   () => props.period,
   () => loadData()

--- a/src/modules/vote/components/VoteDialog.vue
+++ b/src/modules/vote/components/VoteDialog.vue
@@ -144,6 +144,13 @@ const hasDelegatedTokens = computed(() => {
   return totalStaked.isPositive();
 });
 
+// Reacts to: props.proposal (immediate). The quorum line also reads
+// props.quorumTokens, which is deliberately NOT in the dependency set — it is the
+// load-once-stable chain quorum param, so re-deriving only on a proposal change is
+// intentional (a fresh quorumTokens arriving after a dialog is already open would
+// not refresh quorum; tracked as a follow-up on #184).
+// Idempotency: voting-period flag, description, and quorum are pure derivations of
+// the current props; safe on the immediate run and re-fires.
 watch(
   () => props.proposal,
   async () => {
@@ -155,6 +162,9 @@ watch(
   { immediate: true }
 );
 
+// Reacts to: props.bondedTokens + props.proposal.tally.
+// Idempotency: recomputes turnout from the current props (zero-bonded guard returns
+// "0"); pure derivation, safe to re-fire.
 watch(
   () => [props.bondedTokens, props.proposal.tally],
   () => {

--- a/src/modules/vote/components/VoteDialog.vue
+++ b/src/modules/vote/components/VoteDialog.vue
@@ -148,7 +148,7 @@ const hasDelegatedTokens = computed(() => {
 // props.quorumTokens, which is deliberately NOT in the dependency set — it is the
 // load-once-stable chain quorum param, so re-deriving only on a proposal change is
 // intentional (a fresh quorumTokens arriving after a dialog is already open would
-// not refresh quorum; tracked as a follow-up on #184).
+// not refresh quorum; tracked in #231).
 // Idempotency: voting-period flag, description, and quorum are pure derivations of
 // the current props; safe on the immediate run and re-fires.
 watch(

--- a/src/modules/vote/view.vue
+++ b/src/modules/vote/view.vue
@@ -75,6 +75,9 @@ const { fetchGovernanceProposals, fetchProposalData, fetchData, LOAD_TIMEOUT, li
 const { loadBondedTokens, bondedTokens } = useLoadBondedTokens();
 const { loadTallying, quorum } = useLoadTallying();
 
+// Reacts to: configStore.initialized.
+// Idempotency: onInit() runs a Promise.allSettled over the proposal / bonded-token
+// / tally fetches, each safe to repeat; the immediate run performs the initial load.
 watch(
   () => configStore.initialized,
   () => {


### PR DESCRIPTION
## Summary

Add a dependency-set + idempotency-rule header above every watcher that consumes externally-driven state (wallet connection, network selection, route params, polled store data, parent props), mirroring the documented contract above the `protocolFilter` watcher in `common/stores/config/index.ts`. Closes #184. Comment-only — no behaviour change.

## Changes

Headers added to ~19 external-state watchers across 13 files:

- `assets/components/{SwapForm,SendForm,ReceiveForm}.vue` — `initialized`+`protocolFilter` repopulate, debounced route fetch, address validation.
- `leases/components/SingleLease.vue` — route-id fetch; terminal-status redirect (side-effecting).
- `stake/view.vue` — wallet-address vested-token load.
- `history/components/History.vue` — config-init load; wallet-change reset+reload (side-effecting).
- `vote/view.vue`, `vote/components/VoteDialog.vue` — config-init load; proposal/tally derivations.
- `stats/components/{Overview,LoansProvided,LoansChart,LeasesMonthlyChart,SupplyBorrowedChart}.vue` — config-init initialize and polled-data chart rebuilds, period-change refetches.

Side-effecting watchers (navigation / store mutation) carry an explicit `Side effect:` line.

## Verification

- Ran `npm run lint`, `npm run format:check` — clean.
- Ran `npm test` — 840 tests pass across 54 files.
- Ran `npm run build` (production) — succeeds.
- Confirmed every hunk is comment-only: no `watch` source, callback body, or `immediate` option changed.
- Read each watcher body to confirm its header is accurate (dependency set matches the source; idempotency claim matches the callback).

## Follow-ups

- `VoteDialog.vue` proposal watcher derives `quorum` from `props.quorumTokens` but does not watch it. `quorumTokens` is the load-once-stable chain quorum param, so this is latent (only a fresh value arriving after a dialog is already open would show stale quorum). Documented inline; widening the watch source is a small logic change left out of this docs-only PR.