### PR TITLE
fix(vue): VoteDialog quorum watcher + type-based defineProps

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -111,7 +111,8 @@ export default tseslint.config(
       "@typescript-eslint/no-misused-promises": ["error", { checksConditionals: true, checksVoidReturn: true }],
       "no-console": ["error", { allow: ["warn", "error"] }],
 
-      "vue/multi-word-component-names": "off"
+      "vue/multi-word-component-names": "off",
+      "vue/define-props-declaration": ["error", "type-based"]
     }
   },
 

--- a/src/common/components/ListHeader.vue
+++ b/src/common/components/ListHeader.vue
@@ -8,12 +8,7 @@
 </template>
 
 <script lang="ts" setup>
-defineProps({
-  title: {
-    type: String,
-    required: true
-  }
-});
+defineProps<{ title: string }>();
 </script>
 
 <style scoped lang=""></style>

--- a/src/modules/vote/components/ProposalItemWrapper.vue
+++ b/src/modules/vote/components/ProposalItemWrapper.vue
@@ -22,7 +22,7 @@
 
 <script lang="ts" setup>
 import { type FinalTallyResult, type Proposal } from "@/modules/vote/types";
-import { computed, ref, type PropType } from "vue";
+import { computed, ref } from "vue";
 import { Dec } from "@keplr-wallet/unit";
 import { formatDateTime, TextFormat } from "@/common/utils";
 
@@ -30,20 +30,11 @@ import { Proposal as ProposalItem } from "web-components";
 import { parseMarkdownSafe } from "@/common/utils/sanitize";
 import { useI18n } from "vue-i18n";
 
-const props = defineProps({
-  state: {
-    type: Object as PropType<Proposal>,
-    required: true
-  },
-  bondedTokens: {
-    type: Object as PropType<Dec>,
-    required: true
-  },
-  quorum: {
-    type: Object as PropType<Dec>,
-    required: true
-  }
-});
+const props = defineProps<{
+  state: Proposal;
+  bondedTokens: Dec;
+  quorum: Dec;
+}>();
 const i18n = useI18n();
 
 const labels = ref({

--- a/src/modules/vote/components/VoteDialog.test.ts
+++ b/src/modules/vote/components/VoteDialog.test.ts
@@ -248,4 +248,31 @@ describe("VoteDialog.vue", () => {
     expect(hoisted.loggerError).toHaveBeenCalled();
     wrapper.unmount();
   });
+
+  it("refreshes quorum when quorumTokens resolves after the dialog is open", async () => {
+    const wrapper = mount(VoteDialog, {
+      props: {
+        proposal: makeProposal(),
+        bondedTokens: new Dec("1000000"),
+        quorumTokens: new Dec("0")
+      },
+      global: {
+        mocks: { $t: (k: string) => k },
+        provide: { onShowToast: hoisted.onShowToast }
+      }
+    });
+    await wrapper.vm.$nextTick();
+    expect(quorumValue(wrapper)).toContain("0.00");
+
+    await wrapper.setProps({ quorumTokens: new Dec("0.334") });
+    await wrapper.vm.$nextTick();
+    expect(quorumValue(wrapper)).toContain("33.40");
+
+    wrapper.unmount();
+  });
 });
+
+function quorumValue(wrapper: ReturnType<typeof factory>): string {
+  const block = wrapper.findAll(".flex.gap-3 > div").find((b) => b.text().startsWith("message.quorum"));
+  return block?.text() ?? "";
+}

--- a/src/modules/vote/components/VoteDialog.vue
+++ b/src/modules/vote/components/VoteDialog.vue
@@ -144,15 +144,13 @@ const hasDelegatedTokens = computed(() => {
   return totalStaked.isPositive();
 });
 
-// Reacts to: props.proposal (immediate). The quorum line also reads
-// props.quorumTokens, which is deliberately NOT in the dependency set — it is the
-// load-once-stable chain quorum param, so re-deriving only on a proposal change is
-// intentional (a fresh quorumTokens arriving after a dialog is already open would
-// not refresh quorum; tracked in #231).
+// Reacts to: props.proposal + props.quorumTokens (immediate). quorumTokens is the
+// load-once-stable chain quorum param but stays in the dependency set so a tally
+// fetch resolving after the dialog is already open refreshes quorum (#231).
 // Idempotency: voting-period flag, description, and quorum are pure derivations of
 // the current props; safe on the immediate run and re-fires.
 watch(
-  () => props.proposal,
+  () => [props.proposal, props.quorumTokens],
   async () => {
     isVotingPeriod.value = (props.proposal.status as ProposalStatus) === ProposalStatus.PROPOSAL_STATUS_VOTING_PERIOD;
     description.value = parseMarkdownSafe(props.proposal.summary);


### PR DESCRIPTION
## Summary
Fix a latent stale-quorum bug in the governance vote dialog and finish the house-style migration of the last two runtime `defineProps` to type generics.

## Changes
- VoteDialog: widen the proposal watcher to `[props.proposal, props.quorumTokens]` so a late-resolving tally fetch refreshes the displayed quorum (#231)
- Convert `ListHeader.vue` and `ProposalItemWrapper.vue` to `defineProps<{…}>()`, drop the now-unused `PropType` import (#189)
- Enforce `vue/define-props-declaration: ["error", "type-based"]` in eslint config

## Verification
- Added a regression test proving quorum refreshes 0.00 → 33.40 after a late quorumTokens (failed before the watcher fix, passes after)
- Ran `npm run lint` (clean, new rule active across `src`), `vue-tsc` (no errors), full suite 906/906 pass; husky pre-commit gate green on both commits

Closes #231
Closes #189