### PR TITLE
fix(swap): drop SkipRouter.getChains cache on rejection

### DIFF
--- a/src/common/utils/SkipRoute.test.ts
+++ b/src/common/utils/SkipRoute.test.ts
@@ -458,6 +458,50 @@ describe("SkipRouter.submitRoute / transaction()", () => {
   });
 });
 
+describe("SkipRouter.getChains — caching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the private static caches between tests.
+    (SkipRouter as unknown as { chains: unknown }).chains = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    (SkipRouter as unknown as { chains: unknown }).chains = undefined;
+    (SkipRouter as unknown as { client: unknown }).client = undefined;
+  });
+
+  function stubClient(getChainsImpl: ReturnType<typeof vi.fn>) {
+    // Pre-seed the resolved client so getClient() returns it without a network call.
+    (SkipRouter as unknown as { client: unknown }).client = { getChains: getChainsImpl };
+  }
+
+  it("memoizes a successful fetch — the underlying client is called once", async () => {
+    const getChainsImpl = vi.fn().mockResolvedValue([{ chain_id: "nolus-1" }]);
+    stubClient(getChainsImpl);
+
+    const first = await SkipRouter.getChains();
+    const second = await SkipRouter.getChains();
+
+    expect(first).toBe(second);
+    expect(getChainsImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops the cache on rejection so a later call retries instead of replaying the failure", async () => {
+    const getChainsImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("chains fetch failed"))
+      .mockResolvedValueOnce([{ chain_id: "nolus-1" }]);
+    stubClient(getChainsImpl);
+
+    await expect(SkipRouter.getChains()).rejects.toThrow("chains fetch failed");
+
+    const chains = await SkipRouter.getChains();
+    expect(chains).toEqual([{ chain_id: "nolus-1" }]);
+    expect(getChainsImpl).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("SkipRouter.fetchStatus", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/common/utils/SkipRoute.ts
+++ b/src/common/utils/SkipRoute.ts
@@ -83,7 +83,7 @@ class Swap {
 export class SkipRouter {
   private static client: Swap;
   private static chainId: string;
-  private static chains: Promise<Chain[]>;
+  private static chains: Promise<Chain[]> | undefined;
 
   static async getClient(): Promise<Swap> {
     if (SkipRouter.client) {
@@ -297,11 +297,18 @@ export class SkipRouter {
   }
 
   static async getChains() {
-    if (SkipRouter.chains) {
+    if (SkipRouter.chains !== undefined) {
       return SkipRouter.chains;
     }
     const client = await SkipRouter.getClient();
-    SkipRouter.chains = client.getChains();
+    // Cache the in-flight promise to dedupe concurrent callers, but drop it on
+    // rejection so a failed fetch doesn't poison the cache permanently — a
+    // retry must be able to re-issue the request (see "Cache services" in the
+    // project CLAUDE.md).
+    SkipRouter.chains = client.getChains().catch((error: unknown) => {
+      SkipRouter.chains = undefined;
+      throw error;
+    });
     return SkipRouter.chains;
   }
 


### PR DESCRIPTION
## Summary
`SkipRouter.getChains()` cached the unresolved promise returned by `client.getChains()`. If that fetch rejected, the rejected promise stayed in the static cache permanently — every later caller replayed the same rejection and swap routing stayed broken until a page reload. Now the cached promise carries a `.catch` that clears the entry on failure, so a retry can re-issue the request; the cache-hit check is an explicit `!== undefined` comparison. Success-path memoization is unchanged.

This is the one genuine defect surfaced while triaging the promise-misuse sites in #238. The other 21 flagged sites are intentional async callbacks (`setTimeout`/`setInterval`/`watch`/`addEventListener`/`toBlob`/`waitUntil`/`useWalletWatcher`), not bugs — they belong to the follow-up that enables the two promise lint rules.

## Changes
- `SkipRoute.ts` — `getChains()` drops the cache on rejection; `chains` field typed `Promise<Chain[]> | undefined`.
- `SkipRoute.test.ts` — two cases: success memoizes to a single underlying call; a rejection clears the cache so the next call retries.

## Verification
- Ran the full pr-validate gate locally: lint, format:check, test:coverage (879 tests pass), build — all green.
- New tests fail against the pre-fix code (the rejected promise is replayed) and pass after the fix.

## Follow-ups
- #238 remains open for the durable prevention: enable `@typescript-eslint/no-floating-promises` + `no-misused-promises` and resolve the ~112 floating-promise sites. The dead-guard half of #238 already shipped in #239.