### PR TITLE
chore: gitignore .claude local working state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ docs/
 # Claude Code instructions
 CLAUDE.md
 
+# Claude Code local working state (handoffs, scratch, review artifacts)
+.claude/
+
 # Backend build artifacts
 backend/target/
 backend/.env


### PR DESCRIPTION
## Summary
Add `.claude/` to `.gitignore`. The directory holds local-only Claude Code working state — handoffs, scratch patches, review artifacts — some of which contain internal IPs and deploy paths. It was not ignored, so a stray `git add -A` could stage it (this nearly happened during the #238 work). Ignoring the whole directory removes that footgun.

## Verification
- `git status` shows `.claude/` no longer appears as untracked after the change.
- No tracked `.claude/` files exist, so nothing is removed from history — purely prevents future accidental staging.