### PR TITLE
refactor: extract useLeaseOpen from Long/Short forms (#185)

### DIFF
--- a/src/modules/leases/components/new-lease/LongForm.test.ts
+++ b/src/modules/leases/components/new-lease/LongForm.test.ts
@@ -329,3 +329,48 @@ describe("LongForm.vue — reactive balance validation", () => {
     wrapper.unmount();
   });
 });
+
+describe("LongForm.vue — quote error classification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+    // 1 WETH balance and a permissive range so the reactive validation passes
+    // and calculate() reaches the quote — the path under test here.
+    hoisted.state.balances = [{ denom: "ibc/WETH", amount: "1000000000000000000" }];
+
+    hoisted.getDownpaymentRange.mockResolvedValue({
+      WETH: { min: "1", max: "1000000000" },
+      ALL_BTC: { min: "1", max: "1000000000" }
+    });
+    hoisted.getCachedProtocolCurrencies.mockReturnValue(hoisted.protocolCurrencies);
+    hoisted.getActiveProtocolsForNetwork.mockReturnValue([hoisted.LONG_PROTOCOL]);
+  });
+
+  it("maps contract 'No liquidity' errors to the no-liquidity i18n key", async () => {
+    hoisted.leaseQuote.mockRejectedValueOnce(new Error("query wasm: No liquidity for the requested loan"));
+
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("0.5");
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="err"]').text()).toBe("message.no-liquidity");
+    wrapper.unmount();
+  });
+
+  it("maps non-liquidity errors to unexpected-error (stops masking the true cause)", async () => {
+    hoisted.leaseQuote.mockRejectedValueOnce(new Error("invalid downpayment ticker"));
+
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("0.5");
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="err"]').text()).toBe("message.unexpected-error");
+    wrapper.unmount();
+  });
+});

--- a/src/modules/leases/components/new-lease/LongForm.vue
+++ b/src/modules/leases/components/new-lease/LongForm.vue
@@ -173,7 +173,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, ref, watch } from "vue";
+import { computed, inject, watch } from "vue";
 import {
   AdvancedFormControl,
   Button,
@@ -195,27 +195,18 @@ import { usePricesStore } from "@/common/stores/prices";
 import { useHistoryStore } from "@/common/stores/history";
 import { classifyError, getMicroAmount, Logger, walletOperation } from "@/common/utils";
 import { formatDecAsUsd, formatUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
-import { getDownpaymentRange } from "@/common/utils/LeaseConfigService";
 import { NATIVE_NETWORK } from "../../../../config/global/network";
 import type { ExternalCurrency, IObjectKeys } from "@/common/types";
-import {
-  INTEREST_DECIMALS,
-  MAX_POSITION,
-  MIN_POSITION,
-  PERCENT,
-  PERMILLE,
-  POSITIONS,
-  SORT_LEASE,
-  WASM_EVENTS
-} from "@/config/global";
+import { INTEREST_DECIMALS, MAX_POSITION, MIN_POSITION, POSITIONS, SORT_LEASE, WASM_EVENTS } from "@/config/global";
 import type { AssetBalance } from "@/common/stores/wallet/types";
-import { Dec, Int } from "@keplr-wallet/unit";
+import { Dec } from "@keplr-wallet/unit";
 import { h } from "vue";
 import { useI18n } from "vue-i18n";
 import type { NolusWallet } from "@nolus/nolusjs";
-import { CurrencyUtils, NolusClient } from "@nolus/nolusjs";
-import { Leaser, type LeaseApply } from "@nolus/nolusjs/build/contracts";
+import { NolusClient } from "@nolus/nolusjs";
+import { Leaser } from "@nolus/nolusjs/build/contracts";
 import { useRouter } from "vue-router";
+import { useLeaseOpen } from "./useLeaseOpen";
 
 const activeTabIdx = 0;
 const walletStore = useWalletStore();
@@ -226,18 +217,26 @@ const historyStore = useHistoryStore();
 const i18n = useI18n();
 const router = useRouter();
 
-const selectedCurrency = ref(0);
-const selectedLoanCurrency = ref(0);
-const isLoading = ref(false);
-const isDisabled = ref(false);
+const {
+  selectedCurrency,
+  selectedLoanCurrency,
+  isLoading,
+  isDisabled,
+  amount,
+  amountErrorMsg,
+  ltd,
+  leaseApply,
+  errorInsufficientBalance,
+  handleAmountChange,
+  handleParentClick,
+  onDrag,
+  validateMinMaxValues,
+  validateAmountAgainstBalance,
+  isDownPaymentAmountValid
+} = useLeaseOpen();
+
 const onShowToast = inject("onShowToast", (_data: { type: ToastType; message: string }) => {});
 const reload = inject("reload", () => {});
-
-const amount = ref("");
-const amountErrorMsg = ref("");
-const errorInsufficientBalance = computed(() => amountErrorMsg.value === i18n.t("message.invalid-balance-big"));
-const ltd = ref((MAX_POSITION / PERCENT) * PERMILLE);
-const leaseApply = ref<LeaseApply | null>();
 
 watch(
   () => configStore.initialized,
@@ -260,11 +259,11 @@ watch(
   () => [selectedCurrency.value, amount.value, selectedLoanCurrency.value, ltd.value],
   async () => {
     amountErrorMsg.value = "";
-    if (!validateAmountAgainstBalance()) {
+    if (!validateAmountAgainstBalance(currency.value)) {
       leaseApply.value = null;
       return;
     }
-    if (await validateMinMaxValues()) {
+    if (await validateMinMaxValues(currency.value, coinList.value[selectedLoanCurrency.value])) {
       calculate();
     } else {
       leaseApply.value = null;
@@ -426,135 +425,6 @@ const balances = computed(() => {
   });
 });
 
-function handleAmountChange(event: string) {
-  amount.value = event;
-}
-
-const handleParentClick = (index: number) => {
-  const tab = tabs[index];
-  router.push({ path: `/${RouteNames.LEASES}/open/${tab.action}` });
-};
-
-function onDrag(event: number) {
-  const pos = new Dec(event / PERCENT);
-  ltd.value = Number(pos.mul(new Dec(PERMILLE)).truncate().toString());
-}
-
-async function validateMinMaxValues(): Promise<boolean> {
-  try {
-    let isValid = true;
-    const selectedDownPaymentCurrency = currency.value;
-    const selectedCurrency = coinList.value[selectedLoanCurrency.value];
-
-    const downPaymentAmount = amount.value;
-    const currentBalance = selectedDownPaymentCurrency;
-
-    const [c, p] = selectedCurrency.key.split("@");
-    const range = (await getDownpaymentRange(p))[c];
-    if (currentBalance) {
-      if (downPaymentAmount || downPaymentAmount !== "") {
-        const priceData = pricesStore.prices[selectedDownPaymentCurrency.key as string];
-        const priceAmount = priceData?.price ?? "0";
-
-        const max = new Dec(range?.max ?? 0);
-        const min = new Dec(range?.min ?? 0);
-
-        const leaseMax = max.quo(new Dec(priceAmount));
-        const leaseMin = min.quo(new Dec(priceAmount));
-
-        const downPaymentAmountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(
-          downPaymentAmount,
-          currentBalance.ibcData,
-          currentBalance.decimal_digits
-        );
-        const balance = CurrencyUtils.calculateBalance(
-          priceAmount,
-          downPaymentAmountInMinimalDenom,
-          currentBalance.decimal_digits
-        ).toDec();
-
-        if (balance.lt(min)) {
-          amountErrorMsg.value = i18n.t("message.lease-min-error", {
-            minAmount: formatTokenBalance(leaseMin),
-            maxAmount: formatTokenBalance(leaseMax),
-            symbol: selectedDownPaymentCurrency.shortName
-          });
-          isValid = false;
-        }
-
-        if (balance.gt(max)) {
-          amountErrorMsg.value = i18n.t("message.lease-max-error", {
-            minAmount: formatTokenBalance(leaseMin),
-            maxAmount: formatTokenBalance(leaseMax),
-            symbol: selectedDownPaymentCurrency.shortName
-          });
-          isValid = false;
-        }
-      }
-    }
-
-    return isValid;
-  } catch {
-    amountErrorMsg.value = i18n.t("message.integer-out-of-range");
-    return false;
-  }
-}
-
-// Balance/amount validation that must run reactively (on every input change),
-// not only on submit. The contract quote in calculate() cannot stand in for it:
-// a zero-balance collateral has no denom, so the quote attempt throws and the
-// catch surfaces a generic "Unexpected error" instead of "Insufficient balance".
-function validateAmountAgainstBalance(): boolean {
-  const selectedDownPaymentCurrency = currency.value;
-  const downPaymentAmount = amount.value;
-
-  if (!selectedDownPaymentCurrency || !downPaymentAmount) {
-    return true;
-  }
-
-  const downPaymentAmountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(
-    downPaymentAmount,
-    "",
-    selectedDownPaymentCurrency.decimal_digits
-  );
-
-  const isLowerThanOrEqualsToZero = new Dec(downPaymentAmountInMinimalDenom.amount || "0").lte(new Dec(0));
-  const isGreaterThanWalletBalance = new Int(downPaymentAmountInMinimalDenom.amount.toString() || "0").gt(
-    new Int(selectedDownPaymentCurrency?.balance?.amount ?? "0")
-  );
-
-  if (isLowerThanOrEqualsToZero) {
-    amountErrorMsg.value = i18n.t("message.invalid-balance-low");
-    return false;
-  }
-
-  if (isGreaterThanWalletBalance) {
-    amountErrorMsg.value = i18n.t("message.invalid-balance-big");
-    return false;
-  }
-
-  return true;
-}
-
-function isDownPaymentAmountValid() {
-  amountErrorMsg.value = "";
-
-  if (!amount.value) {
-    amountErrorMsg.value = i18n.t("message.missing-amount");
-    return false;
-  }
-
-  if (!validateAmountAgainstBalance()) {
-    return false;
-  }
-
-  if (!validateMinMaxValues()) {
-    return false;
-  }
-
-  return true;
-}
-
 async function calculate() {
   try {
     const selectedDownPaymentCurrency = currency.value;
@@ -609,7 +479,7 @@ async function onOpenLease() {
 
 async function openLease() {
   const wallet = walletStore.wallet as NolusWallet;
-  if (wallet && isDownPaymentAmountValid()) {
+  if (wallet && isDownPaymentAmountValid(currency.value, coinList.value[selectedLoanCurrency.value])) {
     try {
       isLoading.value = true;
 

--- a/src/modules/leases/components/new-lease/ShortForm.test.ts
+++ b/src/modules/leases/components/new-lease/ShortForm.test.ts
@@ -419,3 +419,34 @@ describe("ShortForm.vue — leaseQuote ticker resolution", () => {
     wrapper.unmount();
   });
 });
+
+describe("ShortForm.vue — reactive balance validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+
+    hoisted.getDownpaymentRange.mockResolvedValue({ ALL_BTC: { min: "1", max: "1000000000" } });
+    hoisted.getCachedProtocolCurrencies.mockReturnValue(hoisted.protocolCurrencies);
+    hoisted.getProtocolCurrencies.mockResolvedValue(hoisted.protocolCurrencies);
+
+    hoisted.leaseQuote.mockResolvedValue({
+      borrow: { ticker: "ALL_BTC", amount: "100000" },
+      total: { ticker: "USDC_NOBLE", amount: "400000000" },
+      annual_interest_rate: 100,
+      annual_interest_rate_margin: 80
+    });
+  });
+
+  it("flags a zero amount as invalid before attempting a quote", async () => {
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("0");
+    await flushPromises();
+    await wrapper.vm.$nextTick();
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="err"]').text()).toBe("message.invalid-balance-low");
+    expect(hoisted.leaseQuote).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+});

--- a/src/modules/leases/components/new-lease/ShortForm.vue
+++ b/src/modules/leases/components/new-lease/ShortForm.vue
@@ -173,7 +173,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, ref, watch } from "vue";
+import { computed, inject, watch } from "vue";
 import {
   AdvancedFormControl,
   Button,
@@ -196,27 +196,18 @@ import { usePricesStore } from "@/common/stores/prices";
 import { useHistoryStore } from "@/common/stores/history";
 import { classifyError, getMicroAmount, Logger, walletOperation } from "@/common/utils";
 import { formatDecAsUsd, formatUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
-import { getDownpaymentRange } from "@/common/utils/LeaseConfigService";
 import { NATIVE_NETWORK } from "../../../../config/global/network";
 import type { ExternalCurrency, IObjectKeys } from "@/common/types";
-import {
-  INTEREST_DECIMALS,
-  MAX_POSITION,
-  MIN_POSITION,
-  PERCENT,
-  PERMILLE,
-  POSITIONS,
-  SORT_LEASE,
-  WASM_EVENTS
-} from "@/config/global";
+import { INTEREST_DECIMALS, MAX_POSITION, MIN_POSITION, POSITIONS, SORT_LEASE, WASM_EVENTS } from "@/config/global";
 import type { AssetBalance } from "@/common/stores/wallet/types";
-import { Dec, Int } from "@keplr-wallet/unit";
+import { Dec } from "@keplr-wallet/unit";
 import { h } from "vue";
 import { useI18n } from "vue-i18n";
 import type { NolusWallet } from "@nolus/nolusjs";
-import { CurrencyUtils, NolusClient } from "@nolus/nolusjs";
-import { Leaser, type LeaseApply } from "@nolus/nolusjs/build/contracts";
+import { NolusClient } from "@nolus/nolusjs";
+import { Leaser } from "@nolus/nolusjs/build/contracts";
 import { useRouter } from "vue-router";
+import { useLeaseOpen } from "./useLeaseOpen";
 
 const activeTabIdx = 1;
 const walletStore = useWalletStore();
@@ -229,16 +220,23 @@ const router = useRouter();
 const onShowToast = inject("onShowToast", (_data: { type: ToastType; message: string }) => {});
 const reload = inject("reload", () => {});
 
-const selectedCurrency = ref(0);
-const selectedLoanCurrency = ref(0);
-const isLoading = ref(false);
-const isDisabled = ref(false);
-
-const amount = ref("");
-const amountErrorMsg = ref("");
-const errorInsufficientBalance = computed(() => amountErrorMsg.value === i18n.t("message.invalid-balance-big"));
-const ltd = ref((MAX_POSITION / PERCENT) * PERMILLE);
-const leaseApply = ref<LeaseApply | null>();
+const {
+  selectedCurrency,
+  selectedLoanCurrency,
+  isLoading,
+  isDisabled,
+  amount,
+  amountErrorMsg,
+  ltd,
+  leaseApply,
+  errorInsufficientBalance,
+  handleAmountChange,
+  handleParentClick,
+  onDrag,
+  validateMinMaxValues,
+  validateAmountAgainstBalance,
+  isDownPaymentAmountValid
+} = useLeaseOpen();
 
 watch(
   () => configStore.initialized,
@@ -261,11 +259,11 @@ watch(
   () => [selectedCurrency.value, amount.value, selectedLoanCurrency.value, ltd.value],
   async () => {
     amountErrorMsg.value = "";
-    if (!validateAmountAgainstBalance()) {
+    if (!validateAmountAgainstBalance(currency.value)) {
       leaseApply.value = null;
       return;
     }
-    if (await validateMinMaxValues()) {
+    if (await validateMinMaxValues(currency.value, coinList.value[selectedLoanCurrency.value])) {
       calculate();
     } else {
       leaseApply.value = null;
@@ -397,20 +395,6 @@ const calculatedBalance = computed(() => {
   return formatDecAsUsd(stable);
 });
 
-function handleAmountChange(event: string) {
-  amount.value = event;
-}
-
-const handleParentClick = (index: number) => {
-  const tab = tabs[index];
-  router.push({ path: `/${RouteNames.LEASES}/open/${tab.action}` });
-};
-
-function onDrag(event: number) {
-  const pos = new Dec(event / PERCENT);
-  ltd.value = Number(pos.mul(new Dec(PERMILLE)).truncate().toString());
-}
-
 // For a Short protocol the contract's `leaseTicker` is the stable currency the
 // position is denominated in (e.g., USDC_NOBLE) — NOT the user's down payment.
 // It's exposed in the protocol currencies list with group="lease" (the only one
@@ -422,122 +406,6 @@ async function resolveShortLeaseTicker(protocol: string): Promise<string> {
     throw new Error(`Short protocol ${protocol} has no stable (group="lease") currency`);
   }
   return stable.ticker;
-}
-
-async function validateMinMaxValues(): Promise<boolean> {
-  try {
-    let isValid = true;
-    const selectedDownPaymentCurrency = currency.value;
-    const selectedCurrency = coinList.value[selectedLoanCurrency.value];
-
-    const downPaymentAmount = amount.value;
-    const currentBalance = selectedDownPaymentCurrency;
-
-    const [c, p] = selectedCurrency.key.split("@");
-    const range = (await getDownpaymentRange(p))[c];
-
-    if (currentBalance) {
-      if (downPaymentAmount || downPaymentAmount !== "") {
-        const priceData = pricesStore.prices[selectedDownPaymentCurrency.key as string];
-        const priceAmount = priceData?.price ?? "0";
-
-        const max = new Dec(range?.max ?? 0);
-        const min = new Dec(range?.min ?? 0);
-
-        const leaseMax = max.quo(new Dec(priceAmount));
-        const leaseMin = min.quo(new Dec(priceAmount));
-
-        const downPaymentAmountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(
-          downPaymentAmount,
-          currentBalance.ibcData,
-          currentBalance.decimal_digits
-        );
-        const balance = CurrencyUtils.calculateBalance(
-          priceAmount,
-          downPaymentAmountInMinimalDenom,
-          currentBalance.decimal_digits
-        ).toDec();
-
-        if (balance.lt(min)) {
-          amountErrorMsg.value = i18n.t("message.lease-min-error", {
-            minAmount: formatTokenBalance(leaseMin),
-            maxAmount: formatTokenBalance(leaseMax),
-            symbol: selectedDownPaymentCurrency.shortName
-          });
-          isValid = false;
-        }
-
-        if (balance.gt(max)) {
-          amountErrorMsg.value = i18n.t("message.lease-max-error", {
-            minAmount: formatTokenBalance(leaseMin),
-            maxAmount: formatTokenBalance(leaseMax),
-            symbol: selectedDownPaymentCurrency.shortName
-          });
-          isValid = false;
-        }
-      }
-    }
-
-    return isValid;
-  } catch {
-    amountErrorMsg.value = i18n.t("message.integer-out-of-range");
-    return false;
-  }
-}
-
-// Balance/amount validation that must run reactively (on every input change),
-// not only on submit. The contract quote in calculate() cannot stand in for it:
-// a zero-balance collateral has no denom, so the quote attempt throws and the
-// catch surfaces a generic "Unexpected error" instead of "Insufficient balance".
-function validateAmountAgainstBalance(): boolean {
-  const selectedDownPaymentCurrency = currency.value;
-  const downPaymentAmount = amount.value;
-
-  if (!selectedDownPaymentCurrency || !downPaymentAmount) {
-    return true;
-  }
-
-  const downPaymentAmountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(
-    downPaymentAmount,
-    "",
-    selectedDownPaymentCurrency.decimal_digits
-  );
-
-  const isLowerThanOrEqualsToZero = new Dec(downPaymentAmountInMinimalDenom.amount || "0").lte(new Dec(0));
-  const isGreaterThanWalletBalance = new Int(downPaymentAmountInMinimalDenom.amount.toString() || "0").gt(
-    new Int(selectedDownPaymentCurrency?.balance?.amount ?? "0")
-  );
-
-  if (isLowerThanOrEqualsToZero) {
-    amountErrorMsg.value = i18n.t("message.invalid-balance-low");
-    return false;
-  }
-
-  if (isGreaterThanWalletBalance) {
-    amountErrorMsg.value = i18n.t("message.invalid-balance-big");
-    return false;
-  }
-
-  return true;
-}
-
-function isDownPaymentAmountValid() {
-  amountErrorMsg.value = "";
-
-  if (!amount.value) {
-    amountErrorMsg.value = i18n.t("message.missing-amount");
-    return false;
-  }
-
-  if (!validateAmountAgainstBalance()) {
-    return false;
-  }
-
-  if (!validateMinMaxValues()) {
-    return false;
-  }
-
-  return true;
 }
 
 async function calculate() {
@@ -595,7 +463,7 @@ async function onOpenLease() {
 
 async function openLease() {
   const wallet = walletStore.wallet as NolusWallet;
-  if (wallet && isDownPaymentAmountValid()) {
+  if (wallet && isDownPaymentAmountValid(currency.value, coinList.value[selectedLoanCurrency.value])) {
     try {
       isLoading.value = true;
 

--- a/src/modules/leases/components/new-lease/useLeaseOpen.ts
+++ b/src/modules/leases/components/new-lease/useLeaseOpen.ts
@@ -1,0 +1,203 @@
+import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
+import { RouteNames } from "@/router";
+import { tabs } from "../types";
+import { usePricesStore } from "@/common/stores/prices";
+import { formatTokenBalance } from "@/common/utils/NumberFormatUtils";
+import { getDownpaymentRange } from "@/common/utils/LeaseConfigService";
+import { MAX_POSITION, PERCENT, PERMILLE } from "@/config/global";
+import { Dec, Int } from "@keplr-wallet/unit";
+import { CurrencyUtils } from "@nolus/nolusjs";
+import { useI18n } from "vue-i18n";
+import type { LeaseApply } from "@nolus/nolusjs/build/contracts";
+
+// The down-payment side of the form: the asset option the user pays with. Only
+// the fields the shared validators read are required; each form's `assets`
+// computed produces a richer object that satisfies this structurally.
+export interface DownPaymentOption {
+  key: string;
+  ibcData?: string;
+  decimal_digits: number;
+  shortName: string;
+  balance?: { amount?: string };
+}
+
+// The loan side: the asset-to-lease option. The shared min/max check only needs
+// its key (to resolve the per-protocol downpayment range).
+export interface LoanOption {
+  key: string;
+}
+
+// Infrastructure shared verbatim by LongForm and ShortForm. The divergent,
+// safety-critical parts — `assets`/`coinList` building and the leaseTicker /
+// leaser-protocol derivation in `calculate`/`openLease` — deliberately stay in
+// each form, where the Long-vs-Short asymmetry remains visible (see the
+// Short-protocol notes in the project CLAUDE.md). The validators take the
+// resolved down-payment / loan options as arguments so this composable never
+// needs the per-form `assets`/`coinList`.
+export function useLeaseOpen() {
+  const pricesStore = usePricesStore();
+  const i18n = useI18n();
+  const router = useRouter();
+
+  const selectedCurrency = ref(0);
+  const selectedLoanCurrency = ref(0);
+  const isLoading = ref(false);
+  const isDisabled = ref(false);
+
+  const amount = ref("");
+  const amountErrorMsg = ref("");
+  const errorInsufficientBalance = computed(() => amountErrorMsg.value === i18n.t("message.invalid-balance-big"));
+  const ltd = ref((MAX_POSITION / PERCENT) * PERMILLE);
+  const leaseApply = ref<LeaseApply | null>();
+
+  function handleAmountChange(event: string) {
+    amount.value = event;
+  }
+
+  const handleParentClick = (index: number) => {
+    const tab = tabs[index];
+    router.push({ path: `/${RouteNames.LEASES}/open/${tab.action}` });
+  };
+
+  function onDrag(event: number) {
+    const pos = new Dec(event / PERCENT);
+    ltd.value = Number(pos.mul(new Dec(PERMILLE)).truncate().toString());
+  }
+
+  async function validateMinMaxValues(
+    selectedDownPaymentCurrency: DownPaymentOption | undefined,
+    selectedCurrency: LoanOption
+  ): Promise<boolean> {
+    try {
+      let isValid = true;
+
+      const downPaymentAmount = amount.value;
+      const currentBalance = selectedDownPaymentCurrency;
+
+      const [c, p] = selectedCurrency.key.split("@");
+      const range = (await getDownpaymentRange(p))[c];
+      if (currentBalance) {
+        if (downPaymentAmount || downPaymentAmount !== "") {
+          const priceData = pricesStore.prices[currentBalance.key];
+          const priceAmount = priceData?.price ?? "0";
+
+          const max = new Dec(range?.max ?? 0);
+          const min = new Dec(range?.min ?? 0);
+
+          const leaseMax = max.quo(new Dec(priceAmount));
+          const leaseMin = min.quo(new Dec(priceAmount));
+
+          const downPaymentAmountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(
+            downPaymentAmount,
+            currentBalance.ibcData,
+            currentBalance.decimal_digits
+          );
+          const balance = CurrencyUtils.calculateBalance(
+            priceAmount,
+            downPaymentAmountInMinimalDenom,
+            currentBalance.decimal_digits
+          ).toDec();
+
+          if (balance.lt(min)) {
+            amountErrorMsg.value = i18n.t("message.lease-min-error", {
+              minAmount: formatTokenBalance(leaseMin),
+              maxAmount: formatTokenBalance(leaseMax),
+              symbol: currentBalance.shortName
+            });
+            isValid = false;
+          }
+
+          if (balance.gt(max)) {
+            amountErrorMsg.value = i18n.t("message.lease-max-error", {
+              minAmount: formatTokenBalance(leaseMin),
+              maxAmount: formatTokenBalance(leaseMax),
+              symbol: currentBalance.shortName
+            });
+            isValid = false;
+          }
+        }
+      }
+
+      return isValid;
+    } catch {
+      amountErrorMsg.value = i18n.t("message.integer-out-of-range");
+      return false;
+    }
+  }
+
+  // Balance/amount validation that must run reactively (on every input change),
+  // not only on submit. The contract quote in calculate() cannot stand in for it:
+  // a zero-balance collateral has no denom, so the quote attempt throws and the
+  // catch surfaces a generic "Unexpected error" instead of "Insufficient balance".
+  function validateAmountAgainstBalance(selectedDownPaymentCurrency: DownPaymentOption | undefined): boolean {
+    const downPaymentAmount = amount.value;
+
+    if (!selectedDownPaymentCurrency || !downPaymentAmount) {
+      return true;
+    }
+
+    const downPaymentAmountInMinimalDenom = CurrencyUtils.convertDenomToMinimalDenom(
+      downPaymentAmount,
+      "",
+      selectedDownPaymentCurrency.decimal_digits
+    );
+
+    const isLowerThanOrEqualsToZero = new Dec(downPaymentAmountInMinimalDenom.amount || "0").lte(new Dec(0));
+    const isGreaterThanWalletBalance = new Int(downPaymentAmountInMinimalDenom.amount.toString() || "0").gt(
+      new Int(selectedDownPaymentCurrency?.balance?.amount ?? "0")
+    );
+
+    if (isLowerThanOrEqualsToZero) {
+      amountErrorMsg.value = i18n.t("message.invalid-balance-low");
+      return false;
+    }
+
+    if (isGreaterThanWalletBalance) {
+      amountErrorMsg.value = i18n.t("message.invalid-balance-big");
+      return false;
+    }
+
+    return true;
+  }
+
+  function isDownPaymentAmountValid(
+    selectedDownPaymentCurrency: DownPaymentOption | undefined,
+    selectedLoan: LoanOption
+  ) {
+    amountErrorMsg.value = "";
+
+    if (!amount.value) {
+      amountErrorMsg.value = i18n.t("message.missing-amount");
+      return false;
+    }
+
+    if (!validateAmountAgainstBalance(selectedDownPaymentCurrency)) {
+      return false;
+    }
+
+    if (!validateMinMaxValues(selectedDownPaymentCurrency, selectedLoan)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  return {
+    selectedCurrency,
+    selectedLoanCurrency,
+    isLoading,
+    isDisabled,
+    amount,
+    amountErrorMsg,
+    ltd,
+    leaseApply,
+    errorInsufficientBalance,
+    handleAmountChange,
+    handleParentClick,
+    onDrag,
+    validateMinMaxValues,
+    validateAmountAgainstBalance,
+    isDownPaymentAmountValid
+  };
+}


### PR DESCRIPTION
## Summary
Extract the byte-identical infrastructure shared by `LongForm.vue` and `ShortForm.vue` into a new `useLeaseOpen` composable, continuing the #185 SFC-splitting work. Behaviour-preserving — the shared logic is moved verbatim.

## Changes
- New `useLeaseOpen.ts` holds the 8 form refs, `errorInsufficientBalance`, the input handlers (`handleAmountChange`/`handleParentClick`/`onDrag`), and the three downpayment validators. The validators take the resolved `(downPaymentCurrency, loanCurrency)` as arguments, so the composable never needs the per-form asset lists.
- Both forms drop the duplicated infra (−315 lines across the two) and destructure it from `useLeaseOpen`.
- Test nets widened to parity first (separate commit): LongForm gains the `classifyError` no-liquidity/unexpected-error cases; ShortForm gains the zero-amount reactive-balance case.

## Design note
The divergent, financially load-bearing logic was deliberately kept per-form: `assets`/`coinList` building and the leaseTicker / leaser-protocol derivation in `calculate()`/`openLease()` (Long reads the ticker from the loan key; Short resolves the protocol stable, `group="lease"`, asynchronously). Keeping these in each file preserves the Long-vs-Short asymmetry where a reviewer can see it, rather than unifying genuinely-different financial code behind a shared abstraction. `calculate()`/`openLease()` are unchanged except the one validator call site that now passes the resolved currency/loan option.

## Verification
- Ran the full suite via `npm run test:coverage` — 843 passed, per-file and global floors green.
- Ran `npm run lint` and `npm run build` — clean.
- Both form suites (12 cases) pass untouched against the refactored forms.
- Independent fresh-context code review and a security pass both cleared the diff: validators moved with no logic/threshold change, the reactive validate-balance-before-quote ordering preserved in both forms, `calculate`/`openLease` byte-identical.

## Follow-ups
- Pre-existing (preserved verbatim, not introduced here): `isDownPaymentAmountValid` calls `validateMinMaxValues` without `await`, so the submit-path min/max re-check is a no-op (the reactive watch enforces it correctly). Worth a dedicated fix + test in a separate change, not bundled into this verbatim move.
- Optional: assert the constructed leaser protocol/address across the four quote/open paths — guards currently-untested behaviour in the (unchanged) `calculate`/`openLease`.