### PR TITLE
feat(leases): plot stepped historical liquidation line on price chart

### DIFF
--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -5294,6 +5294,27 @@
               "string",
               "null"
             ]
+          },
+          "debt_stable": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Outstanding debt principal in stable after this event (whole units).\n`None` for shorts / missing-registry rows."
+          },
+          "collateral_asset": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Remaining collateral in the leased asset after this event (whole units).\n`None` for shorts / missing-registry rows."
+          },
+          "liquidation_price": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Reconstructed liquidation trigger effective from this event, stable per\nunit of the leased asset (whole units). `None` for shorts; `\"0\"` once\ndebt is fully repaid. Consumed by the single-lease price chart's stepped\nliquidation line."
           }
         }
       },

--- a/backend/src/external/etl.rs
+++ b/backend/src/external/etl.rs
@@ -416,6 +416,16 @@ pub struct EtlLeaseHistoryEntry {
     #[serde(rename = "time")]
     pub timestamp: Option<String>,
     pub additional: Option<String>,
+    /// Outstanding debt principal in stable after this event (whole units).
+    /// `None` for shorts / missing-registry rows (ETL `LS_History.debt_stable`).
+    pub debt_stable: Option<String>,
+    /// Remaining collateral in the leased asset after this event (whole units).
+    /// `None` for shorts / missing-registry rows (ETL `LS_History.collateral_asset`).
+    pub collateral_asset: Option<String>,
+    /// Reconstructed liquidation trigger effective from this event, stable per
+    /// unit of the leased asset (whole units). `None` for shorts; `"0"` once
+    /// debt is fully repaid (ETL `LS_History.liquidation_price`).
+    pub liquidation_price: Option<String>,
 }
 
 /// PnL data point from ETL API
@@ -726,6 +736,37 @@ mod tests {
         let client = test_client(&server.uri());
         let err = client.fetch_pools().await.unwrap_err();
         assert_etl_error(&err);
+    }
+
+    // ---- lease history entry: stepped-liquidation fields (#196 / #236) ----
+
+    #[test]
+    fn etl_history_entry_captures_stepped_liquidation_fields() {
+        let entry: EtlLeaseHistoryEntry = serde_json::from_value(serde_json::json!({
+            "type": "liquidation",
+            "time": "2026-01-01T00:00:00Z",
+            "debt_stable": "80.23",
+            "collateral_asset": "0.00120254",
+            "liquidation_price": "74000.00"
+        }))
+        .expect("history entry with stepped-liquidation fields deserialises");
+
+        assert_eq!(entry.debt_stable.as_deref(), Some("80.23"));
+        assert_eq!(entry.collateral_asset.as_deref(), Some("0.00120254"));
+        assert_eq!(entry.liquidation_price.as_deref(), Some("74000.00"));
+    }
+
+    #[test]
+    fn etl_history_entry_stepped_fields_default_to_none_when_absent() {
+        let entry: EtlLeaseHistoryEntry = serde_json::from_value(serde_json::json!({
+            "type": "open",
+            "time": "2026-01-01T00:00:00Z"
+        }))
+        .expect("history entry without stepped-liquidation fields deserialises (backwards-compat)");
+
+        assert_eq!(entry.debt_stable, None);
+        assert_eq!(entry.collateral_asset, None);
+        assert_eq!(entry.liquidation_price, None);
     }
 
     // ---- fetch_lease_opening (84-85) ----

--- a/backend/src/handlers/leases.rs
+++ b/backend/src/handlers/leases.rs
@@ -242,6 +242,17 @@ pub struct LeaseHistoryEntry {
     pub amount: Option<String>,
     pub symbol: Option<String>,
     pub timestamp: Option<String>,
+    /// Outstanding debt principal in stable after this event (whole units).
+    /// `None` for shorts / missing-registry rows.
+    pub debt_stable: Option<String>,
+    /// Remaining collateral in the leased asset after this event (whole units).
+    /// `None` for shorts / missing-registry rows.
+    pub collateral_asset: Option<String>,
+    /// Reconstructed liquidation trigger effective from this event, stable per
+    /// unit of the leased asset (whole units). `None` for shorts; `"0"` once
+    /// debt is fully repaid. Consumed by the single-lease price chart's stepped
+    /// liquidation line.
+    pub liquidation_price: Option<String>,
 }
 
 // ============================================================================
@@ -574,6 +585,9 @@ pub async fn get_lease_history(
                     amount: entry.amount,
                     symbol: entry.symbol,
                     timestamp: entry.timestamp,
+                    debt_stable: entry.debt_stable,
+                    collateral_asset: entry.collateral_asset,
+                    liquidation_price: entry.liquidation_price,
                 })
                 .collect()
         }
@@ -887,6 +901,9 @@ async fn fetch_lease_info(
                     amount: entry.amount.clone(),
                     symbol: entry.symbol.clone(),
                     timestamp: entry.timestamp.clone(),
+                    debt_stable: entry.debt_stable.clone(),
+                    collateral_asset: entry.collateral_asset.clone(),
+                    liquidation_price: entry.liquidation_price.clone(),
                 })
                 .collect()
         }),

--- a/src/common/api/types/leases.ts
+++ b/src/common/api/types/leases.ts
@@ -113,6 +113,13 @@ export interface LeaseHistoryEntry {
   amount?: string;
   symbol?: string;
   timestamp?: string;
+  /** Outstanding debt principal in stable after this event, whole units. `null` for shorts/missing-registry. */
+  debt_stable?: string;
+  /** Remaining collateral in the leased asset after this event, whole units. `null` for shorts/missing-registry. */
+  collateral_asset?: string;
+  /** Reconstructed liquidation trigger effective from this event (debt/collateral/0.9), whole units stable-per-unit.
+   * `null` for shorts/missing-registry; `"0"` once debt is fully repaid. */
+  liquidation_price?: string;
 }
 
 export interface LeaseQuoteRequest {

--- a/src/modules/leases/components/single-lease/PriceOverTimeChart.vue
+++ b/src/modules/leases/components/single-lease/PriceOverTimeChart.vue
@@ -33,7 +33,7 @@ import Chart from "@/common/components/Chart.vue";
 import { Tooltip } from "web-components";
 
 import type { LeaseInfo } from "@/common/api";
-import { computeChartLiquidationPrice } from "./liquidationLine";
+import { buildLiquidationSteps, computeChartLiquidationPrice, liquidationLabelFor } from "./liquidationLine";
 import { formatPriceUsd, formatUsd } from "@/common/utils/NumberFormatUtils";
 import {
   CHART_AXIS,
@@ -103,17 +103,21 @@ const currency = computed(() => {
 async function setData() {
   if (props.lease) {
     const chartData = await loadData(props.interval);
-    const liquidation = resolveLiquidationPrice();
-    // computeChartLiquidationPrice returns 0 for any non-opened / zero-value lease.
-    const liquidationLabel = liquidation <= 0 ? null : liquidation.toString();
+
+    // Stepped historical trigger from ETL's per-event series when available;
+    // otherwise the flat current value (shorts, missing data). See liquidationLine.ts.
+    const steps = buildLiquidationSteps(props.lease.etl_data?.history);
+    const active = props.lease.status === "opened";
+    const flat = resolveLiquidationPrice();
 
     data.value = (chartData ?? [])
       .map((item) => {
         const [date, price] = item;
+        const parsedDate = new Date(date);
         return {
-          Date: new Date(date),
+          Date: parsedDate,
           Price: price,
-          Liquidation: liquidationLabel
+          Liquidation: liquidationLabelFor(steps, flat, parsedDate.getTime(), active)
         };
       })
       .reverse();
@@ -122,7 +126,8 @@ async function setData() {
 }
 
 // Current liquidation trigger, resolved with the same decimals the position
-// widgets use. Rendered as a flat line across the series — see liquidationLine.ts.
+// widgets use. Used as the flat fallback line when no per-event ETL series
+// exists (shorts, missing data) — see liquidationLine.ts.
 function resolveLiquidationPrice(): number {
   const protocolKey = props.lease?.protocol as string;
   const unitAssetInfo = configStore.currenciesData?.[`${props.lease?.amount.ticker}@${protocolKey}`];
@@ -173,16 +178,19 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
   const minPrice = Math.min(...prices);
   const maxPrice = Math.max(...prices);
 
-  // Include liquidation in domain only if it's close enough to the price range.
-  // When liquidation is far away (e.g. BTC at $67K, liquidation at $22K) including
-  // it squashes the price line flat. We include it when it's within 50% of the
-  // mid-price — works for both Long (liquidation below) and Short (liquidation above).
-  const firstLiquidation = Number(chartData[0]?.Liquidation ?? 0);
+  // Include liquidation in domain only for the trigger values close enough to the
+  // price range. When a trigger is far away (e.g. BTC at $67K, liquidation at $22K)
+  // including it squashes the price line flat. A stepped series can span several
+  // values, so we consider every visible trigger and keep those within 50% of the
+  // mid-price — works for both Long (below) and Short (above).
   const midPrice = (minPrice + maxPrice) / 2;
-  const closeness = midPrice > 0 ? Math.abs(firstLiquidation - midPrice) / midPrice : Infinity;
-  const includeLiq = firstLiquidation > 0 && closeness <= 0.5;
-  const domainMin = includeLiq ? Math.min(minPrice, firstLiquidation) : minPrice;
-  const domainMax = includeLiq ? Math.max(maxPrice, firstLiquidation) : maxPrice;
+  const liqValues = chartData
+    .map((d) => (d.Liquidation === null ? NaN : Number(d.Liquidation)))
+    .filter((v) => Number.isFinite(v) && v > 0);
+  const inBand = midPrice > 0 ? liqValues.filter((v) => Math.abs(v - midPrice) / midPrice <= 0.5) : [];
+  const includeLiq = inBand.length > 0;
+  const domainMin = includeLiq ? Math.min(minPrice, ...inBand) : minPrice;
+  const domainMax = includeLiq ? Math.max(maxPrice, ...inBand) : maxPrice;
   const range = domainMax - domainMin;
   const padding = range * 0.2 || domainMax * 0.05;
   const yDomain: [number, number] = [Math.max(0, domainMin - padding), domainMax + padding];
@@ -234,7 +242,9 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
         strokeWidth: 2,
         strokeLinecap: "round",
         strokeDasharray: "6, 4",
-        curve: "catmull-rom",
+        // Discrete trigger: hold each value until the next event, then step.
+        // Null rows (before open / after close) render as gaps, not a $0 line.
+        curve: "step-after",
         clip: "frame"
       })
     ]

--- a/src/modules/leases/components/single-lease/liquidationLine.test.ts
+++ b/src/modules/leases/components/single-lease/liquidationLine.test.ts
@@ -1,6 +1,21 @@
 import { describe, it, expect } from "vitest";
-import type { LeaseInfo } from "@/common/api";
-import { computeChartLiquidationPrice } from "./liquidationLine";
+import type { LeaseHistoryEntry, LeaseInfo } from "@/common/api";
+import {
+  buildLiquidationSteps,
+  computeChartLiquidationPrice,
+  liquidationAt,
+  liquidationLabelFor,
+  type LiquidationStep
+} from "./liquidationLine";
+
+function historyEntry(overrides: Partial<LeaseHistoryEntry> = {}): LeaseHistoryEntry {
+  return {
+    action: "liquidation",
+    timestamp: "2026-01-01T00:00:00Z",
+    liquidation_price: "79257.5",
+    ...overrides
+  };
+}
 
 function lease(overrides: Partial<LeaseInfo> = {}): LeaseInfo {
   return {
@@ -84,5 +99,155 @@ describe("computeChartLiquidationPrice", () => {
 
   it("returns 0 for a null lease", () => {
     expect(computeChartLiquidationPrice(null, { positionType: "Long", unitDecimals: 8, stableDecimals: 6 })).toBe(0);
+  });
+});
+
+const T0 = Date.UTC(2026, 0, 1, 0, 0, 0);
+const T1 = Date.UTC(2026, 0, 2, 0, 0, 0);
+const T2 = Date.UTC(2026, 0, 3, 0, 0, 0);
+
+describe("buildLiquidationSteps", () => {
+  it("returns [] for null history", () => {
+    expect(buildLiquidationSteps(null)).toEqual([]);
+  });
+
+  it("returns [] for undefined history", () => {
+    expect(buildLiquidationSteps(undefined)).toEqual([]);
+  });
+
+  it("returns [] for empty history", () => {
+    expect(buildLiquidationSteps([])).toEqual([]);
+  });
+
+  it("maps an entry to its epoch-ms time and whole-unit price", () => {
+    const steps = buildLiquidationSteps([
+      historyEntry({ timestamp: "2026-01-01T00:00:00Z", liquidation_price: "79257.5" })
+    ]);
+    expect(steps).toEqual([{ time: T0, price: 79257.5 }]);
+  });
+
+  it("uses liquidation_price as-is with no decimal scaling", () => {
+    const steps = buildLiquidationSteps([historyEntry({ liquidation_price: "79257.5" })]);
+    expect(steps.map((s) => s.price)).toEqual([79257.5]);
+  });
+
+  it("drops an entry whose liquidation_price is undefined", () => {
+    expect(buildLiquidationSteps([historyEntry({ liquidation_price: undefined })])).toEqual([]);
+  });
+
+  it('drops an entry whose liquidation_price is "0" (fully-repaid event)', () => {
+    expect(buildLiquidationSteps([historyEntry({ liquidation_price: "0" })])).toEqual([]);
+  });
+
+  it("drops an entry whose liquidation_price parses to a negative value", () => {
+    expect(buildLiquidationSteps([historyEntry({ liquidation_price: "-5" })])).toEqual([]);
+  });
+
+  it("drops an entry whose liquidation_price parses to non-finite", () => {
+    expect(buildLiquidationSteps([historyEntry({ liquidation_price: "not-a-number" })])).toEqual([]);
+  });
+
+  it("drops an entry whose timestamp is missing", () => {
+    expect(buildLiquidationSteps([historyEntry({ timestamp: undefined })])).toEqual([]);
+  });
+
+  it("drops an entry whose timestamp is unparseable", () => {
+    expect(buildLiquidationSteps([historyEntry({ timestamp: "not-a-date" })])).toEqual([]);
+  });
+
+  it("returns steps sorted ascending by time when history is out of order", () => {
+    const steps = buildLiquidationSteps([
+      historyEntry({ timestamp: "2026-01-03T00:00:00Z", liquidation_price: "75679" }),
+      historyEntry({ timestamp: "2026-01-01T00:00:00Z", liquidation_price: "79257" }),
+      historyEntry({ timestamp: "2026-01-02T00:00:00Z", liquidation_price: "81003" })
+    ]);
+    expect(steps).toEqual([
+      { time: T0, price: 79257 },
+      { time: T1, price: 81003 },
+      { time: T2, price: 75679 }
+    ]);
+  });
+
+  it("yields exactly the positive steps in time order for a realistic mixed history", () => {
+    const steps = buildLiquidationSteps([
+      historyEntry({ action: "open", timestamp: "2025-12-31T00:00:00Z", liquidation_price: undefined }),
+      historyEntry({ action: "liquidation", timestamp: "2026-01-01T00:00:00Z", liquidation_price: "79257" }),
+      historyEntry({ action: "liquidation", timestamp: "2026-01-02T00:00:00Z", liquidation_price: "81003" }),
+      historyEntry({ action: "liquidation", timestamp: "2026-01-03T00:00:00Z", liquidation_price: "75679" }),
+      historyEntry({ action: "repay", timestamp: "2026-01-04T00:00:00Z", liquidation_price: "0" })
+    ]);
+    expect(steps).toEqual([
+      { time: T0, price: 79257 },
+      { time: T1, price: 81003 },
+      { time: T2, price: 75679 }
+    ]);
+  });
+});
+
+describe("liquidationAt", () => {
+  const steps: LiquidationStep[] = [
+    { time: T0, price: 79257 },
+    { time: T1, price: 81003 },
+    { time: T2, price: 75679 }
+  ];
+
+  it("returns null for empty steps when active", () => {
+    expect(liquidationAt([], T1, true)).toBeNull();
+  });
+
+  it("returns null for empty steps when inactive", () => {
+    expect(liquidationAt([], T1, false)).toBeNull();
+  });
+
+  it("returns null before the first step when active", () => {
+    expect(liquidationAt(steps, T0 - 1, true)).toBeNull();
+  });
+
+  it("returns null before the first step when inactive", () => {
+    expect(liquidationAt(steps, T0 - 1, false)).toBeNull();
+  });
+
+  it("returns the step's price exactly at its time (inclusive lower bound)", () => {
+    expect(liquidationAt(steps, T0, true)).toBe(79257);
+  });
+
+  it("returns the earlier step's price between two steps", () => {
+    expect(liquidationAt(steps, T0 + 1, true)).toBe(79257);
+  });
+
+  it("returns the most-recent step's price at a later step's exact time", () => {
+    expect(liquidationAt(steps, T1, true)).toBe(81003);
+  });
+
+  it("returns the last step's price after the last step when active", () => {
+    expect(liquidationAt(steps, T2 + 1, true)).toBe(75679);
+  });
+
+  it("returns null after the last step when inactive", () => {
+    expect(liquidationAt(steps, T2 + 1, false)).toBeNull();
+  });
+});
+
+describe("liquidationLabelFor", () => {
+  const steps: LiquidationStep[] = [
+    { time: T0, price: 79257 },
+    { time: T1, price: 81003 }
+  ];
+
+  it("uses the stepped value as a string when a series exists", () => {
+    expect(liquidationLabelFor(steps, 63000, T1, true)).toBe("81003");
+  });
+
+  it("returns null inside a series where there is no active trigger (gap), ignoring the flat fallback", () => {
+    // Before the first step: a gap, even though a positive flat value is available.
+    expect(liquidationLabelFor(steps, 63000, T0 - 1, true)).toBeNull();
+  });
+
+  it("falls back to the flat value as a string when there is no series", () => {
+    expect(liquidationLabelFor([], 63000, T1, true)).toBe("63000");
+  });
+
+  it("returns null when there is neither a series nor a positive flat value", () => {
+    expect(liquidationLabelFor([], 0, T1, true)).toBeNull();
   });
 });

--- a/src/modules/leases/components/single-lease/liquidationLine.ts
+++ b/src/modules/leases/components/single-lease/liquidationLine.ts
@@ -1,12 +1,17 @@
 /**
- * Current liquidation-trigger price for the single-lease price chart.
+ * Liquidation-trigger data for the single-lease price chart.
  *
- * The chart draws a flat line at the position's *current* liquidation price —
- * the same value the position widgets show — instead of reconstructing a
- * per-event historical series. The backend exposes no liquidation-price
- * history, and the reconstruction this replaced added every history delta to
- * the debt side only, inflating the value far above spot (a Long BTC position
- * near $62k rendered a ~$109k trigger).
+ * Two surfaces:
+ *  - `computeChartLiquidationPrice` — the position's *current* trigger as a
+ *    single number, drawn as a flat line. Used as the fallback when no
+ *    per-event history is available (short positions, missing-registry data,
+ *    or ETL not yet exposing the series).
+ *  - `buildLiquidationSteps` / `liquidationAt` — the *historical stepped* line,
+ *    built from ETL's per-event reconstructed `liquidation_price` (whole units).
+ *    The reconstruction lives server-side (extract-transform-load#71); never
+ *    reconstruct it client-side from deltas — the prior client-side attempt
+ *    added every history delta to the debt side only, inflating a Long BTC
+ *    trigger near $62k to ~$109k (#193).
  *
  * Mirrors LeaseCalculator.calculateLiquidationPrice:
  *   Long:  (debt / collateral) / 0.9
@@ -14,7 +19,7 @@
  */
 import { Dec } from "@keplr-wallet/unit";
 import { LeaseMath } from "@/common/utils/LeaseMath";
-import type { LeaseInfo } from "@/common/api";
+import type { LeaseHistoryEntry, LeaseInfo } from "@/common/api";
 
 export interface LiquidationPriceInputs {
   /** `Long` / `Short` — raw value from `configStore.getPositionType`. */
@@ -54,4 +59,79 @@ export function computeChartLiquidationPrice(
       : LeaseMath.calculateLiquidation(stableAsset, unitAsset);
 
   return Number(liquidation.toString());
+}
+
+export interface LiquidationStep {
+  /** Event time as epoch milliseconds. */
+  time: number;
+  /** Whole-unit trigger price, strictly positive. */
+  price: number;
+}
+
+/**
+ * Build the stepped liquidation-trigger series from a lease's ETL history.
+ *
+ * Each entry's `liquidation_price` is ETL's per-event reconstructed trigger in
+ * whole units — used as-is, never re-scaled by currency decimals. Events with
+ * no active trigger are dropped: `null`/missing (short positions, missing
+ * registry inputs) and `"0"` (a fully-repaid event) — see #236. The result is
+ * sorted ascending by time; an empty result signals the caller to fall back to
+ * the flat current-value line.
+ */
+export function buildLiquidationSteps(history: readonly LeaseHistoryEntry[] | null | undefined): LiquidationStep[] {
+  if (!history) {
+    return [];
+  }
+
+  return history
+    .map((entry) => ({
+      time: entry.timestamp == null ? NaN : new Date(entry.timestamp).getTime(),
+      price: entry.liquidation_price == null ? NaN : Number(entry.liquidation_price)
+    }))
+    .filter((step) => Number.isFinite(step.time) && Number.isFinite(step.price) && step.price > 0)
+    .sort((a, b) => a.time - b.time);
+}
+
+/**
+ * The liquidation trigger effective at `timeMs`, given `steps` ascending by
+ * time: the most-recent step at or before `timeMs`. Returns `null` when
+ * `timeMs` precedes the first step (no trigger established yet). Past the last
+ * step, an `active` (opened) position extends its current trigger to `timeMs`,
+ * while a closed/repaid position returns `null` so its line ends at the last
+ * positive value rather than extending across the post-close region (#236).
+ */
+export function liquidationAt(steps: readonly LiquidationStep[], timeMs: number, active: boolean): number | null {
+  let current: number | null = null;
+  let lastTime = Number.NEGATIVE_INFINITY;
+  for (const step of steps) {
+    if (timeMs < step.time) {
+      return current;
+    }
+    current = step.price;
+    lastTime = step.time;
+  }
+
+  if (current === null) {
+    return null;
+  }
+  // Strictly past the last event: only an open position carries its trigger
+  // forward to `timeMs`; a closed/repaid position ends at its last value (#236).
+  return timeMs > lastTime && !active ? null : current;
+}
+
+/**
+ * The trigger value to plot at a single chart point, as a string label or
+ * `null` (a gap). When a per-event series exists (`steps` non-empty) the
+ * stepped value at `timeMs` is used; otherwise the flat current value `flat`
+ * (`<= 0` means no flat line). `active` is whether the position is still opened.
+ * This is the step-vs-flat selection the chart applies to every price point.
+ */
+export function liquidationLabelFor(
+  steps: readonly LiquidationStep[],
+  flat: number,
+  timeMs: number,
+  active: boolean
+): string | null {
+  const value = steps.length > 0 ? liquidationAt(steps, timeMs, active) : flat > 0 ? flat : null;
+  return value === null ? null : value.toString();
 }


### PR DESCRIPTION
## Summary

Replace the single-lease price chart's flat current-value liquidation line with a stepped historical line, so a trigger that moved over the lease's life (e.g. after a partial liquidation) is shown as a step rather than a flat line at the latest value. The per-event series is reconstructed server-side by ETL (extract-transform-load#71 / PR #105); the frontend consumes it as-is and renders a `step-after` line.

## Changes

- **Backend**: thread `debt_stable`, `collateral_asset`, `liquidation_price` (optional, whole-unit strings) from the ETL `ls-opening` history entries through `EtlLeaseHistoryEntry` → response `LeaseHistoryEntry` at both mapping sites; regenerate the OpenAPI snapshot. All optional — a response without them deserializes to `None` (backwards-compatible against an ETL that has not exposed them yet).
- **Frontend**: `buildLiquidationSteps` builds the step series from `liquidation_price` (used as-is — never re-scaled by currency decimals); `liquidationAt` is the as-of lookup; `liquidationLabelFor` selects step-vs-flat per point. Wire `PriceOverTimeChart.vue` to the stepped line with `curve: "step-after"`.
- Drop fully-repaid (`0`) and short/missing (`null`) events so no `$0` step or stale trigger renders; a closed position's line ends at its last positive value rather than extending to now (#236).
- Fall back to the flat current value when no series exists (shorts, or against an ETL not yet exposing the fields). Preserve the prior far-trigger / `clip: "frame"` / hover-dot hardening from #193.

## Verification

- Frontend: ran `vue-tsc --noEmit`, `eslint`, `prettier --check`, and the full `vitest` suite (905 pass, incl. 36 in `liquidationLine.test.ts` covering whole-unit passthrough, the 0/null/negative/unparseable drops, as-of boundaries, active-vs-closed extension, and the step-vs-flat selector); coverage floors hold; production build succeeds.
- Backend: ran `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` (478 pass, incl. 2 new ETL deserialization round-trip tests); OpenAPI snapshot regenerated and the drift test passes.
- The values arrive already in whole units, so the chart does not re-scale them — verified by a dedicated test, guarding against the earlier client-side reconstruction that inflated a ~\$62k Long BTC trigger to ~\$109k.

## Notes

- Graceful against production ETL: the stepped line lights up wherever ETL #105 is live (staging today); against an ETL without the fields the chart shows the existing flat line. No coordinated cutover required.

Closes #196
Closes #236