### PR TITLE
chore(lint): enable promise lint rules and clear the backlog

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -107,6 +107,8 @@ export default tseslint.config(
       eqeqeq: ["error", "always", { null: "ignore" }],
       "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "separate-type-imports" }],
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": ["error", { checksConditionals: true, checksVoidReturn: true }],
       "no-console": ["error", { allow: ["warn", "error"] }],
 
       "vue/multi-word-component-names": "off"

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,7 +37,7 @@ BackendApi.onRateLimited = () => {
 };
 
 onMounted(() => {
-  initWorker();
+  void initWorker();
   const language = getCookie(LANGUAGE_KEY);
   if (!language) {
     const locale = i18n.locale.value;

--- a/src/common/api/WebSocketClient.test.ts
+++ b/src/common/api/WebSocketClient.test.ts
@@ -355,7 +355,7 @@ describe("WebSocketClientImpl", () => {
       callback.mockClear();
       unsubscribe();
 
-      client.connect();
+      void client.connect();
       expect(callback).not.toHaveBeenCalled();
     });
   });

--- a/src/common/components/WalletInfo.vue
+++ b/src/common/components/WalletInfo.vue
@@ -130,7 +130,7 @@ function onClickDisconnect() {
 }
 
 async function onCopy() {
-  TextFormat.copyToClipboard(wallet?.wallet?.address ?? "");
+  void TextFormat.copyToClipboard(wallet?.wallet?.address ?? "");
   onShowToast({
     type: ToastType.success,
     message: i18n.t("message.address-coppied")

--- a/src/common/components/activities/TransactionDetails.vue
+++ b/src/common/components/activities/TransactionDetails.vue
@@ -179,7 +179,7 @@ const status = computed(() => {
 
 function copyHash() {
   if (data.value) {
-    TextFormat.copyToClipboard(data.value.tx_hash);
+    void TextFormat.copyToClipboard(data.value.tx_hash);
     onShowToast({ type: ToastType.success, message: i18n.t("message.tx-copied-successfully") });
   }
 }
@@ -193,7 +193,7 @@ function copyTxRaw() {
     }
 
     const params = JSON.stringify(item, (key, value) => (typeof value === "bigint" ? value.toString() : value));
-    TextFormat.copyToClipboard(params);
+    void TextFormat.copyToClipboard(params);
     onShowToast({ type: ToastType.success, message: i18n.t("message.tx-raw-copied-successfully") });
   }
 }

--- a/src/common/components/auth/Disconnect.vue
+++ b/src/common/components/auth/Disconnect.vue
@@ -100,7 +100,7 @@ function close() {
 }
 
 async function onCopy() {
-  TextFormat.copyToClipboard(wallet?.wallet?.address ?? "");
+  void TextFormat.copyToClipboard(wallet?.wallet?.address ?? "");
   onShowToast({
     type: ToastType.success,
     message: i18n.t("message.address-coppied")
@@ -110,7 +110,7 @@ async function onCopy() {
 async function onClickDisconnect() {
   try {
     close();
-    router.push({ name: RouteNames.DASHBOARD });
+    void router.push({ name: RouteNames.DASHBOARD });
     WalletStorage.eraseWalletInfo();
     wallet[WalletActions.DISCONNECT]();
     connectionStore.disconnectWallet();

--- a/src/common/composables/useBlockInfo.ts
+++ b/src/common/composables/useBlockInfo.ts
@@ -29,9 +29,9 @@ export function useBlockInfo() {
   let intervalId: ReturnType<typeof setInterval> | null = null;
 
   onMounted(() => {
-    setBlock();
-    setVersion();
-    intervalId = setInterval(setBlock, UPDATE_BLOCK_INTERVAL);
+    void setBlock();
+    void setVersion();
+    intervalId = setInterval(() => void setBlock(), UPDATE_BLOCK_INTERVAL);
   });
 
   onUnmounted(() => {

--- a/src/common/composables/useWalletEvents.ts
+++ b/src/common/composables/useWalletEvents.ts
@@ -42,6 +42,7 @@ export function useWalletEvents(): void {
   }
 
   const updateKeplr = createKeystoreListener(() => wallet.CONNECT_KEPLR());
+  const onKeystoreChange = () => void updateKeplr();
 
   async function loadNetwork() {
     try {
@@ -65,13 +66,13 @@ export function useWalletEvents(): void {
       if (wallet.wallet?.address) {
         await connectionStore.connectWallet(wallet.wallet.address);
       }
-      window.addEventListener("keplr_keystorechange", updateKeplr);
-      wallet.LOAD_APR();
+      window.addEventListener("keplr_keystorechange", onKeystoreChange);
+      void wallet.LOAD_APR();
     },
     { immediate: true }
   );
 
   onUnmounted(() => {
-    window.removeEventListener("keplr_keystorechange", updateKeplr);
+    window.removeEventListener("keplr_keystorechange", onKeystoreChange);
   });
 }

--- a/src/common/composables/useWalletWatcher.ts
+++ b/src/common/composables/useWalletWatcher.ts
@@ -2,18 +2,18 @@ import { watch } from "vue";
 import { useConnectionStore } from "@/common/stores/connection";
 
 export function useWalletWatcher(
-  onConnect: (address: string) => void,
-  onDisconnect: () => void,
-  onReconnect?: () => void
+  onConnect: (address: string) => void | Promise<void>,
+  onDisconnect: () => void | Promise<void>,
+  onReconnect?: () => void | Promise<void>
 ): void {
   const connectionStore = useConnectionStore();
   watch(
     () => connectionStore.walletAddress,
     (newAddress, oldAddress) => {
       if (newAddress && newAddress !== oldAddress) {
-        onConnect(newAddress);
+        void onConnect(newAddress);
       } else if (!newAddress && oldAddress) {
-        onDisconnect();
+        void onDisconnect();
       }
     },
     { immediate: true }
@@ -24,7 +24,7 @@ export function useWalletWatcher(
       () => connectionStore.wsReconnectCount,
       () => {
         if (connectionStore.walletAddress) {
-          onReconnect();
+          void onReconnect();
         }
       }
     );

--- a/src/common/stores/history/index.ts
+++ b/src/common/stores/history/index.ts
@@ -413,7 +413,7 @@ export const useHistoryStore = defineStore("history", () => {
   // connected will still load data (the watcher fires with current value).
   useWalletWatcher((addr) => {
     setAddress(addr);
-    loadActivities();
+    void loadActivities();
   }, cleanup);
 
   // ==========================================================================

--- a/src/common/stores/wallet/actions/connectKeplrLike.ts
+++ b/src/common/stores/wallet/actions/connectKeplrLike.ts
@@ -68,5 +68,5 @@ export async function connectKeplrLike(
     }
   }
 
-  IntercomService.load(store.wallet?.address as string, label.toLowerCase());
+  void IntercomService.load(store.wallet?.address as string, label.toLowerCase());
 }

--- a/src/common/stores/wallet/actions/connectLedger.ts
+++ b/src/common/stores/wallet/actions/connectLedger.ts
@@ -61,7 +61,7 @@ export async function connectLedger(this: Store, payload: { isBluetooth?: boolea
       }
     }
 
-    IntercomService.load(this.wallet?.address as string, "ledger");
+    void IntercomService.load(this.wallet?.address as string, "ledger");
   } finally {
     clearTimeout(to);
   }

--- a/src/common/stores/wallet/actions/connectPhantom.ts
+++ b/src/common/stores/wallet/actions/connectPhantom.ts
@@ -23,5 +23,5 @@ export async function connectPhantom(this: Store) {
   this.wallet = nolusWalletOfflineSigner;
   applyNolusWalletOverrides(this.wallet);
 
-  IntercomService.load(this.wallet.address, "phantom");
+  void IntercomService.load(this.wallet.address, "phantom");
 }

--- a/src/common/stores/wallet/actions/connectSolflare.ts
+++ b/src/common/stores/wallet/actions/connectSolflare.ts
@@ -23,5 +23,5 @@ export async function connectSolflare(this: Store) {
   this.wallet = nolusWalletOfflineSigner;
   applyNolusWalletOverrides(this.wallet);
 
-  IntercomService.load(this.wallet.address, "solflare");
+  void IntercomService.load(this.wallet.address, "solflare");
 }

--- a/src/common/stores/wallet/actions/disconnect.ts
+++ b/src/common/stores/wallet/actions/disconnect.ts
@@ -4,7 +4,7 @@ import type { Store } from "../types";
 
 export function disconnect(this: Store) {
   this.wallet = undefined;
-  IntercomService.disconnect();
+  void IntercomService.disconnect();
   // Clear the wallet-driven network filter so the next connect's first
   // watcher tick sees a fresh slate.
   applyWalletProtocolFilter(null);

--- a/src/common/utils/LanguageUtils.ts
+++ b/src/common/utils/LanguageUtils.ts
@@ -37,5 +37,5 @@ export function getLanguage(): (typeof languages)[keyof typeof languages] {
  * Store language preference in IndexedDB (for service worker/push notifications)
  */
 export function setLanguageDb(lang: string): void {
-  idbPut(LANGUAGE_KEY, lang);
+  void idbPut(LANGUAGE_KEY, lang);
 }

--- a/src/modules/assets/components/useReceiveForm.ts
+++ b/src/modules/assets/components/useReceiveForm.ts
@@ -116,7 +116,7 @@ export function useReceiveForm() {
     [() => configStore.initialized, () => configStore.protocolFilter],
     () => {
       if (configStore.initialized) {
-        onInit();
+        void onInit();
       }
     },
     {
@@ -218,12 +218,14 @@ export function useReceiveForm() {
         if (validateAmount() && wallet.value?.length > 0) {
           clearTimeout(timeOut);
           tempRoute.value = null;
-          timeOut = setTimeout(async () => {
-            try {
-              tempRoute.value = await getRoute();
-            } catch (e: unknown) {
-              amountErrorMsg.value = i18n.t(classifyError(e));
-            }
+          timeOut = setTimeout(() => {
+            void (async () => {
+              try {
+                tempRoute.value = await getRoute();
+              } catch (e: unknown) {
+                amountErrorMsg.value = i18n.t(classifyError(e));
+              }
+            })();
           });
         }
       }
@@ -404,7 +406,7 @@ export function useReceiveForm() {
           await submit(wallets);
           await balancesStore.fetchBalances();
 
-          historyStore.loadActivities();
+          void historyStore.loadActivities();
           step.value = CONFIRM_STEP.SUCCESS;
           walletStore.history[id].historyData.route.activeStep = walletStore.history[id].historyData.route.steps.length;
           walletStore.history[id].historyData.routeDetails.activeStep =

--- a/src/modules/assets/components/useSendForm.ts
+++ b/src/modules/assets/components/useSendForm.ts
@@ -149,7 +149,7 @@ export function useSendForm() {
     [() => configStore.initialized, () => configStore.protocolFilter],
     () => {
       if (configStore.initialized) {
-        onInit();
+        void onInit();
       }
     },
     {
@@ -240,12 +240,14 @@ export function useSendForm() {
         if (validateAmount() && wallet.value?.length > 0) {
           clearTimeout(timeOut);
           tempRoute.value = null;
-          timeOut = setTimeout(async () => {
-            try {
-              tempRoute.value = await getRoute();
-            } catch (e: unknown) {
-              amountErrorMsg.value = i18n.t(classifyError(e));
-            }
+          timeOut = setTimeout(() => {
+            void (async () => {
+              try {
+                tempRoute.value = await getRoute();
+              } catch (e: unknown) {
+                amountErrorMsg.value = i18n.t(classifyError(e));
+              }
+            })();
           });
         }
       }
@@ -408,14 +410,14 @@ export function useSendForm() {
     if (network.value.native) {
       return onSubmitNative();
     }
-    onSubmitCosmos();
+    void onSubmitCosmos();
   }
 
   function onSubmitNative() {
     const isValid = validateAmount() && validateAddress(receiverAddress.value).length === 0;
 
     if (isValid) {
-      onSwap();
+      void onSwap();
     }
   }
 
@@ -502,7 +504,7 @@ export function useSendForm() {
         }
       }
 
-      historyStore.loadActivities();
+      void historyStore.loadActivities();
       onClose();
     } catch (e: unknown) {
       amountErrorMsg.value = i18n.t(classifyError(e));
@@ -538,7 +540,7 @@ export function useSendForm() {
           await submit(wallets);
           await balancesStore.fetchBalances();
 
-          historyStore.loadActivities();
+          void historyStore.loadActivities();
 
           step.value = CONFIRM_STEP.SUCCESS;
           walletStore.history[id].historyData.route.activeStep = walletStore.history[id].historyData.route.steps.length;

--- a/src/modules/assets/components/useSwapForm.ts
+++ b/src/modules/assets/components/useSwapForm.ts
@@ -147,7 +147,7 @@ export function useSwapForm() {
     [() => configStore.initialized, () => configStore.protocolFilter],
     () => {
       if (configStore.initialized) {
-        onInit();
+        void onInit();
       }
     },
     {
@@ -183,7 +183,7 @@ export function useSwapForm() {
       selectedFirstCurrencyOption.value = firstCurrency;
       selectedSecondCurrencyOption.value = secondCurrency;
 
-      setSwapFee();
+      void setSwapFee();
     } catch (error) {
       Logger.error(error);
     }
@@ -291,7 +291,7 @@ export function useSwapForm() {
         first.decimal_digits
       );
       if (token.amount.gt(new Int(0))) {
-        setRoute(token, false);
+        void setRoute(token, false);
       }
     }
   }
@@ -307,7 +307,7 @@ export function useSwapForm() {
         second.decimal_digits
       );
       if (token.amount.gt(new Int(0))) {
-        setRoute(token, true);
+        void setRoute(token, true);
       }
     }
   }
@@ -315,51 +315,53 @@ export function useSwapForm() {
   async function setRoute(token: Coin, revert = false) {
     clearTimeout(time);
 
-    time = setTimeout(async () => {
-      try {
-        loading.value = true;
-        error.value = "";
+    time = setTimeout(() => {
+      void (async () => {
+        try {
+          loading.value = true;
+          error.value = "";
 
-        const first = selectedFirstCurrencyOption.value;
-        const second = selectedSecondCurrencyOption.value;
-        if (!first || !second) return;
+          const first = selectedFirstCurrencyOption.value;
+          const second = selectedSecondCurrencyOption.value;
+          if (!first || !second) return;
 
-        const network = configStore.protocolFilter.toLowerCase();
+          const network = configStore.protocolFilter.toLowerCase();
 
-        if (revert) {
-          route = await SkipRouter.getRoute(
-            first.ibcData,
-            second.ibcData,
-            token.amount.toString(),
-            revert,
-            undefined,
-            undefined,
-            network
-          );
-          firstInputAmount.value = new Dec(route?.amount_in, first.decimal_digits).toString(first.decimal_digits);
-          amount.value = secondInputAmount.value;
-        } else {
-          route = await SkipRouter.getRoute(
-            first.ibcData,
-            second.ibcData,
-            token.amount.toString(),
-            revert,
-            undefined,
-            undefined,
-            network
-          );
-          secondInputAmount.value = new Dec(route?.amount_out, second.decimal_digits).toString(second.decimal_digits);
-          swapToAmount.value = secondInputAmount.value;
+          if (revert) {
+            route = await SkipRouter.getRoute(
+              first.ibcData,
+              second.ibcData,
+              token.amount.toString(),
+              revert,
+              undefined,
+              undefined,
+              network
+            );
+            firstInputAmount.value = new Dec(route?.amount_in, first.decimal_digits).toString(first.decimal_digits);
+            amount.value = secondInputAmount.value;
+          } else {
+            route = await SkipRouter.getRoute(
+              first.ibcData,
+              second.ibcData,
+              token.amount.toString(),
+              revert,
+              undefined,
+              undefined,
+              network
+            );
+            secondInputAmount.value = new Dec(route?.amount_out, second.decimal_digits).toString(second.decimal_digits);
+            swapToAmount.value = secondInputAmount.value;
+          }
+          priceImapact.value = Number(route?.swap_price_impact_percent ?? "0");
+          void setSwapFee();
+        } catch (e) {
+          error.value = i18n.t(classifyError(e));
+          route = null;
+          Logger.error(e);
+        } finally {
+          loading.value = false;
         }
-        priceImapact.value = Number(route?.swap_price_impact_percent ?? "0");
-        setSwapFee();
-      } catch (e) {
-        error.value = i18n.t(classifyError(e));
-        route = null;
-        Logger.error(e);
-      } finally {
-        loading.value = false;
-      }
+      })();
     }, timeOut);
   }
 
@@ -428,7 +430,7 @@ export function useSwapForm() {
 
         element.status = SwapStatus.success;
         await balancesStore.fetchBalances();
-        historyStore.loadActivities();
+        void historyStore.loadActivities();
       });
 
       onClose();

--- a/src/modules/dashboard/components/DashboardRewards.vue
+++ b/src/modules/dashboard/components/DashboardRewards.vue
@@ -144,7 +144,7 @@ async function requestClaim() {
       }
     }
 
-    historyStore.loadActivities();
+    void historyStore.loadActivities();
     await balancesStore.fetchBalances();
   } catch (error: unknown) {
     Logger.error(error);

--- a/src/modules/earn/components/EarnChart.vue
+++ b/src/modules/earn/components/EarnChart.vue
@@ -57,7 +57,7 @@ const currency = computed(() => {
 watch(
   () => [wallet?.apr, props.amount, currency.value],
   () => {
-    loadData();
+    void loadData();
   },
   {
     immediate: true

--- a/src/modules/earn/components/SupplyForm.vue
+++ b/src/modules/earn/components/SupplyForm.vue
@@ -206,7 +206,7 @@ watch(
   () => configStore.initialized,
   () => {
     if (configStore.initialized) {
-      onInit();
+      void onInit();
     }
   },
   {
@@ -215,7 +215,7 @@ watch(
 );
 
 async function onInit() {
-  fetchDepositCapacity();
+  void fetchDepositCapacity();
 }
 
 const apr = computed(() => {
@@ -282,7 +282,7 @@ async function transferAmount() {
 
       await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
       await Promise.all([balancesStore.fetchBalances(), loadLPNCurrency()]);
-      historyStore.loadActivities();
+      void historyStore.loadActivities();
       onClose();
       onShowToast({
         type: ToastType.success,

--- a/src/modules/earn/components/WithdrawForm.vue
+++ b/src/modules/earn/components/WithdrawForm.vue
@@ -200,7 +200,7 @@ const isEmpty = computed(() => {
 watch(
   () => walletStore.wallet,
   async () => {
-    fetchDepositBalance();
+    void fetchDepositBalance();
   },
   {
     immediate: true
@@ -327,7 +327,7 @@ async function transferAmount() {
 
       await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
       await Promise.all([loadLPNCurrency(), balancesStore.fetchBalances()]);
-      historyStore.loadActivities();
+      void historyStore.loadActivities();
       onClose();
       onShowToast({
         type: ToastType.success,

--- a/src/modules/history/components/Action.vue
+++ b/src/modules/history/components/Action.vue
@@ -64,7 +64,7 @@ const emitter = defineEmits(["click"]);
 
 function copyHash() {
   if (props.transaction) {
-    TextFormat.copyToClipboard(props.transaction?.tx_hash);
+    void TextFormat.copyToClipboard(props.transaction?.tx_hash);
     onShowToast({ type: ToastType.success, message: i18n.t("message.tx-copied-successfully") });
   }
   popoverRef.value?.close();
@@ -79,7 +79,7 @@ function copyTxRaw() {
     }
 
     const data = JSON.stringify(item, (key, value) => (typeof value === "bigint" ? value.toString() : value));
-    TextFormat.copyToClipboard(data);
+    void TextFormat.copyToClipboard(data);
     onShowToast({ type: ToastType.success, message: i18n.t("message.tx-raw-copied-successfully") });
   }
   popoverRef.value?.close();

--- a/src/modules/history/components/FilterLeaseId.vue
+++ b/src/modules/history/components/FilterLeaseId.vue
@@ -135,7 +135,7 @@ function setupObserver(): void {
     (entries) => {
       const entry = entries[0];
       if (entry.isIntersecting) {
-        loadMore();
+        void loadMore();
       }
     },
     {
@@ -169,11 +169,13 @@ watch(
   () => search.value,
   async () => {
     clearTimeout(timer);
-    timer = setTimeout(async () => {
-      skip = 0;
-      positions.value = [];
-      loaded.value = false;
-      await loadMore();
+    timer = setTimeout(() => {
+      void (async () => {
+        skip = 0;
+        positions.value = [];
+        loaded.value = false;
+        await loadMore();
+      })();
     }, throttle);
   }
 );

--- a/src/modules/history/components/History.vue
+++ b/src/modules/history/components/History.vue
@@ -161,7 +161,7 @@ watch(
   () => configStore.initialized,
   () => {
     if (configStore.initialized) {
-      initializeHistory();
+      void initializeHistory();
     }
   },
   { immediate: true }
@@ -179,7 +179,7 @@ watch(
 
     if (wallet.wallet?.address) {
       historyStore.setAddress(wallet.wallet.address);
-      loadTransactions(true);
+      void loadTransactions(true);
     }
   }
 );
@@ -216,6 +216,6 @@ async function loadMoreTransactions(): Promise<void> {
 function onFilter(f: IObjectKeys): void {
   skip = 0;
   filters.value = f as TransactionFilters;
-  loadTransactions(true);
+  void loadTransactions(true);
 }
 </script>

--- a/src/modules/history/components/RealisedPnl.vue
+++ b/src/modules/history/components/RealisedPnl.vue
@@ -114,7 +114,7 @@ watch(
 );
 
 onMounted(() => {
-  setStats();
+  void setStats();
 });
 
 async function setStats() {

--- a/src/modules/leases/components/NewLease.vue
+++ b/src/modules/leases/components/NewLease.vue
@@ -30,6 +30,6 @@ const route = useRoute();
 const router = useRouter();
 
 function goBack() {
-  router.push({ path: `/${RouteNames.LEASES}` });
+  void router.push({ path: `/${RouteNames.LEASES}` });
 }
 </script>

--- a/src/modules/leases/components/PnlLog.vue
+++ b/src/modules/leases/components/PnlLog.vue
@@ -163,14 +163,14 @@ watch(
       skip = 0;
       loans.value = [];
       loaded.value = false;
-      loadMore();
+      void loadMore();
     }
   },
   { immediate: true }
 );
 
 function goBack() {
-  router.push({ path: `/${RouteNames.HISTORY}` });
+  void router.push({ path: `/${RouteNames.HISTORY}` });
 }
 
 async function loadMore() {

--- a/src/modules/leases/components/SingleLease.vue
+++ b/src/modules/leases/components/SingleLease.vue
@@ -143,8 +143,8 @@ async function fetchLease() {
 }
 
 function reload() {
-  fetchLease();
-  balancesStore.fetchBalances();
+  void fetchLease();
+  void balancesStore.fetchBalances();
 }
 
 const status = computed(() => {
@@ -185,8 +185,8 @@ const openingSubState = computed(() => {
 });
 
 onMounted(() => {
-  fetchLease();
-  timeOut = setInterval(fetchLease, UPDATE_LEASES);
+  void fetchLease();
+  timeOut = setInterval(() => void fetchLease(), UPDATE_LEASES);
 });
 
 onUnmounted(() => {
@@ -210,8 +210,8 @@ watch(
   () => lease.value?.status,
   (newStatus) => {
     if (newStatus === "closed" || newStatus === "liquidated" || newStatus === "paid_off") {
-      balancesStore.fetchBalances();
-      leasesStore.refresh().then(() => router.replace(`/${RouteNames.LEASES}`));
+      void balancesStore.fetchBalances();
+      void leasesStore.refresh().then(() => router.replace(`/${RouteNames.LEASES}`));
     }
   }
 );

--- a/src/modules/leases/components/new-lease/LongForm.vue
+++ b/src/modules/leases/components/new-lease/LongForm.vue
@@ -242,7 +242,7 @@ watch(
   () => configStore.initialized,
   () => {
     if (configStore.initialized) {
-      onInit();
+      void onInit();
     }
   },
   {
@@ -264,7 +264,7 @@ watch(
       return;
     }
     if (await validateMinMaxValues(currency.value, coinList.value[selectedLoanCurrency.value])) {
-      calculate();
+      void calculate();
     } else {
       leaseApply.value = null;
     }
@@ -511,15 +511,15 @@ async function openLease() {
       });
 
       const data = item?.attributes[WASM_EVENTS["wasm-ls-request-loan"].index];
-      balancesStore.fetchBalances();
-      historyStore.loadActivities();
+      void balancesStore.fetchBalances();
+      void historyStore.loadActivities();
       reload();
       onShowToast({
         type: ToastType.success,
         message: i18n.t("message.currently-opening")
       });
 
-      router.push(`/${RouteNames.LEASES}/${data.value}`);
+      void router.push(`/${RouteNames.LEASES}/${data.value}`);
     } catch (error: unknown) {
       amountErrorMsg.value = i18n.t(classifyError(error));
       Logger.error(error);

--- a/src/modules/leases/components/new-lease/LongLeaseDetails.vue
+++ b/src/modules/leases/components/new-lease/LongLeaseDetails.vue
@@ -171,7 +171,7 @@ onUnmounted(() => {
 watch(
   () => [props.lease],
   () => {
-    setSwapFee();
+    void setSwapFee();
   }
 );
 
@@ -316,44 +316,46 @@ async function setSwapFee() {
   clearTimeout(time);
   const lease = props.lease;
   if (lease) {
-    time = setTimeout(async () => {
-      const currency = downPaymentAsset.value;
-      const [_, p] = asset.value.key.split("@");
+    time = setTimeout(() => {
+      void (async () => {
+        const currency = downPaymentAsset.value;
+        const [_, p] = asset.value.key.split("@");
 
-      const microAmount = CurrencyUtils.convertDenomToMinimalDenom(
-        props.downpaymenAmount,
-        currency.ibcData,
-        currency.decimal_digits
-      ).amount.toString();
+        const microAmount = CurrencyUtils.convertDenomToMinimalDenom(
+          props.downpaymenAmount,
+          currency.ibcData,
+          currency.decimal_digits
+        ).amount.toString();
 
-      const lpn = getLpnByProtocol(p);
-      let amountIn = 0;
-      let amountOut = 0;
-      await Promise.all([
-        SkipRouter.getRoute(currency.ibcData, asset.value.ibcData, microAmount).then((data) => {
-          amountIn += Number(data.usd_amount_in ?? 0);
-          amountOut += Number(data.usd_amount_out ?? 0);
+        const lpn = getLpnByProtocol(p);
+        let amountIn = 0;
+        let amountOut = 0;
+        await Promise.all([
+          SkipRouter.getRoute(currency.ibcData, asset.value.ibcData, microAmount).then((data) => {
+            amountIn += Number(data.usd_amount_in ?? 0);
+            amountOut += Number(data.usd_amount_out ?? 0);
 
-          return Number(data?.swap_price_impact_percent ?? 0);
-        }),
-        SkipRouter.getRoute(lpn.ibcData, asset.value.ibcData, lease.borrow.amount).then((data) => {
-          amountIn += Number(data.usd_amount_in ?? 0);
-          amountOut += Number(data.usd_amount_out ?? 0);
+            return Number(data?.swap_price_impact_percent ?? 0);
+          }),
+          SkipRouter.getRoute(lpn.ibcData, asset.value.ibcData, lease.borrow.amount).then((data) => {
+            amountIn += Number(data.usd_amount_in ?? 0);
+            amountOut += Number(data.usd_amount_out ?? 0);
 
-          return Number(data?.swap_price_impact_percent ?? 0);
-        })
-      ]);
-      const out_a = Math.max(amountOut, amountIn);
-      const in_a = Math.min(amountOut, amountIn);
+            return Number(data?.swap_price_impact_percent ?? 0);
+          })
+        ]);
+        const out_a = Math.max(amountOut, amountIn);
+        const in_a = Math.min(amountOut, amountIn);
 
-      const diff = out_a - in_a;
-      swapStableFee.value = diff;
-      let fee = 0;
+        const diff = out_a - in_a;
+        swapStableFee.value = diff;
+        let fee = 0;
 
-      if (in_a > 0) {
-        fee = diff / in_a;
-      }
-      swapFee.value = fee;
+        if (in_a > 0) {
+          fee = diff / in_a;
+        }
+        swapFee.value = fee;
+      })();
     }, timeOut);
   }
 }

--- a/src/modules/leases/components/new-lease/PositionPreviewChart.vue
+++ b/src/modules/leases/components/new-lease/PositionPreviewChart.vue
@@ -65,7 +65,7 @@ watch(
     props.borrowAsset
   ],
   () => {
-    setStats();
+    void setStats();
     chart.value?.update();
   }
 );

--- a/src/modules/leases/components/new-lease/ShortForm.vue
+++ b/src/modules/leases/components/new-lease/ShortForm.vue
@@ -242,7 +242,7 @@ watch(
   () => configStore.initialized,
   () => {
     if (configStore.initialized) {
-      onInit();
+      void onInit();
     }
   },
   {
@@ -264,7 +264,7 @@ watch(
       return;
     }
     if (await validateMinMaxValues(currency.value, coinList.value[selectedLoanCurrency.value])) {
-      calculate();
+      void calculate();
     } else {
       leaseApply.value = null;
     }
@@ -501,15 +501,15 @@ async function openLease() {
       });
 
       const data = item?.attributes[WASM_EVENTS["wasm-ls-request-loan"].index];
-      balancesStore.fetchBalances();
-      historyStore.loadActivities();
+      void balancesStore.fetchBalances();
+      void historyStore.loadActivities();
       reload();
       onShowToast({
         type: ToastType.success,
         message: i18n.t("message.currently-opening")
       });
 
-      router.push(`/${RouteNames.LEASES}/${data.value}`);
+      void router.push(`/${RouteNames.LEASES}/${data.value}`);
     } catch (error: unknown) {
       amountErrorMsg.value = i18n.t(classifyError(error));
       Logger.error(error);

--- a/src/modules/leases/components/new-lease/ShortLeaseDetails.vue
+++ b/src/modules/leases/components/new-lease/ShortLeaseDetails.vue
@@ -173,7 +173,7 @@ onUnmounted(() => {
 watch(
   () => [props.lease],
   (_value) => {
-    setSwapFee();
+    void setSwapFee();
   }
 );
 
@@ -346,53 +346,55 @@ const setSwapFee = async () => {
   clearTimeout(time);
   const lease = props.lease;
   if (!lease) return;
-  time = setTimeout(async () => {
-    const currency = downPaymentAsset.value;
-    const [_, p] = asset.value.key.split("@");
+  time = setTimeout(() => {
+    void (async () => {
+      const currency = downPaymentAsset.value;
+      const [_, p] = asset.value.key.split("@");
 
-    // For a Short position the on-chain flow swaps both the down payment and
-    // the borrowed LPN to the stable the position settles in (lease.total.ticker,
-    // e.g. USDC_NOBLE) — NOT to asset.value (the borrowed/shorted asset, which
-    // on a Short protocol is the same as the LPN). Routing source→source is a
-    // no-op and Skip returns a zero fee, so the UI showed 0.00 BTC.
-    const stableTicker = lease.total?.ticker;
-    const stable = stableTicker ? configStore.currenciesData?.[`${stableTicker}@${p}`] : null;
-    if (!stable) return;
+      // For a Short position the on-chain flow swaps both the down payment and
+      // the borrowed LPN to the stable the position settles in (lease.total.ticker,
+      // e.g. USDC_NOBLE) — NOT to asset.value (the borrowed/shorted asset, which
+      // on a Short protocol is the same as the LPN). Routing source→source is a
+      // no-op and Skip returns a zero fee, so the UI showed 0.00 BTC.
+      const stableTicker = lease.total?.ticker;
+      const stable = stableTicker ? configStore.currenciesData?.[`${stableTicker}@${p}`] : null;
+      if (!stable) return;
 
-    const microAmount = CurrencyUtils.convertDenomToMinimalDenom(
-      props.downpaymenAmount,
-      currency.ibcData,
-      currency.decimal_digits
-    ).amount.toString();
+      const microAmount = CurrencyUtils.convertDenomToMinimalDenom(
+        props.downpaymenAmount,
+        currency.ibcData,
+        currency.decimal_digits
+      ).amount.toString();
 
-    const lpn = getLpnByProtocol(p);
-    let amountIn = 0;
-    let amountOut = 0;
-    await Promise.all([
-      SkipRouter.getRoute(currency.ibcData, stable.ibcData, microAmount).then((data) => {
-        amountIn += Number(data.usd_amount_in ?? 0);
-        amountOut += Number(data.usd_amount_out ?? 0);
+      const lpn = getLpnByProtocol(p);
+      let amountIn = 0;
+      let amountOut = 0;
+      await Promise.all([
+        SkipRouter.getRoute(currency.ibcData, stable.ibcData, microAmount).then((data) => {
+          amountIn += Number(data.usd_amount_in ?? 0);
+          amountOut += Number(data.usd_amount_out ?? 0);
 
-        return Number(data?.swap_price_impact_percent ?? 0);
-      }),
-      SkipRouter.getRoute(lpn.ibcData, stable.ibcData, lease.borrow.amount).then((data) => {
-        amountIn += Number(data.usd_amount_in ?? 0);
-        amountOut += Number(data.usd_amount_out ?? 0);
+          return Number(data?.swap_price_impact_percent ?? 0);
+        }),
+        SkipRouter.getRoute(lpn.ibcData, stable.ibcData, lease.borrow.amount).then((data) => {
+          amountIn += Number(data.usd_amount_in ?? 0);
+          amountOut += Number(data.usd_amount_out ?? 0);
 
-        return Number(data?.swap_price_impact_percent ?? 0);
-      })
-    ]);
-    const out_a = Math.max(amountOut, amountIn);
-    const in_a = Math.min(amountOut, amountIn);
+          return Number(data?.swap_price_impact_percent ?? 0);
+        })
+      ]);
+      const out_a = Math.max(amountOut, amountIn);
+      const in_a = Math.min(amountOut, amountIn);
 
-    const diff = out_a - in_a;
-    swapStableFee.value = diff;
-    let fee = 0;
+      const diff = out_a - in_a;
+      swapStableFee.value = diff;
+      let fee = 0;
 
-    if (in_a > 0) {
-      fee = diff / in_a;
-    }
-    swapFee.value = fee;
+      if (in_a > 0) {
+        fee = diff / in_a;
+      }
+      swapFee.value = fee;
+    })();
   }, timeOut);
 };
 </script>

--- a/src/modules/leases/components/new-lease/useLeaseOpen.ts
+++ b/src/modules/leases/components/new-lease/useLeaseOpen.ts
@@ -57,7 +57,7 @@ export function useLeaseOpen() {
 
   const handleParentClick = (index: number) => {
     const tab = tabs[index];
-    router.push({ path: `/${RouteNames.LEASES}/open/${tab.action}` });
+    void router.push({ path: `/${RouteNames.LEASES}/open/${tab.action}` });
   };
 
   function onDrag(event: number) {

--- a/src/modules/leases/components/single-lease/Action.vue
+++ b/src/modules/leases/components/single-lease/Action.vue
@@ -66,7 +66,7 @@ const router = useRouter();
 
 function navigate(path: string) {
   popoverRef.value?.close();
-  router.push(path);
+  void router.push(path);
 }
 
 function sharePnl() {

--- a/src/modules/leases/components/single-lease/PnlOverTimeChart.vue
+++ b/src/modules/leases/components/single-lease/PnlOverTimeChart.vue
@@ -82,7 +82,7 @@ async function setData() {
 watch(
   () => [props.lease?.address, props.lease?.status, chartTimeRange.value],
   () => {
-    setData();
+    void setData();
   }
 );
 

--- a/src/modules/leases/components/single-lease/PriceOverTimeChart.vue
+++ b/src/modules/leases/components/single-lease/PriceOverTimeChart.vue
@@ -81,7 +81,7 @@ const likert = {
 watch(
   () => [props.lease?.address, props.lease?.status, props.interval],
   () => {
-    setData();
+    void setData();
   }
 );
 

--- a/src/modules/leases/components/single-lease/SingleLeaseHeader.vue
+++ b/src/modules/leases/components/single-lease/SingleLeaseHeader.vue
@@ -240,7 +240,7 @@ const stable = computed(() => {
 });
 
 function goBack() {
-  router.push(`/${RouteNames.LEASES}`);
+  void router.push(`/${RouteNames.LEASES}`);
 }
 
 const status = computed(() => {

--- a/src/modules/leases/components/single-lease/StopLossDialog.vue
+++ b/src/modules/leases/components/single-lease/StopLossDialog.vue
@@ -156,7 +156,7 @@ function initLease() {
     lease.value = cached;
     displayData.value = leasesStore.getLeaseDisplayData(cached);
     if (cached.status === "closed") {
-      router.push(`/${RouteNames.LEASES}`);
+      void router.push(`/${RouteNames.LEASES}`);
     }
   }
 }
@@ -356,8 +356,8 @@ async function operation() {
         usedFee: _usedFee
       } = await leaseClient.simulateChangeClosePolicyTx(wallet, stopLoss, takeProfit, funds);
       await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
-      balancesStore.fetchBalances();
-      historyStore.loadActivities();
+      void balancesStore.fetchBalances();
+      void historyStore.loadActivities();
       reload();
       dialog?.value?.close();
       onShowToast({

--- a/src/modules/leases/components/single-lease/TakeProfitDialog.vue
+++ b/src/modules/leases/components/single-lease/TakeProfitDialog.vue
@@ -155,7 +155,7 @@ function initLease() {
     lease.value = cached;
     displayData.value = leasesStore.getLeaseDisplayData(cached);
     if (cached.status === "closed") {
-      router.push(`/${RouteNames.LEASES}`);
+      void router.push(`/${RouteNames.LEASES}`);
     }
   }
 }
@@ -369,8 +369,8 @@ async function operation() {
         usedFee: _usedFee
       } = await leaseClient.simulateChangeClosePolicyTx(wallet, stopLoss, takeProfit, funds);
       await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
-      balancesStore.fetchBalances();
-      historyStore.loadActivities();
+      void balancesStore.fetchBalances();
+      void historyStore.loadActivities();
       reload();
       dialog?.value?.close();
       onShowToast({

--- a/src/modules/leases/components/single-lease/useCloseLease.ts
+++ b/src/modules/leases/components/single-lease/useCloseLease.ts
@@ -76,7 +76,7 @@ export function useCloseLease() {
       lease.value = cached;
       displayData.value = leasesStore.getLeaseDisplayData(cached);
       if (cached.status === "closed") {
-        router.push(`/${RouteNames.LEASES}`);
+        void router.push(`/${RouteNames.LEASES}`);
         return;
       }
       try {
@@ -90,7 +90,7 @@ export function useCloseLease() {
 
   onMounted(() => {
     dialog?.value?.show();
-    initLease();
+    void initLease();
   });
 
   onBeforeUnmount(() => {
@@ -474,58 +474,60 @@ export function useCloseLease() {
 
   async function setSwapFee() {
     clearTimeout(time);
-    time = setTimeout(async () => {
-      const lease_currency = currency.value;
-      const lpnCurrency = getLpnByProtocol(lease.value?.protocol as string);
-      const debtValue = debt.value;
-      if (!debtValue || !lpnCurrency || !lease_currency) {
-        return;
-      }
-      // The Skip route call (and the Dec conversions) run inside a debounced timer
-      // detached from the render cycle: an unhandled rejection here would surface
-      // as a console error and leave the preview fee silently stale. Catch and log
-      // so a transient route/price failure degrades gracefully instead.
-      try {
-        let microAmount = CurrencyUtils.convertDenomToMinimalDenom(
-          debtValue.amount.toDec().toString(),
-          lease_currency.ibcData,
-          lease_currency.decimal_digits
-        ).amount.toString();
-
-        let amountIn = 0;
-        let amountOut = 0;
-
-        const positionType = configStore.getPositionType(lease.value?.protocol as string);
-        if (positionType === "Short") {
-          microAmount = CurrencyUtils.convertDenomToMinimalDenom(
+    time = setTimeout(() => {
+      void (async () => {
+        const lease_currency = currency.value;
+        const lpnCurrency = getLpnByProtocol(lease.value?.protocol as string);
+        const debtValue = debt.value;
+        if (!debtValue || !lpnCurrency || !lease_currency) {
+          return;
+        }
+        // The Skip route call (and the Dec conversions) run inside a debounced timer
+        // detached from the render cycle: an unhandled rejection here would surface
+        // as a console error and leave the preview fee silently stale. Catch and log
+        // so a transient route/price failure degrades gracefully instead.
+        try {
+          let microAmount = CurrencyUtils.convertDenomToMinimalDenom(
             debtValue.amount.toDec().toString(),
-            lpnCurrency.ibcData,
-            lpnCurrency.decimal_digits
+            lease_currency.ibcData,
+            lease_currency.decimal_digits
           ).amount.toString();
+
+          let amountIn = 0;
+          let amountOut = 0;
+
+          const positionType = configStore.getPositionType(lease.value?.protocol as string);
+          if (positionType === "Short") {
+            microAmount = CurrencyUtils.convertDenomToMinimalDenom(
+              debtValue.amount.toDec().toString(),
+              lpnCurrency.ibcData,
+              lpnCurrency.decimal_digits
+            ).amount.toString();
+          }
+
+          await Promise.all([
+            SkipRouter.getRoute(lease_currency.ibcData, lpnCurrency.ibcData, microAmount).then((data) => {
+              amountIn += Number(data.usd_amount_in ?? 0);
+              amountOut += Number(data.usd_amount_out ?? 0);
+
+              return Number(data?.swap_price_impact_percent ?? 0);
+            })
+          ]);
+
+          const out_a = Math.max(amountOut, amountIn);
+          const in_a = Math.min(amountOut, amountIn);
+
+          const diff = out_a - in_a;
+          let fee = 0;
+          if (in_a > 0) {
+            fee = diff / in_a;
+          }
+
+          swapFee.value = fee;
+        } catch (e) {
+          Logger.error(e);
         }
-
-        await Promise.all([
-          SkipRouter.getRoute(lease_currency.ibcData, lpnCurrency.ibcData, microAmount).then((data) => {
-            amountIn += Number(data.usd_amount_in ?? 0);
-            amountOut += Number(data.usd_amount_out ?? 0);
-
-            return Number(data?.swap_price_impact_percent ?? 0);
-          })
-        ]);
-
-        const out_a = Math.max(amountOut, amountIn);
-        const in_a = Math.min(amountOut, amountIn);
-
-        const diff = out_a - in_a;
-        let fee = 0;
-        if (in_a > 0) {
-          fee = diff / in_a;
-        }
-
-        swapFee.value = fee;
-      } catch (e) {
-        Logger.error(e);
-      }
+      })();
     }, timeOut);
   }
 
@@ -719,10 +721,10 @@ export function useCloseLease() {
         } = await leaseClient.simulateClosePositionLeaseTx(wallet, getCurrency(), funds);
         await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
         leasesStore.markLeaseInProgress(lease.value.address, "close");
-        balancesStore.fetchBalances();
+        void balancesStore.fetchBalances();
         reload();
         dialog?.value?.close();
-        historyStore.loadActivities();
+        void historyStore.loadActivities();
         onShowToast({
           type: ToastType.success,
           message: i18n.t("message.toast-closed")
@@ -773,7 +775,7 @@ export function useCloseLease() {
   watch(
     () => [currency.value?.key],
     () => {
-      setSwapFee();
+      void setSwapFee();
     },
     {
       deep: true
@@ -846,7 +848,7 @@ export function useCloseLease() {
       route.matched[2].path === `/${RouteNames.LEASES}`
         ? `/${RouteNames.LEASES}`
         : `/${RouteNames.LEASES}/${route.params.id}`;
-    router.push(path);
+    void router.push(path);
   }
 
   return {

--- a/src/modules/leases/components/single-lease/usePositionSummary.ts
+++ b/src/modules/leases/components/single-lease/usePositionSummary.ts
@@ -335,7 +335,7 @@ export function usePositionSummary(props: PositionSummaryProps) {
         const takeProfitValue = props.lease.close_policy?.take_profit;
         const { txBytes } = await leaseClient.simulateChangeClosePolicyTx(wallet, null, takeProfitValue);
         await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
-        historyStore.loadActivities();
+        void historyStore.loadActivities();
         reload();
         onShowToast({
           type: ToastType.success,
@@ -365,7 +365,7 @@ export function usePositionSummary(props: PositionSummaryProps) {
         const stopLossValue = props.lease.close_policy?.stop_loss;
         const { txBytes } = await leaseClient.simulateChangeClosePolicyTx(wallet, stopLossValue, null);
         await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
-        historyStore.loadActivities();
+        void historyStore.loadActivities();
         reload();
         onShowToast({
           type: ToastType.success,
@@ -380,11 +380,11 @@ export function usePositionSummary(props: PositionSummaryProps) {
   }
 
   function onEditStopLoss() {
-    router.push({ path: `/${RouteNames.LEASES}/${props.lease?.address}/${SingleLeaseDialog.STOP_LOSS}` });
+    void router.push({ path: `/${RouteNames.LEASES}/${props.lease?.address}/${SingleLeaseDialog.STOP_LOSS}` });
   }
 
   function onEditTakeProfit() {
-    router.push({ path: `/${RouteNames.LEASES}/${props.lease?.address}/${SingleLeaseDialog.TAKE_PROFIT}` });
+    void router.push({ path: `/${RouteNames.LEASES}/${props.lease?.address}/${SingleLeaseDialog.TAKE_PROFIT}` });
   }
 
   return {

--- a/src/modules/leases/components/single-lease/useRepayLease.ts
+++ b/src/modules/leases/components/single-lease/useRepayLease.ts
@@ -63,7 +63,7 @@ export function useRepayLease() {
       lease.value = cached;
       displayData.value = leasesStore.getLeaseDisplayData(cached);
       if (cached.status === "closed") {
-        router.push(`/${RouteNames.LEASES}`);
+        void router.push(`/${RouteNames.LEASES}`);
       }
     }
   }
@@ -415,8 +415,8 @@ export function useRepayLease() {
         const { txBytes } = await leaseClient.simulateRepayLeaseTx(wallet, funds);
         await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
         leasesStore.markLeaseInProgress(lease.value.address, "repayment");
-        balancesStore.fetchBalances();
-        historyStore.loadActivities();
+        void balancesStore.fetchBalances();
+        void historyStore.loadActivities();
         reload();
         dialog?.value?.close();
         onShowToast({
@@ -534,7 +534,7 @@ export function useRepayLease() {
       route.matched[2].path === `/${RouteNames.LEASES}`
         ? `/${RouteNames.LEASES}`
         : `/${RouteNames.LEASES}/${route.params.id}`;
-    router.push(path);
+    void router.push(path);
   }
 
   return {

--- a/src/modules/leases/components/single-lease/useSharePnLDialog.ts
+++ b/src/modules/leases/components/single-lease/useSharePnLDialog.ts
@@ -151,14 +151,14 @@ export function useSharePnLDialog() {
 
   function setBackgroundIndex(index: number) {
     imageIndex.value = index;
-    generateCanvas();
+    void generateCanvas();
   }
 
   watch([showPnlAmount, showPrice, showPositionSize], () => {
-    generateCanvas();
+    void generateCanvas();
     for (const key in canvasRefs.value) {
       const img = images[key as keyof typeof images];
-      generateSmallCanvas(canvasRefs.value[key], img as string);
+      void generateSmallCanvas(canvasRefs.value[key], img as string);
     }
   });
 
@@ -445,22 +445,24 @@ export function useSharePnLDialog() {
     }
 
     const canvasElement = canvas.value as HTMLCanvasElement;
-    canvasElement.toBlob(async (blob) => {
-      try {
-        const filesArray = [
-          new File([blob as Blob], "position.png", {
-            type: blob?.type,
-            lastModified: new Date().getTime()
-          })
-        ];
-        const shareData = {
-          files: filesArray
-        };
+    canvasElement.toBlob((blob) => {
+      void (async () => {
+        try {
+          const filesArray = [
+            new File([blob as Blob], "position.png", {
+              type: blob?.type,
+              lastModified: new Date().getTime()
+            })
+          ];
+          const shareData = {
+            files: filesArray
+          };
 
-        await navigator.share(shareData);
-      } catch (error) {
-        Logger.error(error);
-      }
+          await navigator.share(shareData);
+        } catch (error) {
+          Logger.error(error);
+        }
+      })();
     }, "image/png");
   }
 
@@ -469,11 +471,11 @@ export function useSharePnLDialog() {
     leaseDisplayData = displayData ?? null;
     dialog?.value?.show();
     await nextTick();
-    generateCanvas();
+    void generateCanvas();
 
     for (const key in canvasRefs.value) {
       const img = images[key as keyof typeof images];
-      generateSmallCanvas(canvasRefs.value[key], img as string);
+      void generateSmallCanvas(canvasRefs.value[key], img as string);
     }
   };
 

--- a/src/modules/leases/components/useLeases.ts
+++ b/src/modules/leases/components/useLeases.ts
@@ -166,7 +166,7 @@ export function useLeases() {
 
           if (mobile) {
             const navigate = () => {
-              router.push(`/${RouteNames.LEASES}/${item.address}`);
+              void router.push(`/${RouteNames.LEASES}/${item.address}`);
             };
             const isOpened = item.status === "opened";
 
@@ -233,7 +233,7 @@ export function useLeases() {
                 subValueClass: "text-typography-secondary rounded border-[1px] px-2 py-1 self-start",
                 variant: "left",
                 click: () => {
-                  router.push(`/${RouteNames.LEASES}/${item.address}`);
+                  void router.push(`/${RouteNames.LEASES}/${item.address}`);
                 },
                 class: "text-typography-link font-semibold flex-[1.1_1_0%] cursor-pointer"
               },
@@ -293,9 +293,9 @@ export function useLeases() {
   });
 
   onMounted(() => {
-    leasesStore.refresh();
+    void leasesStore.refresh();
     timeOut = setInterval(() => {
-      leasesStore.refresh();
+      void leasesStore.refresh();
     }, UPDATE_LEASES);
   });
 
@@ -304,8 +304,8 @@ export function useLeases() {
   });
 
   function reload() {
-    leasesStore.refresh();
-    balancesStore.fetchBalances();
+    void leasesStore.refresh();
+    void balancesStore.fetchBalances();
   }
 
   function getTitle(item: LeaseInfo) {

--- a/src/modules/stake/components/DelegateForm.vue
+++ b/src/modules/stake/components/DelegateForm.vue
@@ -211,8 +211,8 @@ async function delegate() {
 
   await wallet.wallet?.broadcastTx(txBytes as Uint8Array);
   await Promise.all([stakingStore.fetchPositions(), balancesStore.fetchBalances()]);
-  historyStore.loadActivities();
-  router.push(`/${RouteNames.STAKE}`);
+  void historyStore.loadActivities();
+  void router.push(`/${RouteNames.STAKE}`);
   onShowToast({
     type: ToastType.success,
     message: i18n.t("message.delegate-successful")

--- a/src/modules/stake/components/RedelegateButton.vue
+++ b/src/modules/stake/components/RedelegateButton.vue
@@ -106,7 +106,7 @@ async function delegate() {
     await wallet.wallet.broadcastTx(txBytes as Uint8Array);
 
     await Promise.all([stakingStore.fetchPositions(), balancesStore.fetchBalances()]);
-    historyStore.loadActivities();
+    void historyStore.loadActivities();
 
     onShowToast({
       type: ToastType.success,

--- a/src/modules/stake/components/StakingRewards.vue
+++ b/src/modules/stake/components/StakingRewards.vue
@@ -131,7 +131,7 @@ async function requestClaim() {
     await wallet.wallet.broadcastTx(txBytes as Uint8Array);
 
     await Promise.all([stakingStore.fetchPositions(), balancesStore.fetchBalances()]);
-    historyStore.loadActivities();
+    void historyStore.loadActivities();
     onShowToast({
       type: ToastType.success,
       message: i18n.t("message.rewards-claimed-successful")

--- a/src/modules/stake/components/UndelegateForm.vue
+++ b/src/modules/stake/components/UndelegateForm.vue
@@ -201,8 +201,8 @@ async function undelegate() {
 
   await wallet.wallet?.broadcastTx(txBytes as Uint8Array);
   await Promise.all([stakingStore.fetchPositions(), balancesStore.fetchBalances()]);
-  historyStore.loadActivities();
-  router.push(`/${RouteNames.STAKE}`);
+  void historyStore.loadActivities();
+  void router.push(`/${RouteNames.STAKE}`);
   onShowToast({
     type: ToastType.success,
     message: i18n.t("message.undelegate-successful")

--- a/src/modules/stats/components/LoansProvided.vue
+++ b/src/modules/stats/components/LoansProvided.vue
@@ -54,7 +54,7 @@ watch(
   () => configStore.initialized,
   () => {
     if (configStore.initialized && !statsStore.initialized) {
-      statsStore.initialize();
+      void statsStore.initialize();
     }
   },
   {

--- a/src/modules/stats/components/Overview.vue
+++ b/src/modules/stats/components/Overview.vue
@@ -136,7 +136,7 @@ watch(
   () => configStore.initialized,
   () => {
     if (configStore.initialized && !statsStore.initialized) {
-      statsStore.initialize();
+      void statsStore.initialize();
     }
   },
   {

--- a/src/modules/vote/components/VoteDialog.vue
+++ b/src/modules/vote/components/VoteDialog.vue
@@ -213,7 +213,7 @@ async function onVoteEmit(vote: VoteOption) {
 
       await connectedWallet.broadcastTx(txBytes as Uint8Array);
       hide();
-      historyStore.loadActivities();
+      void historyStore.loadActivities();
       onShowToast({
         type: ToastType.success,
         message: i18n.t("message.vote-successful", {

--- a/src/modules/vote/view.vue
+++ b/src/modules/vote/view.vue
@@ -82,7 +82,7 @@ watch(
   () => configStore.initialized,
   () => {
     if (configStore.initialized) {
-      onInit();
+      void onInit();
     }
   },
   {

--- a/src/push/worker.ts
+++ b/src/push/worker.ts
@@ -140,7 +140,7 @@ async function parseNotification(payload: IObjectKeys): Promise<[string, Notific
   return ["Notification", notification];
 }
 
-self.addEventListener("push", async (event) => {
+self.addEventListener("push", (event) => {
   event.waitUntil(handlePushEvent(event));
 });
 
@@ -166,7 +166,7 @@ self.addEventListener("pushsubscriptionchange", (event: ExtendableEvent) => {
 });
 
 self.addEventListener("install", () => {
-  self.skipWaiting();
+  void self.skipWaiting();
 });
 
 self.addEventListener("activate", (evt) => {


### PR DESCRIPTION
## Summary
Enable `@typescript-eslint/no-floating-promises` and `@typescript-eslint/no-misused-promises` as `error` for `src/**/*.{ts,vue}`, and resolve the 133 violations they surface. This is the durable prevention for #238: the dead-async-guard class that shipped in the lease-open submit path (fixed in #239) now fails the lint gate instead of reaching production. Closes #238.

## Changes
- `eslint.config.js`: both rules added as `error` (`no-misused-promises` with `checksConditionals` + `checksVoidReturn`).
- ~108 fire-and-forget promises `void`-prefixed (store refreshes, `onMounted` fetches, debounced timer bodies, post-success activity reloads, clipboard/navigation/analytics side effects).
- ~13 async callbacks passed to `setInterval`/`setTimeout`/`watch`/`addEventListener`/`toBlob` wrapped to return void, preserving each body verbatim.
- `useWalletWatcher`: callback params widened from `() => void` to accept a returned promise, clearing all 6 store call sites with one signature change.
- `useWalletEvents`: the keystore-change listener uses a single shared handler reference so `removeEventListener` still unregisters (no listener leak).

No behaviour change: every tx broadcast remains `await`ed inside its error-surfacing `try/catch`; only post-success refreshes and UI navigation are `void`-ed. The one genuine missing-`await` defect of this class was already fixed in #239; `SkipRouter.getChains` cache poisoning (a latent variant) in #240.

## Verification
- `npm run lint` exits 0 with both rules enabled (all 133 resolved).
- `npx vue-tsc --noEmit`: 0 errors, identical to `main` — no type regression.
- Full suite: 879 tests pass; `npm run format:check`, `npm run build` clean.
- Two independent fresh-context reviews (correctness + security): both confirmed every `void` lands on a post-success refresh or UI nav, no tx error is swallowed, the `useWalletWatcher` widening and the listener-reference fix are sound.

## Follow-ups
- `.claude/` is not in this repo's `.gitignore`, so a stray `git add -A` can stage local working files (handoffs/scratch). Worth adding `.claude/` to `.gitignore` separately.