### PR TITLE
style(tailwind): replace hardcoded hex colors with design tokens

### DIFF
--- a/scripts/ts-style-check.sh
+++ b/scripts/ts-style-check.sh
@@ -37,6 +37,19 @@ if grep -rnE '(export )?(class|const|function|type|interface) [A-Za-z0-9_]*(Mana
   report "parasite-word abstraction — rename to an intent-revealing name (no Manager/Helper/Util(s)/Handler suffix)"
 fi
 
+# Raw hex colors in .vue: markup and chart code must reference the web-components
+# design tokens (--color-* / Tailwind utilities) instead of literal hex that
+# duplicates a token, so light/dark theming cannot silently diverge from the
+# palette. See ~/.claude/kit tailwind-style "No magic colors / sizes". Markup uses
+# bg-/text-<token> or var(--color-…); D3/Plot/canvas charts read the token at
+# render time via getComputedStyle(...).getPropertyValue('--color-…'). 8-digit
+# (alpha) hex is caught too. TermsDialog.vue (static legal-text + link colors) is
+# a pre-existing exception owned by a separate issue.
+if grep -rnE '#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?\b' --include='*.vue' "$src_dir" \
+     | grep -v '/TermsDialog\.vue:'; then
+  report "raw hex color in .vue — use a --color-* design token (bg-/text-<token>, var(--color-…), or getPropertyValue('--color-…')) instead"
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "TypeScript style checks FAILED." >&2
   exit 1

--- a/src/assets/styles/_state.scss
+++ b/src/assets/styles/_state.scss
@@ -1,7 +1,7 @@
 .state-loading {
   position: relative;
   height: 24px;
-  background-color: #ebeff5;
+  background-color: var(--color-progress);
   display: block;
   border-radius: 4px;
   width: 100%;
@@ -33,14 +33,10 @@
 body.dark,
 body.sync {
   div.status {
-    background-color: #2b384b;
+    background-color: var(--color-progress);
   }
 
-  .state-loading {
-    background-color: #2b384b;
-
-    &::before {
-      background: #c9c9c917;
-    }
+  .state-loading::before {
+    background: rgb(201 201 201 / 9%);
   }
 }

--- a/src/modules/earn/components/EarnChart.vue
+++ b/src/modules/earn/components/EarnChart.vue
@@ -30,6 +30,8 @@ import { Dec, Int } from "@keplr-wallet/unit";
 import { useConfigStore } from "@/common/stores/config";
 import { useEarnStore } from "@/common/stores/earn";
 
+const styles = window.getComputedStyle(document.documentElement);
+
 type ChartData = { amount: number; date: number };
 
 const data = ref<ChartData[]>([]);
@@ -97,7 +99,7 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
       lineY(data.value, {
         x: "date",
         y: "amount",
-        stroke: "#3470E2",
+        stroke: styles.getPropertyValue("--color-primary-default").trim(),
         curve: "basis",
         clip: "frame"
       })

--- a/src/modules/history/components/RealisedPnl.vue
+++ b/src/modules/history/components/RealisedPnl.vue
@@ -173,7 +173,7 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
     .attr("x2", chartWidth)
     .style("display", "none");
 
-  const baseColor = "#3470E2";
+  const baseColor = styles.getPropertyValue("--color-primary-default").trim();
   const hoverColor = color(baseColor)?.brighter(0.4)?.formatHex() ?? baseColor;
 
   const rects = select(plotChart).select('g[aria-label="bar"]').selectAll("path");

--- a/src/modules/leases/components/new-lease/PositionPreviewChart.vue
+++ b/src/modules/leases/components/new-lease/PositionPreviewChart.vue
@@ -92,6 +92,7 @@ async function setStats() {
 function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivElement, unknown, HTMLElement, unknown>) {
   if (!plotContainer) return;
 
+  const styles = window.getComputedStyle(document.documentElement);
   const values = responses.value.map((d) => d.value);
   const yDomain: [number, number] = [0, Math.max(...values)];
   const yTicks = computeYTicks(yDomain);
@@ -107,7 +108,7 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
       barY([responses.value[1]], {
         x: "name",
         y: "value",
-        fill: "#C1CAD7",
+        fill: styles.getPropertyValue("--color-background-200").trim(),
         rx: 6,
         insetBottom: 0,
         clip: "frame"
@@ -115,7 +116,7 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
       barY([responses.value[0]], {
         x: "name",
         y: "value",
-        fill: "#19A96C",
+        fill: styles.getPropertyValue("--color-icon-success").trim(),
         rx: 6,
         insetBottom: 0,
         clip: "frame"

--- a/src/modules/leases/components/single-lease/PnlOverTimeChart.vue
+++ b/src/modules/leases/components/single-lease/PnlOverTimeChart.vue
@@ -200,7 +200,12 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
         dot
           .attr("cx", xPixel)
           .attr("cy", yScale.apply(closestData.amount))
-          .attr("fill", closestData.amount >= 0 ? "#19A96C" : "#DF294D")
+          .attr(
+            "fill",
+            closestData.amount >= 0
+              ? styles.getPropertyValue("--color-icon-success").trim()
+              : styles.getPropertyValue("--color-icon-error").trim()
+          )
           .style("display", null);
 
         tooltip.html(`<strong>${i18n.t("message.amount")}:</strong> ${formatUsd(closestData.amount)}`);
@@ -234,6 +239,6 @@ function getClosestDataPoint(cPosition: number) {
 </script>
 <style lang="scss" scoped>
 .btn-gradient {
-  background: linear-gradient(270deg, #19a96c 0%, #df294d 100%);
+  background: linear-gradient(270deg, var(--color-icon-success) 0%, var(--color-icon-error) 100%);
 }
 </style>

--- a/src/modules/leases/components/single-lease/PositionHealthWidget.vue
+++ b/src/modules/leases/components/single-lease/PositionHealthWidget.vue
@@ -28,15 +28,15 @@
         >
           <path
             :d="arcPath(0, yellowEndAngle)"
+            class="stroke-red-500"
             fill="none"
-            stroke="#DF294D"
             stroke-width="12"
           />
 
           <path
             :d="arcPath(yellowEndAngle, greenEndAngle)"
+            class="stroke-yellow-200"
             fill="none"
-            stroke="#FFBF34"
             stroke-width="12"
           />
 
@@ -44,8 +44,8 @@
           <path
             v-if="greenEndAngle > 0"
             :d="arcPath(greenEndAngle, 180)"
+            class="stroke-green-400"
             fill="none"
-            stroke="#19A96C"
             stroke-width="12"
             stroke-linecap="round"
           />

--- a/src/modules/leases/components/single-lease/useSharePnLDialog.ts
+++ b/src/modules/leases/components/single-lease/useSharePnLDialog.ts
@@ -42,6 +42,9 @@ export function useSharePnLDialog() {
     { text: "#082D63", muted: "#5E7699" } // light lavender
   ];
 
+  // Fixed brand hex, NOT design tokens: the cover is rendered to a downloadable
+  // PNG that must look identical regardless of the viewer's light/dark theme, so
+  // these cannot resolve a theme-dependent CSS variable.
   const PNL_POSITIVE = "#1AB171";
   const PNL_NEGATIVE = "#AB1F3B";
 

--- a/src/modules/stats/components/LoansChart.vue
+++ b/src/modules/stats/components/LoansChart.vue
@@ -125,7 +125,7 @@ function updateChart(plotContainer: HTMLElement, tooltip: Selection<HTMLDivEleme
     .attr("x2", chartWidth)
     .style("display", "none");
 
-  const baseColor = "#3470E2";
+  const baseColor = styles.getPropertyValue("--color-primary-default").trim();
   const hoverColor = color(baseColor)?.brighter(0.4)?.formatHex() ?? baseColor;
 
   const rects = select(plotChart).select('g[aria-label="bar"]').selectAll("path");

--- a/src/modules/vote/components/VotingLine.vue
+++ b/src/modules/vote/components/VotingLine.vue
@@ -23,11 +23,11 @@ const props = defineProps<{
   labels: Record<string, string>;
 }>();
 
-const colors: Record<string, { bg: string; before: string; hex: string }> = {
-  yes_count: { bg: "bg-[#1AB171]", before: "before:bg-[#1AB171]", hex: "#1AB171" },
-  abstain_count: { bg: "bg-[#C1CAD7]", before: "before:bg-[#C1CAD7]", hex: "#C1CAD7" },
-  no_count: { bg: "bg-[#E42929]", before: "before:bg-[#E42929]", hex: "#E42929" },
-  no_with_veto_count: { bg: "bg-[#082D63]", before: "before:bg-[#082D63]", hex: "#082D63" }
+const colors: Record<string, { bg: string; before: string; text: string }> = {
+  yes_count: { bg: "bg-success-100", before: "before:bg-success-100", text: "text-success-100" },
+  abstain_count: { bg: "bg-neutral-200", before: "before:bg-neutral-200", text: "text-neutral-200" },
+  no_count: { bg: "bg-danger-100", before: "before:bg-danger-100", text: "text-danger-100" },
+  no_with_veto_count: { bg: "bg-blue-900", before: "before:bg-blue-900", text: "text-blue-900" }
 };
 
 const barClasses =
@@ -47,7 +47,7 @@ const segments = computed(() =>
 );
 
 function tooltipContent(segment: { key: string; label: string; percent: string }) {
-  const color = colors[segment.key].hex;
-  return `<span style="color:${color}">${segment.label} ${segment.percent}%</span>`;
+  const textClass = colors[segment.key].text;
+  return `<span class="${textClass}">${segment.label} ${segment.percent}%</span>`;
 }
 </script>


### PR DESCRIPTION
## Summary
Route every hardcoded colour through the web-components design tokens so light/dark theming can't silently diverge from the palette, and add a CI guard against new raw hex in `.vue`. Closes #180.

## Changes
- **Markup → token utilities / `var(--color-…)`:** vote tally bars (`VotingLine.vue`), position-health arcs (`PositionHealthWidget.vue`), and the skeleton-loading background (`_state.scss`, now themed via `--color-progress`, dropping the manual dark override; the dark shimmer's 8-digit hex rewritten as its `rgb(… / 9%)` equivalent).
- **Chart fills → tokens read at render time:** `EarnChart`, `RealisedPnl`, `LoansChart`, `PnlOverTimeChart`, `PositionPreviewChart` now resolve `getComputedStyle(documentElement).getPropertyValue('--color-…')`, matching the existing `PriceOverTimeChart` / `UnrealizedPnlChart` pattern.
- **CI guard:** `scripts/ts-style-check.sh` (run by `npm run lint:style` in pr-validate) now fails on raw 6/8-digit hex in `.vue`.

## Notes
- Token mechanics matter here: web-components defines tokens both as runtime `:root` variables (usable via `var()` / `getComputedStyle`) and as `@theme inline` (Tailwind-utility-only, no runtime variable). Chart/SVG/`var()` usages target `:root` tokens; utility-only tokens (`blue-900`, `neutral-200`, `red-500`, `yellow-200`, `green-400`) are used strictly as `bg-/text-/stroke-` classes. All generated classes were confirmed present in the built CSS.
- Two deliberate palette alignments (hex had no exact light-mode token): chart green → `--color-icon-success` (`#148555` in light), veto bar → `blue-900` (`#122f63`).
- `useSharePnLDialog.ts` keeps fixed brand hex by design — that cover renders to a downloadable, theme-independent PNG; documented in-code.
- `TermsDialog.vue` (static legal-text + link colours) is excluded from the guard and left for a separate change.

## Verification
- Ran `npm run build`; confirmed every introduced utility (`bg-/text-success-100/neutral-200/danger-100/blue-900`, `stroke-red-500/yellow-200/green-400`) generated in the shipped CSS with the expected values, and the chart `var()`/`getPropertyValue` targets all resolve to `:root` tokens
- Ran `npm run lint:style` (new hex guard), `npm run lint`, `npm run format:check`, `shellcheck scripts/ts-style-check.sh` — all clean
- Ran `npm test` — 906 passed (59 files)
- Reviewed the diff against the bug checklist and ran a separate pass on the `VotingLine` tooltip HTML sink: the injected string interpolates only static i18n labels and the fixed tally keys (no proposal-controlled text), and this change does not widen it