### PR TITLE
fix(history): read the lease search response as the bare address array

### DIFF
--- a/src/common/api/BackendApi.test.ts
+++ b/src/common/api/BackendApi.test.ts
@@ -634,5 +634,25 @@ describe("BackendApi", () => {
       if (plainCall === undefined) throw new Error("expected fetch to have been called for the plain request");
       expect(String(plainCall[0])).not.toContain("search=");
     });
+
+    it("searchLeases returns the live bare string-array response as lease addresses", async () => {
+      const api = new BackendApiClient();
+      fetchMock.mockResolvedValueOnce(jsonResponse(["nolus1aaa", "nolus1bbb"]));
+      await expect(api.searchLeases("nolus1x", 0, 10)).resolves.toEqual(["nolus1aaa", "nolus1bbb"]);
+    });
+
+    it("searchLeases unwraps a paginated wrapper response to lease addresses", async () => {
+      const api = new BackendApiClient();
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ data: [{ lease_address: "nolus1ccc" }], total: 1, skip: 0, limit: 10 })
+      );
+      await expect(api.searchLeases("nolus1x", 0, 10)).resolves.toEqual(["nolus1ccc"]);
+    });
+
+    it("searchLeases rejects an unrecognized response shape", async () => {
+      const api = new BackendApiClient();
+      fetchMock.mockResolvedValueOnce(jsonResponse({ leases: ["nolus1ddd"] }));
+      await expect(api.searchLeases("nolus1x", 0, 10)).rejects.toThrow(/lease search/);
+    });
   });
 });

--- a/src/common/api/BackendApi.ts
+++ b/src/common/api/BackendApi.ts
@@ -83,7 +83,6 @@ import type {
   TransactionFilters,
   LeaseOpeningResponse,
   LeaseClosingEntry,
-  LeasesSearchResponse,
   LpWithdrawResponse,
   RealizedPnlDataResponse
 } from "./types";
@@ -601,19 +600,15 @@ export class BackendApiClient {
   }
 
   /**
-   * Search leases by address
+   * Search leases by address. Returns the matching lease contract addresses.
    */
-  async searchLeases(
-    address: string,
-    skip: number = 0,
-    limit: number = 50,
-    search?: string
-  ): Promise<LeasesSearchResponse> {
+  async searchLeases(address: string, skip: number = 0, limit: number = 50, search?: string): Promise<string[]> {
     const params: Record<string, string | number> = { address, skip, limit };
     if (search && search.length > 0) {
       params.search = search;
     }
-    return this.request<LeasesSearchResponse>("GET", "/api/etl/leases-search", { params });
+    const res = await this.request<unknown>("GET", "/api/etl/leases-search", { params });
+    return parseLeaseAddresses(res);
   }
 
   /**
@@ -736,6 +731,35 @@ export class BackendApiClient {
   async getEtlPools(): Promise<PoolsResponse> {
     return this.request<PoolsResponse>("GET", "/api/etl/pools");
   }
+}
+
+// The live ETL passthrough returns a bare string array (verified against the
+// deployed backend); a paginated { data: [{ lease_address }] } wrapper is
+// tolerated because prod and dev ETL versions are known to drift. Anything
+// else fails loudly rather than rendering an empty filter.
+function parseLeaseAddresses(res: unknown): string[] {
+  if (Array.isArray(res)) {
+    return res.map((entry) => {
+      if (typeof entry !== "string") {
+        throw new Error("Unrecognized lease search entry shape");
+      }
+      return entry;
+    });
+  }
+  if (res !== null && typeof res === "object" && "data" in res && Array.isArray(res.data)) {
+    return res.data.map((entry: unknown) => {
+      if (
+        entry !== null &&
+        typeof entry === "object" &&
+        "lease_address" in entry &&
+        typeof entry.lease_address === "string"
+      ) {
+        return entry.lease_address;
+      }
+      throw new Error("Unrecognized lease search entry shape");
+    });
+  }
+  throw new Error("Unrecognized lease search response shape");
 }
 
 // Export singleton instance

--- a/src/common/api/types/etl.ts
+++ b/src/common/api/types/etl.ts
@@ -457,28 +457,6 @@ export interface LeaseClosingEntry {
 }
 
 /**
- * Lease search entry
- */
-export interface LeaseSearchEntry {
-  lease_address: string;
-  status: string;
-  protocol: string;
-  position_ticker?: string;
-  position_amount?: string;
-  pnl?: string;
-}
-
-/**
- * Leases search paginated response
- */
-export interface LeasesSearchResponse {
-  data: LeaseSearchEntry[];
-  total: number;
-  skip: number;
-  limit: number;
-}
-
-/**
  * LP withdraw response
  */
 export interface LpWithdrawResponse {

--- a/src/modules/history/components/FilterLeaseId.vue
+++ b/src/modules/history/components/FilterLeaseId.vue
@@ -100,11 +100,11 @@ async function fetchPositions(): Promise<PositionItem[]> {
     return [];
   }
 
-  const res = await BackendApi.searchLeases(wallet.wallet.address, skip, limit, search.value);
+  const leaseAddresses = await BackendApi.searchLeases(wallet.wallet.address, skip, limit, search.value);
 
-  return res.data.map((item) => ({
-    contract: item.lease_address,
-    label: `#${item.lease_address.slice(-8)}`,
+  return leaseAddresses.map((contract) => ({
+    contract,
+    label: `#${contract.slice(-8)}`,
     checked: false
   }));
 }


### PR DESCRIPTION
## Summary

Fix the lease-ID filter broken by #248: the live `/api/etl/leases-search` passthrough returns a bare string array, but the strict-floor rework trusted the repo's declared paginated-wrapper type — which turns out to be fiction — so `res.data.map` threw on every fetch. `searchLeases` now validates the response shape at the boundary and returns the lease addresses.

## Changes

- `BackendApi.searchLeases` returns `Promise<string[]>`, parsing the response through a shape validator: bare string array is the live contract, the paginated `{ data: [{ lease_address }] }` wrapper stays tolerated (prod and dev ETL versions are known to drift), anything else throws instead of rendering an empty filter
- `FilterLeaseId.vue` maps the addresses directly (restores the pre-#248 runtime behavior)
- Deleted the fictional `LeasesSearchResponse` / `LeaseSearchEntry` types — no consumers remain; see the correction on #249 (the dead backend client's `Vec<String>` model was the accurate one)

## Verification

- Verified the live wire shape directly against the deployed dev backend: HTTP 200, `content-type: application/json`, body `[]` (bare array) for an address with no leases
- Wrote the regression tests first and confirmed the wrapper-unwrap and shape-reject cases failed against the previous code, then fixed: 42/42 in the BackendApi suite, 990 tests total through the pre-commit gate
- Ran `npm run typecheck` (0 errors), `npm run lint`, `npm run lint:style`, `npm run format:check`, `npm run build` — all clean

## Follow-ups

- Delete the dead backend `search_leases` client — already tracked in #249 (premise corrected there)