### PR TITLE
refactor(backend): strictly type swap_config and Skip status responses

### DIFF
--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -3382,15 +3382,15 @@
           "swap"
         ],
         "summary": "Get swap UI config",
-        "description": "Returns UI-only swap configuration (blacklist, defaults, transfers) from\nbackground-refreshed cache. Response is an opaque JSON object — shape is\nnot fixed in this spec.",
+        "description": "Returns UI-only swap configuration (blacklist, defaults, transfers) from\nbackground-refreshed cache. Per-network `swap_currency_<network>` keys are\ndynamic — the set of networks is data-driven.",
         "operationId": "get_swap_config",
         "responses": {
           "200": {
-            "description": "Opaque swap UI config",
+            "description": "Swap UI config",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/SwapConfigResponse"
                 }
               }
             }
@@ -6034,6 +6034,21 @@
           }
         }
       },
+      "NetworkTransfers": {
+        "type": "object",
+        "description": "Currencies transferable on one network.",
+        "required": [
+          "currencies"
+        ],
+        "properties": {
+          "currencies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferCurrency"
+            }
+          }
+        }
+      },
       "NetworksResponse": {
         "type": "object",
         "description": "Response for all networks",
@@ -7593,6 +7608,53 @@
           }
         }
       },
+      "SwapConfigResponse": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "Dynamic `swap_currency_<network>` keys → resolved denom"
+          },
+          {
+            "type": "object",
+            "required": [
+              "blacklist",
+              "fee",
+              "swap_to_currency",
+              "transfers"
+            ],
+            "properties": {
+              "blacklist": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Blacklisted currency tickers excluded from swap routes"
+              },
+              "fee": {
+                "type": "integer",
+                "format": "int32",
+                "description": "Affiliate fee in basis points",
+                "minimum": 0
+              },
+              "swap_to_currency": {
+                "type": "string",
+                "description": "Resolved denom of the swap target currency; empty when unconfigured"
+              },
+              "transfers": {
+                "type": "object",
+                "description": "Transferable currencies per network (uppercase network key)",
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/NetworkTransfers"
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "description": "Swap UI configuration assembled by `refresh_swap_config` from gated\nsettings + ETL denom resolution.\n\nPer-network swap currencies are served as dynamic `swap_currency_<network>`\nkeys via the flattened map — a network must be able to disappear (protocol\ndeprecation) without changing this type, so no network is ever a named\nfield. The frontend validates per-network keys at point of use only."
+      },
       "TallyResponse": {
         "type": "object",
         "required": [
@@ -7690,6 +7752,26 @@
               "string",
               "null"
             ]
+          }
+        }
+      },
+      "TransferCurrency": {
+        "type": "object",
+        "description": "One transferable currency: bank denom on Nolus and its DEX-side denom.",
+        "required": [
+          "from",
+          "to",
+          "native"
+        ],
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          },
+          "native": {
+            "type": "boolean"
           }
         }
       },

--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -3518,7 +3518,7 @@
           "swap"
         ],
         "summary": "Get swap status",
-        "description": "Forwards to Skip API `/v2/tx/status`. Response is an opaque Skip API\npassthrough — shape is not fixed in this spec.",
+        "description": "Forwards to Skip API `/v2/tx/status`. The upstream response is validated\nagainst `SkipStatusResponse` at ingress — `state` and the error envelope\nare typed; unconsumed tracking fields are preserved verbatim.",
         "operationId": "get_status",
         "parameters": [
           {
@@ -3542,17 +3542,17 @@
         ],
         "responses": {
           "200": {
-            "description": "Opaque Skip API passthrough",
+            "description": "Validated Skip status response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/SkipStatusResponse"
                 }
               }
             }
           },
           "502": {
-            "description": "Skip API call failed",
+            "description": "Skip API call failed or returned a malformed status",
             "content": {
               "application/json": {
                 "schema": {
@@ -7252,6 +7252,29 @@
         ],
         "description": "The cosmos transaction envelope the frontend signs and broadcasts."
       },
+      "SkipIbcTransferStatus": {
+        "type": "object",
+        "description": "IBC transfer hop status.",
+        "required": [
+          "src_chain_id",
+          "dst_chain_id",
+          "state"
+        ],
+        "properties": {
+          "src_chain_id": {
+            "type": "string"
+          },
+          "dst_chain_id": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "packet_txs": {
+            "type": "object"
+          }
+        }
+      },
       "SkipMessagesResponse": {
         "allOf": [
           {
@@ -7349,6 +7372,88 @@
           }
         ],
         "description": "Skip `/v2/fungible/route` response.\n\nOnly the fields the swap flow consumes are typed and required; every other\nfield Skip returns (price impact, estimated fees, USD amounts, route\nduration, …) is preserved verbatim through `additional` so the frontend\nkeeps its display data. `operations` stays opaque and is echoed back to\n`/v2/fungible/msgs` unchanged, so it must round-trip byte-for-byte."
+      },
+      "SkipStatusError": {
+        "allOf": [
+          {
+            "type": "object"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        ],
+        "description": "Structured Skip status error. Only `message` is consumed; `type` and\n`details` ride in `additional`."
+      },
+      "SkipStatusResponse": {
+        "allOf": [
+          {
+            "type": "object"
+          },
+          {
+            "type": "object",
+            "required": [
+              "state"
+            ],
+            "properties": {
+              "state": {
+                "type": "string",
+                "description": "Overall transaction state (`STATE_SUBMITTED`, `STATE_PENDING`,\n`STATE_COMPLETED_SUCCESS`, `STATE_COMPLETED_ERROR`,\n`STATE_PENDING_ERROR`, `STATE_ABANDONED`)"
+              },
+              "error": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SkipStatusError"
+                  }
+                ]
+              },
+              "transfer_sequence": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/SkipTransferEvent"
+                },
+                "description": "Per-hop transfer events; each entry wraps exactly one transfer kind\n(`ibc_transfer`, `cctp_transfer`, `axelar_transfer`, …)"
+              }
+            }
+          }
+        ],
+        "description": "Skip `/v2/tx/status` response.\n\n`state` drives the frontend tracking loop and `error.message` is what it\nsurfaces — both are validated at ingress. Every other field Skip returns\n(`transfers`, `next_blocking_transfer`, `transfer_asset_release`, …) is\npreserved verbatim through `additional`."
+      },
+      "SkipTransferEvent": {
+        "allOf": [
+          {
+            "type": "object"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "ibc_transfer": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SkipIbcTransferStatus"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "description": "One hop in a Skip transfer sequence. IBC hops are typed; every other\ntransfer kind (`cctp_transfer`, `axelar_transfer`, `go_fast_transfer`, …)\nis preserved through `additional`."
       },
       "SkipTx": {
         "allOf": [

--- a/backend/src/data_cache.rs
+++ b/backend/src/data_cache.rs
@@ -28,6 +28,7 @@ use crate::handlers::gated_assets::AssetsResponse;
 use crate::handlers::gated_networks::NetworksResponse;
 use crate::handlers::leases::LeaseConfigResponse;
 use crate::handlers::staking::Validator;
+use crate::handlers::swap::SwapConfigResponse;
 use crate::propagation::user_data_filter::UserDataFilterContext;
 use std::collections::HashMap;
 
@@ -188,7 +189,7 @@ pub struct AppDataCache {
 
     // ── Swap ─────────────────────────────────────────────────────
     /// Swap config (gated swap settings + ETL currencies resolved to denoms)
-    pub swap_config: Cached<serde_json::Value>,
+    pub swap_config: Cached<SwapConfigResponse>,
 
     // ── Lease configs ────────────────────────────────────────────
     /// Lease configs per protocol (downpayment ranges + leaser on-chain config)

--- a/backend/src/external/skip.rs
+++ b/backend/src/external/skip.rs
@@ -73,11 +73,6 @@ impl SkipClient {
         self.post_url(url, body).await
     }
 
-    /// Make a raw GET request to a URL and return JSON response
-    pub async fn get_raw(&self, url: &str) -> Result<serde_json::Value, AppError> {
-        self.get_url(url).await
-    }
-
     /// Get transaction status
     pub async fn get_status(
         &self,
@@ -125,26 +120,60 @@ impl SkipClient {
 // Skip Request/Response Types
 // ============================================================================
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Skip `/v2/tx/status` response.
+///
+/// `state` drives the frontend tracking loop and `error.message` is what it
+/// surfaces — both are validated at ingress. Every other field Skip returns
+/// (`transfers`, `next_blocking_transfer`, `transfer_asset_release`, …) is
+/// preserved verbatim through `additional`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct SkipStatusResponse {
-    pub status: String,
-    #[serde(default)]
-    pub state: Option<String>,
-    pub transfer_sequence: Option<Vec<SkipTransferSequenceItem>>,
-    #[serde(default)]
-    pub error: Option<serde_json::Value>,
+    /// Overall transaction state (`STATE_SUBMITTED`, `STATE_PENDING`,
+    /// `STATE_COMPLETED_SUCCESS`, `STATE_COMPLETED_ERROR`,
+    /// `STATE_PENDING_ERROR`, `STATE_ABANDONED`)
+    pub state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<SkipStatusError>,
+    /// Per-hop transfer events; each entry wraps exactly one transfer kind
+    /// (`ibc_transfer`, `cctp_transfer`, `axelar_transfer`, …)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transfer_sequence: Option<Vec<SkipTransferEvent>>,
+    #[serde(flatten)]
+    #[schema(value_type = Object)]
+    pub additional: serde_json::Map<String, serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SkipTransferSequenceItem {
+/// Structured Skip status error. Only `message` is consumed; `type` and
+/// `details` ride in `additional`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SkipStatusError {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(flatten)]
+    #[schema(value_type = Object)]
+    pub additional: serde_json::Map<String, serde_json::Value>,
+}
+
+/// One hop in a Skip transfer sequence. IBC hops are typed; every other
+/// transfer kind (`cctp_transfer`, `axelar_transfer`, `go_fast_transfer`, …)
+/// is preserved through `additional`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SkipTransferEvent {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ibc_transfer: Option<SkipIbcTransferStatus>,
+    #[serde(flatten)]
+    #[schema(value_type = Object)]
+    pub additional: serde_json::Map<String, serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// IBC transfer hop status.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct SkipIbcTransferStatus {
     pub src_chain_id: String,
     pub dst_chain_id: String,
     pub state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Object)]
     pub packet_txs: Option<serde_json::Value>,
 }
 
@@ -254,8 +283,7 @@ mod tests {
 
     fn status_body() -> serde_json::Value {
         serde_json::json!({
-            "status": "STATE_COMPLETED",
-            "state": "STATE_COMPLETED",
+            "state": "STATE_COMPLETED_SUCCESS",
             "transfer_sequence": [],
             "error": null
         })
@@ -285,7 +313,7 @@ mod tests {
 
         let client = test_client(&server.uri(), None);
         let resp = client.get_status("abc+/=", "osmosis/1").await.unwrap();
-        assert_eq!(resp.status, "STATE_COMPLETED");
+        assert_eq!(resp.state, "STATE_COMPLETED_SUCCESS");
     }
 
     // ---- 96-98: get_status success/malformed/500 ----
@@ -300,7 +328,7 @@ mod tests {
             .await;
         let client = test_client(&server.uri(), None);
         let resp = client.get_status("h", "c").await.unwrap();
-        assert_eq!(resp.status, "STATE_COMPLETED");
+        assert_eq!(resp.state, "STATE_COMPLETED_SUCCESS");
     }
 
     #[tokio::test]
@@ -396,7 +424,7 @@ mod tests {
 
         let client = test_client(&server.uri(), Some("secret".to_string()));
         let resp = client.get_status("h", "c").await.unwrap();
-        assert_eq!(resp.status, "STATE_COMPLETED");
+        assert_eq!(resp.state, "STATE_COMPLETED_SUCCESS");
     }
 
     #[tokio::test]
@@ -444,35 +472,15 @@ mod tests {
         assert_eq!(resp, serde_json::json!({ "ok": true }));
     }
 
-    // ---- 104: get_raw ----
+    // ---- 105: null optional fields accepted, state required ----
 
     #[tokio::test]
-    async fn skip_get_raw_forwards_and_parses() {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/v2/raw-get"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "hello": "world" })),
-            )
-            .mount(&server)
-            .await;
-
-        let client = test_client(&server.uri(), None);
-        let url = format!("{}/v2/raw-get", server.uri());
-        let resp = client.get_raw(&url).await.unwrap();
-        assert_eq!(resp["hello"], "world");
-    }
-
-    // ---- 105: null fields accepted ----
-
-    #[tokio::test]
-    async fn skip_status_response_accepts_null_fields() {
+    async fn skip_status_response_accepts_null_optional_fields() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/v2/tx/status"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "status": "STATE_PENDING",
-                "state": null,
+                "state": "STATE_PENDING",
                 "transfer_sequence": null,
                 "error": null
             })))
@@ -481,9 +489,28 @@ mod tests {
 
         let client = test_client(&server.uri(), None);
         let resp = client.get_status("h", "c").await.unwrap();
-        assert_eq!(resp.status, "STATE_PENDING");
-        assert!(resp.state.is_none());
+        assert_eq!(resp.state, "STATE_PENDING");
         assert!(resp.transfer_sequence.is_none());
+        assert!(resp.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn skip_status_response_missing_state_rejected() {
+        // The frontend tracking loop dispatches on `state`; a payload without
+        // it would spin the 60-retry poll to exhaustion. Fail loud instead.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v2/tx/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": "STATE_PENDING",
+                "transfer_sequence": []
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server.uri(), None);
+        let err = client.get_status("h", "c").await.unwrap_err();
+        assert_skip_error(&err);
     }
 
     // ---- 106: rejects wrong types ----
@@ -494,7 +521,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/v2/tx/status"))
             .respond_with(
-                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "status": 123 })),
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "state": 123 })),
             )
             .mount(&server)
             .await;
@@ -502,6 +529,53 @@ mod tests {
         let client = test_client(&server.uri(), None);
         let err = client.get_status("h", "c").await.unwrap_err();
         assert_skip_error(&err);
+    }
+
+    #[test]
+    fn skip_status_response_parses_and_preserves_unconsumed_fields() {
+        // Shape per https://docs.skip.build /v2/tx/status: wrapped per-hop
+        // transfer events, structured error, extra top-level tracking fields.
+        let raw = serde_json::json!({
+            "state": "STATE_COMPLETED_ERROR",
+            "error": { "type": "STATUS_ERROR_TRANSACTION_EXECUTION", "message": "out of gas" },
+            "transfer_sequence": [
+                {
+                    "ibc_transfer": {
+                        "src_chain_id": "pirin-1",
+                        "dst_chain_id": "osmosis-1",
+                        "state": "TRANSFER_FAILURE",
+                        "packet_txs": { "send_tx": { "tx_hash": "AA" } }
+                    }
+                },
+                { "cctp_transfer": { "src_chain_id": "1", "state": "CCTP_TRANSFER_SENT" } }
+            ],
+            "transfers": [{ "state": "STATE_COMPLETED_ERROR" }],
+            "transfer_asset_release": { "chain_id": "pirin-1", "denom": "unls", "released": true }
+        });
+
+        let parsed: SkipStatusResponse =
+            serde_json::from_value(raw.clone()).expect("valid status response deserializes");
+
+        assert_eq!(parsed.state, "STATE_COMPLETED_ERROR");
+        assert_eq!(
+            parsed.error.as_ref().and_then(|e| e.message.as_deref()),
+            Some("out of gas")
+        );
+        let sequence = parsed
+            .transfer_sequence
+            .as_ref()
+            .expect("transfer_sequence present");
+        let ibc = sequence[0]
+            .ibc_transfer
+            .as_ref()
+            .expect("first hop is an ibc_transfer");
+        assert_eq!(ibc.dst_chain_id, "osmosis-1");
+        // Non-IBC hops and extra tracking fields survive verbatim.
+        assert!(sequence[1].additional.contains_key("cctp_transfer"));
+        assert!(parsed.additional.contains_key("transfers"));
+        assert!(parsed.additional.contains_key("transfer_asset_release"));
+        // Re-serialization is shape-equal to the upstream payload (no field loss).
+        assert_eq!(serde_json::to_value(&parsed).expect("re-serializes"), raw);
     }
 
     // ---- 107: route response validates envelope, keeps operations + extras ----

--- a/backend/src/handlers/openapi.rs
+++ b/backend/src/handlers/openapi.rs
@@ -280,6 +280,9 @@ use crate::handlers::{
         swap::MessagesRequest,
         swap::TrackRequest,
         swap::TrackResponse,
+        swap::SwapConfigResponse,
+        swap::NetworkTransfers,
+        swap::TransferCurrency,
         // Skip ingress responses validated at the boundary
         external::skip::SkipRouteResponse,
         external::skip::SkipMessagesResponse,

--- a/backend/src/handlers/openapi.rs
+++ b/backend/src/handlers/openapi.rs
@@ -290,6 +290,10 @@ use crate::handlers::{
         external::skip::SkipCosmosTx,
         external::skip::SkipMsg,
         external::skip::SkipChain,
+        external::skip::SkipStatusResponse,
+        external::skip::SkipStatusError,
+        external::skip::SkipTransferEvent,
+        external::skip::SkipIbcTransferStatus,
         // ETL batch passthroughs (fields opaque)
         etl_proxy::StatsOverviewBatch,
         etl_proxy::LoansStatsBatch,

--- a/backend/src/handlers/swap.rs
+++ b/backend/src/handlers/swap.rs
@@ -20,7 +20,9 @@ use utoipa::ToSchema;
 
 use crate::error::AppError;
 use crate::external::base_client::ExternalApiClient;
-use crate::external::skip::{SkipChain, SkipMessagesResponse, SkipRouteResponse};
+use crate::external::skip::{
+    SkipChain, SkipMessagesResponse, SkipRouteResponse, SkipStatusResponse,
+};
 use crate::AppState;
 
 // ============================================================================
@@ -249,8 +251,9 @@ pub async fn get_messages(
 
 /// Get swap status
 ///
-/// Forwards to Skip API `/v2/tx/status`. Response is an opaque Skip API
-/// passthrough — shape is not fixed in this spec.
+/// Forwards to Skip API `/v2/tx/status`. The upstream response is validated
+/// against `SkipStatusResponse` at ingress — `state` and the error envelope
+/// are typed; unconsumed tracking fields are preserved verbatim.
 #[utoipa::path(
     get,
     path = "/api/swap/status/{tx_hash}",
@@ -260,25 +263,21 @@ pub async fn get_messages(
         StatusQuery,
     ),
     responses(
-        (status = 200, description = "Opaque Skip API passthrough", content_type = "application/json", body = Object),
-        (status = 502, description = "Skip API call failed", body = crate::error::ErrorResponse),
+        (status = 200, description = "Validated Skip status response", body = SkipStatusResponse),
+        (status = 502, description = "Skip API call failed or returned a malformed status", body = crate::error::ErrorResponse),
     ),
 )]
 pub async fn get_status(
     State(state): State<Arc<AppState>>,
     Path(tx_hash): Path<String>,
     Query(query): Query<StatusQuery>,
-) -> Result<Json<serde_json::Value>, AppError> {
+) -> Result<Json<SkipStatusResponse>, AppError> {
     debug!("Getting swap status for tx: {}", tx_hash);
 
-    let url = format!(
-        "{}/v2/tx/status?tx_hash={}&chain_id={}",
-        state.skip_client.base_url(),
-        urlencoding::encode(&tx_hash),
-        urlencoding::encode(&query.chain_id)
-    );
-
-    let response = state.skip_client.get_raw(&url).await?;
+    let response = state
+        .skip_client
+        .get_status(&tx_hash, &query.chain_id)
+        .await?;
     Ok(Json(response))
 }
 

--- a/backend/src/handlers/swap.rs
+++ b/backend/src/handlers/swap.rs
@@ -13,6 +13,7 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tracing::debug;
 use utoipa::ToSchema;
@@ -382,23 +383,60 @@ pub async fn track_transaction(
     }))
 }
 
+/// Swap UI configuration assembled by `refresh_swap_config` from gated
+/// settings + ETL denom resolution.
+///
+/// Per-network swap currencies are served as dynamic `swap_currency_<network>`
+/// keys via the flattened map — a network must be able to disappear (protocol
+/// deprecation) without changing this type, so no network is ever a named
+/// field. The frontend validates per-network keys at point of use only.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct SwapConfigResponse {
+    /// Blacklisted currency tickers excluded from swap routes
+    pub blacklist: Vec<String>,
+    /// Affiliate fee in basis points
+    pub fee: u32,
+    /// Resolved denom of the swap target currency; empty when unconfigured
+    pub swap_to_currency: String,
+    /// Transferable currencies per network (uppercase network key)
+    pub transfers: BTreeMap<String, NetworkTransfers>,
+    /// Dynamic `swap_currency_<network>` keys → resolved denom
+    #[serde(flatten)]
+    #[schema(value_type = Object)]
+    pub swap_currencies: BTreeMap<String, String>,
+}
+
+/// Currencies transferable on one network.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct NetworkTransfers {
+    pub currencies: Vec<TransferCurrency>,
+}
+
+/// One transferable currency: bank denom on Nolus and its DEX-side denom.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct TransferCurrency {
+    pub from: String,
+    pub to: String,
+    pub native: bool,
+}
+
 /// Get swap UI config
 ///
 /// Returns UI-only swap configuration (blacklist, defaults, transfers) from
-/// background-refreshed cache. Response is an opaque JSON object — shape is
-/// not fixed in this spec.
+/// background-refreshed cache. Per-network `swap_currency_<network>` keys are
+/// dynamic — the set of networks is data-driven.
 #[utoipa::path(
     get,
     path = "/api/swap/config",
     tag = "swap",
     responses(
-        (status = 200, description = "Opaque swap UI config", content_type = "application/json", body = Object),
+        (status = 200, description = "Swap UI config", body = SwapConfigResponse),
         (status = 503, description = "Swap config not yet populated", body = crate::error::ErrorResponse),
     ),
 )]
 pub async fn get_swap_config(
     State(state): State<Arc<AppState>>,
-) -> Result<Json<serde_json::Value>, AppError> {
+) -> Result<Json<SwapConfigResponse>, AppError> {
     let result = state
         .data_cache
         .swap_config

--- a/backend/src/handlers/websocket.rs
+++ b/backend/src/handlers/websocket.rs
@@ -281,7 +281,7 @@ pub struct CachedLeaseState {
 /// Cached Skip transaction state for tracking
 #[derive(Debug, Clone, PartialEq)]
 pub struct CachedSkipTxState {
-    pub status: String,
+    pub state: String,
     pub completed_hops: u32,
     pub total_hops: u32,
 }
@@ -1400,7 +1400,7 @@ async fn check_skip_tx_status(
 
     // Create current state
     let current_state = CachedSkipTxState {
-        status: status_response.status.clone(),
+        state: status_response.state.clone(),
         completed_hops,
         total_hops,
     };
@@ -1411,14 +1411,12 @@ async fn check_skip_tx_status(
         .update_skip_tx_state(tx_hash, current_state.clone());
 
     if changed {
-        // Determine status value for frontend
-        let is_complete = matches!(
-            status_response.status.as_str(),
-            "STATE_COMPLETED" | "STATE_COMPLETED_SUCCESS"
-        );
+        // Determine status value for frontend, per Skip's documented
+        // TransactionState enum (matches the REST polling path's mapping)
+        let is_complete = status_response.state == "STATE_COMPLETED_SUCCESS";
         let is_failed = matches!(
-            status_response.status.as_str(),
-            "STATE_FAILED" | "STATE_ABANDONED"
+            status_response.state.as_str(),
+            "STATE_COMPLETED_ERROR" | "STATE_PENDING_ERROR" | "STATE_ABANDONED"
         );
 
         let status = if is_complete {
@@ -1429,12 +1427,16 @@ async fn check_skip_tx_status(
             TxStatusValue::Pending
         };
 
-        // Extract error message if failed (status itself describes the failure)
         let error = if is_failed {
-            Some(format!(
-                "Transaction failed with status: {}",
-                status_response.status
-            ))
+            Some(
+                status_response
+                    .error
+                    .as_ref()
+                    .and_then(|e| e.message.clone())
+                    .unwrap_or_else(|| {
+                        format!("Transaction failed with state: {}", status_response.state)
+                    }),
+            )
         } else {
             None
         };
@@ -2260,7 +2262,7 @@ mod tests {
     async fn test_update_skip_tx_state_tracks_old_and_new() {
         let m = WebSocketManager::new(16);
         let s1 = CachedSkipTxState {
-            status: "STATE_PENDING".to_string(),
+            state: "STATE_PENDING".to_string(),
             completed_hops: 0,
             total_hops: 3,
         };
@@ -2271,11 +2273,11 @@ mod tests {
         // Idempotent update
         let (changed, old) = m.update_skip_tx_state("TX", s1.clone());
         assert!(!changed);
-        assert_eq!(old.unwrap().status, "STATE_PENDING");
+        assert_eq!(old.unwrap().state, "STATE_PENDING");
 
         // Change hops → changed=true with old state returned
         let s2 = CachedSkipTxState {
-            status: "STATE_PENDING".to_string(),
+            state: "STATE_PENDING".to_string(),
             completed_hops: 1,
             total_hops: 3,
         };
@@ -2322,7 +2324,7 @@ mod tests {
         m.update_skip_tx_state(
             "TX",
             CachedSkipTxState {
-                status: "STATE_PENDING".to_string(),
+                state: "STATE_PENDING".to_string(),
                 completed_hops: 0,
                 total_hops: 1,
             },
@@ -2350,7 +2352,7 @@ mod tests {
         m.update_skip_tx_state(
             "TX",
             CachedSkipTxState {
-                status: "STATE_PENDING".to_string(),
+                state: "STATE_PENDING".to_string(),
                 completed_hops: 0,
                 total_hops: 1,
             },

--- a/backend/src/refresh.rs
+++ b/backend/src/refresh.rs
@@ -4,7 +4,7 @@
 //! `start_all()` spawns them on appropriate intervals.
 //! `warm_essential_data()` runs blocking at startup before the server accepts requests.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -49,6 +49,7 @@ use crate::handlers::gated_assets::{get_price_for_asset, AssetResponse, AssetsRe
 use crate::handlers::gated_networks::NetworksResponse;
 use crate::handlers::leases::LeaseConfigResponse;
 use crate::handlers::staking::Validator;
+use crate::handlers::swap::{NetworkTransfers, SwapConfigResponse, TransferCurrency};
 use crate::propagation::user_data_filter::UserDataFilterContext;
 use crate::propagation::{PropagationFilter, PropagationMerger};
 use crate::AppState;
@@ -1209,7 +1210,7 @@ pub async fn refresh_swap_config(state: &Arc<AppState>) {
     }
 
     // Build transfers
-    let mut transfers: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
+    let mut transfers: BTreeMap<String, Vec<TransferCurrency>> = BTreeMap::new();
     let mut seen: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
 
     for currency in &currencies_response.currencies {
@@ -1228,39 +1229,28 @@ pub async fn refresh_swap_config(state: &Arc<AppState>) {
             if !network_seen.insert(protocol_mapping.bank_symbol.clone()) {
                 continue;
             }
-            let entry = serde_json::json!({
-                "from": protocol_mapping.bank_symbol,
-                "to": protocol_mapping.dex_symbol,
-                "native": false,
-            });
+            let entry = TransferCurrency {
+                from: protocol_mapping.bank_symbol.clone(),
+                to: protocol_mapping.dex_symbol.clone(),
+                native: false,
+            };
             transfers.entry(network.clone()).or_default().push(entry);
         }
     }
 
-    let mut transfers_map = serde_json::Map::new();
-    for (network, currencies) in transfers {
-        transfers_map.insert(network, serde_json::json!({ "currencies": currencies }));
-    }
+    let transfers = transfers
+        .into_iter()
+        .map(|(network, currencies)| (network, NetworkTransfers { currencies }))
+        .collect();
 
-    // Build public config response (UI-only fields)
-    let mut response = serde_json::Map::new();
-    response.insert(
-        "blacklist".to_string(),
-        serde_json::json!(swap_settings.blacklist),
-    );
-    response.insert("fee".to_string(), serde_json::json!(swap_settings.fee));
-
-    let swap_to_denom = swap_settings
+    let swap_to_currency = swap_settings
         .swap_to_currency
         .as_deref()
         .and_then(|ticker| ticker_to_denom.get(ticker))
         .cloned()
         .unwrap_or_default();
-    response.insert(
-        "swap_to_currency".to_string(),
-        serde_json::json!(swap_to_denom),
-    );
 
+    let mut swap_currencies: BTreeMap<String, String> = BTreeMap::new();
     for (network, ticker) in &swap_settings.swap_currencies {
         let network_upper = network.to_uppercase();
         let denom = ticker_network_to_denom
@@ -1268,21 +1258,16 @@ pub async fn refresh_swap_config(state: &Arc<AppState>) {
             .or_else(|| ticker_to_denom.get(ticker))
             .cloned()
             .unwrap_or_default();
-        response.insert(
-            format!("swap_currency_{}", network),
-            serde_json::json!(denom),
-        );
+        swap_currencies.insert(format!("swap_currency_{}", network), denom);
     }
 
-    response.insert(
-        "transfers".to_string(),
-        serde_json::Value::Object(transfers_map),
-    );
-
-    state
-        .data_cache
-        .swap_config
-        .store(serde_json::Value::Object(response));
+    state.data_cache.swap_config.store(SwapConfigResponse {
+        blacklist: swap_settings.blacklist.clone(),
+        fee: swap_settings.fee,
+        swap_to_currency,
+        transfers,
+        swap_currencies,
+    });
 }
 
 /// Refresh lease configs for all protocols
@@ -2636,10 +2621,13 @@ mod tests {
         state.data_cache.gated_config.store(sample_gated_bundle());
 
         // Pre-seed swap_config with a sentinel.
-        state
-            .data_cache
-            .swap_config
-            .store(json!({"sentinel": true}));
+        state.data_cache.swap_config.store(SwapConfigResponse {
+            blacklist: vec!["SENTINEL".to_string()],
+            fee: 0,
+            swap_to_currency: String::new(),
+            transfers: BTreeMap::new(),
+            swap_currencies: BTreeMap::new(),
+        });
 
         Mock::given(method("GET"))
             .and(path("/api/protocols"))
@@ -2655,13 +2643,19 @@ mod tests {
         refresh_swap_config(&state).await;
 
         let loaded = state.data_cache.swap_config.load().expect("stale retained");
-        assert_eq!(loaded, json!({"sentinel": true}));
+        assert_eq!(loaded.blacklist, ["SENTINEL"]);
     }
 
     #[tokio::test]
     async fn refresh_swap_config_populates_on_success() {
         let (state, etl, _chain) = state_with_wiremock_etl_and_chain().await;
-        state.data_cache.gated_config.store(sample_gated_bundle());
+        let mut bundle = sample_gated_bundle();
+        bundle
+            .swap_settings
+            .swap_currencies
+            .insert("osmosis".to_string(), "USDC".to_string());
+        bundle.swap_settings.swap_to_currency = Some("USDC".to_string());
+        state.data_cache.gated_config.store(bundle);
 
         Mock::given(method("GET"))
             .and(path("/api/protocols"))
@@ -2677,11 +2671,20 @@ mod tests {
         refresh_swap_config(&state).await;
 
         let loaded = state.data_cache.swap_config.load().expect("populated");
-        let obj = loaded.as_object().expect("object");
-        assert!(obj.contains_key("blacklist"));
-        assert!(obj.contains_key("fee"));
-        assert!(obj.contains_key("swap_to_currency"));
-        assert!(obj.contains_key("transfers"));
+        assert_eq!(loaded.fee, 35);
+        assert_eq!(loaded.swap_to_currency, "ibc/USDC-NOLUS");
+        let osmosis = loaded
+            .transfers
+            .get("OSMOSIS")
+            .expect("OSMOSIS transfers present");
+        assert_eq!(osmosis.currencies[0].from, "ibc/USDC-NOLUS");
+        assert_eq!(osmosis.currencies[0].to, "ibc/USDC-DEX");
+
+        // Wire contract: per-network currencies flatten to dynamic
+        // `swap_currency_<network>` top-level keys, never named fields.
+        let wire = serde_json::to_value(&loaded).expect("swap config serializes");
+        assert_eq!(wire["swap_currency_osmosis"], "ibc/USDC-NOLUS");
+        assert_eq!(wire["blacklist"], json!([]));
     }
 
     #[tokio::test]
@@ -2748,12 +2751,7 @@ mod tests {
         refresh_swap_config(&state).await;
 
         let loaded = state.data_cache.swap_config.load().expect("populated");
-        let transfers = loaded
-            .as_object()
-            .and_then(|o| o.get("transfers"))
-            .and_then(|t| t.as_object())
-            .expect("transfers object");
-        assert!(!transfers.contains_key("NOLUS"));
+        assert!(!loaded.transfers.contains_key("NOLUS"));
     }
 
     // =======================================================================

--- a/src/common/api/types/swap.ts
+++ b/src/common/api/types/swap.ts
@@ -93,11 +93,20 @@ export interface SkipStatusRequest {
 
 export interface SkipStatusResponse {
   state: string;
-  error?: string;
-  transfer_sequence?: SkipTransferSequence[];
+  error?: SkipStatusError;
+  transfer_sequence?: SkipTransferEvent[];
 }
 
-export interface SkipTransferSequence {
+export interface SkipStatusError {
+  message?: string;
+}
+
+/** One hop in a Skip transfer sequence; each entry wraps exactly one transfer kind. */
+export interface SkipTransferEvent {
+  ibc_transfer?: SkipIbcTransferStatus;
+}
+
+export interface SkipIbcTransferStatus {
   src_chain_id: string;
   dst_chain_id: string;
   state: string;

--- a/src/common/utils/SkipRoute.test.ts
+++ b/src/common/utils/SkipRoute.test.ts
@@ -513,8 +513,7 @@ describe("SkipRouter.fetchStatus", () => {
 
   it("returns status on STATE_COMPLETED_SUCCESS", async () => {
     (BackendApi.getSkipStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
-      state: "STATE_COMPLETED_SUCCESS",
-      error: ""
+      state: "STATE_COMPLETED_SUCCESS"
     });
     const res = await SkipRouter.fetchStatus("hash", "chain");
     expect(res.state).toBe("STATE_COMPLETED_SUCCESS");
@@ -522,25 +521,23 @@ describe("SkipRouter.fetchStatus", () => {
 
   it("throws on STATE_ABANDONED", async () => {
     (BackendApi.getSkipStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
-      state: "STATE_ABANDONED",
-      error: ""
+      state: "STATE_ABANDONED"
     });
     await expect(SkipRouter.fetchStatus("h", "c")).rejects.toThrow();
   });
 
   it("throws on STATE_COMPLETED_ERROR", async () => {
     (BackendApi.getSkipStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
-      state: "STATE_COMPLETED_ERROR",
-      error: ""
+      state: "STATE_COMPLETED_ERROR"
     });
     await expect(SkipRouter.fetchStatus("h", "c")).rejects.toThrow();
   });
 
-  it("throws when the backend returns an error string", async () => {
+  it("throws the structured error's message when the backend returns one", async () => {
     (BackendApi.getSkipStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
       state: "STATE_PENDING",
-      error: "rate limited"
+      error: { message: "rate limited" }
     });
-    await expect(SkipRouter.fetchStatus("h", "c")).rejects.toBe("rate limited");
+    await expect(SkipRouter.fetchStatus("h", "c")).rejects.toThrow("rate limited");
   });
 });

--- a/src/common/utils/SkipRoute.ts
+++ b/src/common/utils/SkipRoute.ts
@@ -61,7 +61,7 @@ class Swap {
     const status = await BackendApi.getSkipStatus(chain_id, tx_hash);
     return {
       state: status.state,
-      error: status.error || ""
+      error: status.error?.message ?? ""
     };
   }
 
@@ -216,7 +216,7 @@ export class SkipRouter {
     const status = await client.getTransactionStatus({ chain_id: chainId, tx_hash: hash });
 
     if (status.error) {
-      throw status.error;
+      throw new Error(status.error);
     }
 
     switch (status.state) {


### PR DESCRIPTION
## Summary

Replace the two remaining untyped `serde_json::Value` surfaces in the swap backend, extending the route/messages ingress validation from #217. Closes #220 and #219.

`/api/swap/config` is now assembled, cached, and served as a typed `SwapConfigResponse`. The per-network `swap_currency_<network>` keys stay a flattened dynamic map — never named fields — so a deprecated network can vanish from the response without a type change, preserving the schema-decoupling contract from #228. The serialized wire shape is unchanged (pinned by a test asserting the dynamic keys).

`/api/swap/status/{tx_hash}` now validates Skip's response at ingress instead of forwarding it opaquely. Skip's published v2 contract settled the three contradictory `transfer_sequence` declarations: entries are wrapped per-hop events and `error` is a structured object, so the flat frontend type was wrong on both counts and has been corrected. `state` is the only required field (the tracking loops dispatch on nothing else); a payload without it returns 502 instead of spinning the 60-retry poll. Unconsumed fields are preserved verbatim via flattened maps.

## Changes

- `SwapConfigResponse` / `NetworkTransfers` / `TransferCurrency` in `handlers/swap.rs`; `refresh_swap_config` builds the struct directly; cache is `Cached<SwapConfigResponse>`; stale-on-ETL-error semantics unchanged; `BTreeMap` makes key order deterministic
- `SkipStatusResponse` reworked in `external/skip.rs`: required `state`, structured `SkipStatusError`, wrapped `SkipTransferEvent` hops, flatten-preserve for everything else; the legacy required `status` field (not in Skip's v2 contract) is dropped; status handler routes through the typed client method
- WS tracking (`websocket.rs check_skip_tx_status`) reconciled to the documented state enum: it previously matched `STATE_FAILED`/`STATE_COMPLETED` (which do not exist in v2) and treated `STATE_COMPLETED_ERROR`/`STATE_PENDING_ERROR` as pending forever; it now also surfaces Skip's `error.message`
- Frontend `SkipStatusResponse` corrected to the wrapped shape; `SkipRoute.getTransactionStatus` extracts `error.message` at the boundary (previously a raw object could be thrown where the type promised a string)
- `SkipClient::get_raw` removed — this change orphaned its last production caller
- OpenAPI snapshot regenerated; both endpoints now advertise real schemas instead of `Object`

## Verification

- Ran the backend gate: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` (with the CI allow-list), `scripts/style-check.sh`, `cargo build --all-targets`, `cargo test --all-targets` — 477 tests pass, including the OpenAPI snapshot guard
- Ran the frontend gate: `npm run lint`, `npm run format:check`, `npm run test:coverage` (906 tests, coverage floors hold), `npm run build`
- New tests: status round-trip preservation (wrapped IBC + non-IBC hops + extra tracking fields re-serialize byte-equal), missing-`state` rejection, null-optional acceptance, swap-config wire-shape assertion incl. dynamic `swap_currency_osmosis` key, frontend structured-error propagation
- Verified the serialized swap-config shape field-by-field against the frontend Zod schema (`SkipRouteConfigSchema`) — key names, nesting, and value types identical; only key order changes, which no JSON consumer observes
- Two independent fresh-context reviews of the full diff: the 12-item bug checklist passed on every item with one finding (the orphaned `get_raw`, removed); the security pass reported no findings above informational — upstream `error.message` reaches UI text only through escaped interpolation, the Skip API key cannot reach error bodies, and the typed struct is field-exact with the old assembly so no gated-config fields leak

## Follow-ups

- Per-hop `ibc_transfer.state` matching in `check_skip_tx_status` still includes a vestigial `STATE_COMPLETED` value vs Skip's documented `TRANSFER_*` hop states — pre-existing, worth its own issue