### PR TITLE
style(tailwind): isolate infinite animations, restore skeleton sweep

### DIFF
--- a/src/assets/styles/_state.scss
+++ b/src/assets/styles/_state.scss
@@ -6,6 +6,7 @@
   border-radius: 4px;
   width: 100%;
   overflow: hidden;
+  contain: layout paint;
 
   &::before {
     content: "";
@@ -16,6 +17,16 @@
     animation: skeleton 800ms infinite;
     background: rgb(201 201 201 / 15%);
     filter: blur(8px);
+    will-change: left;
+  }
+}
+
+@keyframes skeleton {
+  0% {
+    left: 0;
+  }
+  100% {
+    left: calc(100% - 20px);
   }
 }
 

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -41,6 +41,8 @@ svg {
 .skeleton-box {
   background-color: var(--color-background-300);
   animation: blink 1.2s linear infinite;
+  will-change: opacity;
+  contain: layout paint;
 }
 
 @keyframes blink {

--- a/src/common/components/icons/SidebarIcon.vue
+++ b/src/common/components/icons/SidebarIcon.vue
@@ -237,6 +237,8 @@ defineProps<{
     animation: blink 7s linear 3s infinite;
     transform-origin: center;
     transform-box: border-box;
+    will-change: transform;
+    contain: layout paint;
   }
 }
 


### PR DESCRIPTION
## Summary
Isolate the three infinite CSS animations so they can't leak compositor invalidation onto neighbouring elements (the "unrelated element flickers with no JS event" bug), and restore a skeleton shimmer that had silently gone static. Closes #181.

## Changes
- `global.scss` `.skeleton-box` (blink/opacity) — `will-change: opacity` + `contain: layout paint`
- `SidebarIcon.vue` `.animate-blink` (blink/`scaleY`) — `will-change: transform` + `contain: layout paint`
- `_state.scss` `.state-loading` — `contain: layout paint` on the container, `will-change: left` on `::before`, and restored the deleted `@keyframes skeleton`

## Notes
The third target was not actually animating. `.state-loading::before` referenced `@keyframes skeleton`, but that keyframe was dropped as dead code (commit `bd4a47d0`), leaving a dangling animation-name reference — the shimmer rendered as a static blurred box. The keyframe is restored to its original `left: 0 → calc(100% - 20px)` sweep. It stays `left`-based rather than transform because the box is a fixed 40px inside a variable-width parent (e.g. `SwapForm.vue` uses `!w-[60px]`): `left: %` is parent-relative and sweeps correctly at any width, whereas `translateX(%)` is element-relative and can't span a variable parent without container queries. `contain: layout paint` on the parent is the effective isolation for that layout-driven child.

So this is a visual *restoration*, not a regression: `.skeleton-box` and the sidebar blink are visually unchanged; the `.state-loading` shimmer now moves again where it had been static.

## Verification
- Ran `npm run build`; the shipped bundle now contains `@keyframes skeleton{0%{left:0}to{left:calc(100% - 20px)}}` and the `will-change` (left/opacity/transform) + `contain:layout paint` declarations
- Ran prettier --check and eslint on the changed files — clean
- Husky pre-commit (lint + test + build) passed

## Follow-ups
- The `.state-loading` colours are still raw hex (`#ebeff5`, `#2b384b`, `#c9c9c917`) — tracked separately in #180