### PR TITLE
refactor(leases): drain long/short form scripts into composables

### DIFF
--- a/src/modules/leases/components/new-lease/LongForm.vue
+++ b/src/modules/leases/components/new-lease/LongForm.vue
@@ -172,7 +172,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, watch } from "vue";
+import { h } from "vue";
 import {
   AdvancedFormControl,
   Button,
@@ -181,39 +181,15 @@ import {
   Slider,
   Size,
   type AssetItemProps,
-  AssetItem,
-  ToastType
+  AssetItem
 } from "web-components";
-import { RouteNames } from "@/router";
 import { tabs } from "../types";
 import LongLeaseDetails from "@/modules/leases/components/new-lease/LongLeaseDetails.vue";
-import { useWalletStore } from "@/common/stores/wallet";
-import { useBalancesStore } from "@/common/stores/balances";
-import { useConfigStore } from "@/common/stores/config";
-import { usePricesStore } from "@/common/stores/prices";
-import { useHistoryStore } from "@/common/stores/history";
-import { classifyError, getMicroAmount, Logger, walletOperation } from "@/common/utils";
-import { formatDecAsUsd, formatUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
 import { NATIVE_NETWORK } from "../../../../config/global/network";
-import type { ExternalCurrency } from "@/common/types";
-import { INTEREST_DECIMALS, MAX_POSITION, MIN_POSITION, POSITIONS, SORT_LEASE, WASM_EVENTS } from "@/config/global";
-import { Dec } from "@keplr-wallet/unit";
-import { h } from "vue";
-import { useI18n } from "vue-i18n";
-import type { NolusWallet } from "@nolus/nolusjs";
-import { NolusClient } from "@nolus/nolusjs";
-import { Leaser } from "@nolus/nolusjs/build/contracts";
-import { useRouter } from "vue-router";
-import { useLeaseOpen } from "./useLeaseOpen";
+import { MAX_POSITION, MIN_POSITION, POSITIONS } from "@/config/global";
+import { useLongLeaseForm } from "./useLongLeaseForm";
 
 const activeTabIdx = 0;
-const walletStore = useWalletStore();
-const balancesStore = useBalancesStore();
-const configStore = useConfigStore();
-const pricesStore = usePricesStore();
-const historyStore = useHistoryStore();
-const i18n = useI18n();
-const router = useRouter();
 
 const {
   selectedCurrency,
@@ -222,364 +198,18 @@ const {
   isDisabled,
   amount,
   amountErrorMsg,
-  ltd,
   leaseApply,
-  errorInsufficientBalance,
   handleAmountChange,
   handleParentClick,
   onDrag,
-  validateMinMaxValues,
-  validateAmountAgainstBalance,
-  isDownPaymentAmountValid
-} = useLeaseOpen();
-
-const onShowToast = inject("onShowToast", (_data: { type: ToastType; message: string }) => {});
-const reload = inject("reload", () => {});
-
-watch(
-  () => configStore.initialized,
-  () => {
-    if (configStore.initialized) {
-      void onInit();
-    }
-  },
-  {
-    immediate: true
-  }
-);
-
-async function onInit() {
-  // Free interest is handled by a 3rd party service
-  // Asset filtering (ignore_long) is now done by the backend in /api/protocols/{protocol}/currencies
-}
-
-watch(
-  () => [selectedCurrency.value, amount.value, selectedLoanCurrency.value, ltd.value],
-  async () => {
-    amountErrorMsg.value = "";
-    if (!validateAmountAgainstBalance(currency.value)) {
-      leaseApply.value = null;
-      return;
-    }
-    if (await validateMinMaxValues(currency.value, coinList.value[selectedLoanCurrency.value])) {
-      void calculate();
-    } else {
-      leaseApply.value = null;
-    }
-  }
-);
-
-const totalBalances = computed(() => {
-  const currencies: ExternalCurrency[] = [];
-  // Use long protocols from gated protocols API
-  const longProtocols = configStore.longProtocolsForCurrentNetwork;
-
-  for (const protocol of longProtocols) {
-    // Get cached currencies for this protocol
-    const protocolCurrencies = configStore.getCachedProtocolCurrencies(protocol.protocol);
-
-    for (const currency of protocolCurrencies) {
-      // Find matching currency in currenciesData to get full info
-      const key = `${currency.ticker}@${protocol.protocol}`;
-      const currencyInfo = configStore.currenciesData?.[key];
-
-      if (currencyInfo) {
-        const balance = balancesStore.balances.find((b) => b.denom === currencyInfo.ibcData);
-        currencies.push({ ...currencyInfo, balance: balance } as ExternalCurrency);
-      }
-    }
-  }
-  return currencies;
-});
-
-const isShortEnabled = computed(() => {
-  // Use dynamic check from config store instead of hardcoded protocolsFilter
-  return configStore.hasShortProtocols(configStore.protocolFilter);
-});
-
-const isProtocolDisabled = computed(() => {
-  // Use dynamic check from config store instead of hardcoded protocolsFilter
-  return configStore.isNetworkDisabled(configStore.protocolFilter);
-});
-
-const currency = computed(() => {
-  return assets.value[selectedCurrency.value];
-});
-
-const selectedLoanOption = computed(() => {
-  return coinList.value[selectedLoanCurrency.value];
-});
-
-const advancedControlBindings = computed(() => {
-  return {
-    ...(errorInsufficientBalance.value ? { inputClass: "text-typography-error" } : {}),
-    ...(currency.value !== undefined ? { selectedCurrencyOption: currency.value } : {})
-  };
-});
-
-const assets = computed(() => {
-  const data = [];
-  // Use dynamic protocols from config store instead of hardcoded protocolsFilter.hold
-  const activeProtocols = configStore.getActiveProtocolsForNetwork(configStore.protocolFilter);
-  const b = ((balances.value as ExternalCurrency[]) ?? []).filter((item) => {
-    const [_, p] = item.key.split("@");
-
-    if (p === undefined) {
-      console.error(`LongForm: malformed currency key: ${item.key}`);
-      return false;
-    }
-    if (activeProtocols.includes(p)) {
-      return true;
-    }
-    return false;
-  });
-
-  for (const asset of b) {
-    const value = new Dec(asset.balance?.amount.toString() ?? 0, asset.decimal_digits);
-    const balance = formatTokenBalance(value);
-    const exactBalance = value.isZero() ? "0" : value.toString(asset.decimal_digits).replace(/\.?0+$/, "");
-    const denom = asset.ibcData;
-    const price = new Dec(pricesStore.prices[asset.key]?.price ?? 0);
-    const stable = price.mul(value);
-
-    data.push({
-      name: asset.name,
-      value: denom,
-      label: asset.shortName,
-      shortName: asset.shortName,
-      icon: asset.icon,
-      decimal_digits: asset.decimal_digits,
-      balance: {
-        value: exactBalance,
-        customLabel: `${balance} ${asset.shortName}`,
-        ticker: asset.shortName,
-        denom: asset.balance?.denom,
-        amount: asset.balance?.amount
-      },
-      ibcData: (asset as ExternalCurrency).ibcData,
-      native: asset.native,
-      symbol: asset.symbol,
-      ticker: asset.ticker,
-      key: asset.key,
-      stable,
-      price: formatDecAsUsd(stable)
-    });
-  }
-  return data.sort((a, b) => {
-    return Number(b.stable.sub(a.stable).toString(8));
-  });
-});
-
-const coinList = computed(() => {
-  if (!currency.value?.key) {
-    return [];
-  }
-
-  const [_ticker, downPaymentProtocol] = currency.value.key.split("@");
-  if (downPaymentProtocol === undefined) {
-    console.error(`LongForm: malformed currency key: ${currency.value.key}`);
-    return [];
-  }
-
-  // Get currencies for the selected protocol that can be leased (group === "lease")
-  const protocolCurrencies = configStore.getCachedProtocolCurrencies(downPaymentProtocol);
-  const leaseCurrencies = protocolCurrencies.filter((c) => c.group === "lease");
-
-  // Backend already filters out ignored assets in /api/protocols/{protocol}/currencies
-  const list = leaseCurrencies.map((item) => {
-    return {
-      decimal_digits: item.decimals,
-      key: `${item.ticker}@${downPaymentProtocol}`,
-      ticker: item.ticker,
-      label: item.shortName,
-      value: item.bank_symbol,
-      icon: item.icon
-    };
-  });
-
-  const sortOrder = new Map(SORT_LEASE.map((t, i) => [t, i]));
-
-  return list.sort((a, b) => {
-    const aIndex = sortOrder.get(a.ticker);
-    const bIndex = sortOrder.get(b.ticker);
-    if (aIndex === undefined && bIndex === undefined) return 0;
-    if (aIndex !== undefined && bIndex === undefined) return -1;
-    if (aIndex === undefined && bIndex !== undefined) return 1;
-    return (aIndex as number) - (bIndex as number);
-  });
-});
-
-const calculatedBalance = computed(() => {
-  const asset = assets.value[selectedCurrency.value];
-  if (!asset) {
-    return formatUsd(0);
-  }
-  const price = new Dec(pricesStore.prices[asset.key]?.price ?? 0);
-  const v = amount?.value?.length ? amount?.value : "0";
-  const stable = price.mul(new Dec(v));
-  return formatDecAsUsd(stable);
-});
-
-const balances = computed(() => {
-  // Backend already filters out ignored assets in /api/protocols/{protocol}/currencies
-  return totalBalances.value.filter((item) => {
-    if (!item.key) {
-      return false;
-    }
-
-    const [ticker, protocol] = item.key?.split("@") ?? [];
-    if (protocol === undefined) {
-      console.error(`LongForm: malformed currency key: ${item.key}`);
-      return false;
-    }
-
-    // Get protocol currencies from cache and check if this is valid collateral
-    const protocolCurrencies = configStore.getCachedProtocolCurrencies(protocol);
-    const currencyInfo = protocolCurrencies.find((c) => c.ticker === ticker);
-
-    // Valid collateral: LPN, native, or lease currencies
-    if (currencyInfo) {
-      return currencyInfo.group === "lpn" || currencyInfo.group === "native" || currencyInfo.group === "lease";
-    }
-
-    return false;
-  });
-});
-
-async function calculate() {
-  try {
-    const selectedDownPaymentCurrency = currency.value;
-    const selectedCurrency = coinList.value[selectedLoanCurrency.value];
-    const downPayment = amount.value;
-
-    if (downPayment) {
-      if (selectedDownPaymentCurrency === undefined || selectedCurrency === undefined) {
-        throw new Error("down payment or lease currency is not selected");
-      }
-      const denom = selectedDownPaymentCurrency.balance.denom;
-      if (denom === undefined) {
-        throw new Error(`missing bank denom for ${selectedDownPaymentCurrency.key}`);
-      }
-      const microAmount = getMicroAmount(denom, downPayment);
-
-      const lease = selectedCurrency;
-
-      const [downPaymentTicker, protocol] = selectedDownPaymentCurrency.key.split("@");
-      const [leaseTicker] = lease.key.split("@");
-      if (downPaymentTicker === undefined || protocol === undefined || leaseTicker === undefined) {
-        throw new Error(`malformed currency key: ${selectedDownPaymentCurrency.key} / ${lease.key}`);
-      }
-
-      const contracts = configStore.contracts[protocol];
-      if (contracts === undefined || contracts.leaser === null) {
-        throw new Error(`no leaser contract configured for protocol ${protocol}`);
-      }
-
-      const cosmWasmClient = await NolusClient.getInstance().getCosmWasmClient();
-      const leaserClient = new Leaser(cosmWasmClient, contracts.leaser);
-
-      const makeLeaseApplyResp = await leaserClient.leaseQuote(
-        microAmount.mAmount.amount.toString(),
-        downPaymentTicker,
-        leaseTicker,
-        ltd.value
-      );
-
-      makeLeaseApplyResp.annual_interest_rate =
-        makeLeaseApplyResp.annual_interest_rate / Math.pow(10, INTEREST_DECIMALS);
-      makeLeaseApplyResp.annual_interest_rate_margin =
-        makeLeaseApplyResp.annual_interest_rate_margin / Math.pow(10, INTEREST_DECIMALS);
-
-      leaseApply.value = makeLeaseApplyResp;
-    } else {
-      leaseApply.value = null;
-    }
-  } catch (error) {
-    Logger.error("LongForm calculate error:", error);
-    amountErrorMsg.value = i18n.t(classifyError(error));
-    leaseApply.value = null;
-  }
-}
-
-async function onOpenLease() {
-  try {
-    isDisabled.value = true;
-    await walletOperation(openLease);
-  } catch (error: unknown) {
-    amountErrorMsg.value = i18n.t(classifyError(error));
-    Logger.error(error);
-  } finally {
-    isDisabled.value = false;
-  }
-}
-
-async function openLease() {
-  const wallet = walletStore.wallet as NolusWallet;
-  if (wallet && (await isDownPaymentAmountValid(currency.value, coinList.value[selectedLoanCurrency.value]))) {
-    try {
-      isLoading.value = true;
-
-      const selectedDownPaymentCurrency = currency.value;
-      const downPayment = amount.value;
-      const selectedCurrency = coinList.value[selectedLoanCurrency.value];
-
-      if (selectedDownPaymentCurrency === undefined || selectedCurrency === undefined) {
-        throw new Error("down payment or lease currency is not selected");
-      }
-      const denom = selectedDownPaymentCurrency.balance.denom;
-      if (denom === undefined) {
-        throw new Error(`missing bank denom for ${selectedDownPaymentCurrency.key}`);
-      }
-      const microAmount = getMicroAmount(denom, downPayment);
-
-      const funds = [
-        {
-          denom: microAmount.coinMinimalDenom,
-          amount: microAmount.mAmount.amount.toString()
-        }
-      ];
-
-      const cosmWasmClient = await NolusClient.getInstance().getCosmWasmClient();
-
-      const [leaseTicker, protocol] = selectedCurrency.key.split("@");
-      if (leaseTicker === undefined || protocol === undefined) {
-        throw new Error(`malformed lease currency key: ${selectedCurrency.key}`);
-      }
-
-      const contracts = configStore.contracts[protocol];
-      if (contracts === undefined || contracts.leaser === null) {
-        throw new Error(`no leaser contract configured for protocol ${protocol}`);
-      }
-
-      const leaserClient = new Leaser(cosmWasmClient, contracts.leaser);
-
-      const { txBytes } = await leaserClient.simulateOpenLeaseTx(wallet, leaseTicker, ltd.value, funds);
-
-      const tx = await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
-
-      const item = tx?.events.find((event) => {
-        return event.type === WASM_EVENTS["wasm-ls-request-loan"].key;
-      });
-
-      const data = item?.attributes[WASM_EVENTS["wasm-ls-request-loan"].index];
-      void balancesStore.fetchBalances();
-      void historyStore.loadActivities();
-      reload();
-      onShowToast({
-        type: ToastType.success,
-        message: i18n.t("message.currently-opening")
-      });
-
-      if (data === undefined) {
-        throw new Error("wasm-ls-request-loan event attribute missing from the broadcast result");
-      }
-      void router.push(`/${RouteNames.LEASES}/${data.value}`);
-    } catch (error: unknown) {
-      amountErrorMsg.value = i18n.t(classifyError(error));
-      Logger.error(error);
-    } finally {
-      isLoading.value = false;
-    }
-  }
-}
+  assets,
+  coinList,
+  currency,
+  selectedLoanOption,
+  advancedControlBindings,
+  calculatedBalance,
+  isShortEnabled,
+  isProtocolDisabled,
+  onOpenLease
+} = useLongLeaseForm();
 </script>

--- a/src/modules/leases/components/new-lease/ShortForm.vue
+++ b/src/modules/leases/components/new-lease/ShortForm.vue
@@ -172,7 +172,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, watch } from "vue";
+import { h } from "vue";
 import {
   AdvancedFormControl,
   Button,
@@ -181,42 +181,15 @@ import {
   Slider,
   Size,
   type AssetItemProps,
-  AssetItem,
-  ToastType
+  AssetItem
 } from "web-components";
-import { RouteNames } from "@/router";
 import { tabs } from "../types";
-
 import ShortLeaseDetails from "@/modules/leases/components/new-lease/ShortLeaseDetails.vue";
-import { useWalletStore } from "@/common/stores/wallet";
-import { useBalancesStore } from "@/common/stores/balances";
-import { useConfigStore } from "@/common/stores/config";
-import { usePricesStore } from "@/common/stores/prices";
-import { useHistoryStore } from "@/common/stores/history";
-import { classifyError, getMicroAmount, Logger, walletOperation } from "@/common/utils";
-import { formatDecAsUsd, formatUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
 import { NATIVE_NETWORK } from "../../../../config/global/network";
-import type { ExternalCurrency } from "@/common/types";
-import { INTEREST_DECIMALS, MAX_POSITION, MIN_POSITION, POSITIONS, SORT_LEASE, WASM_EVENTS } from "@/config/global";
-import { Dec } from "@keplr-wallet/unit";
-import { h } from "vue";
-import { useI18n } from "vue-i18n";
-import type { NolusWallet } from "@nolus/nolusjs";
-import { NolusClient } from "@nolus/nolusjs";
-import { Leaser } from "@nolus/nolusjs/build/contracts";
-import { useRouter } from "vue-router";
-import { useLeaseOpen } from "./useLeaseOpen";
+import { MAX_POSITION, MIN_POSITION, POSITIONS } from "@/config/global";
+import { useShortLeaseForm } from "./useShortLeaseForm";
 
 const activeTabIdx = 1;
-const walletStore = useWalletStore();
-const balancesStore = useBalancesStore();
-const configStore = useConfigStore();
-const pricesStore = usePricesStore();
-const historyStore = useHistoryStore();
-const i18n = useI18n();
-const router = useRouter();
-const onShowToast = inject("onShowToast", (_data: { type: ToastType; message: string }) => {});
-const reload = inject("reload", () => {});
 
 const {
   selectedCurrency,
@@ -225,337 +198,16 @@ const {
   isDisabled,
   amount,
   amountErrorMsg,
-  ltd,
   leaseApply,
-  errorInsufficientBalance,
   handleAmountChange,
   handleParentClick,
   onDrag,
-  validateMinMaxValues,
-  validateAmountAgainstBalance,
-  isDownPaymentAmountValid
-} = useLeaseOpen();
-
-watch(
-  () => configStore.initialized,
-  () => {
-    if (configStore.initialized) {
-      void onInit();
-    }
-  },
-  {
-    immediate: true
-  }
-);
-
-async function onInit() {
-  // Free interest is handled by a 3rd party service
-  // Asset filtering (ignore_short) is now done by the backend in /api/protocols/{protocol}/currencies
-}
-
-watch(
-  () => [selectedCurrency.value, amount.value, selectedLoanCurrency.value, ltd.value],
-  async () => {
-    amountErrorMsg.value = "";
-    if (!validateAmountAgainstBalance(currency.value)) {
-      leaseApply.value = null;
-      return;
-    }
-    if (await validateMinMaxValues(currency.value, coinList.value[selectedLoanCurrency.value])) {
-      void calculate();
-    } else {
-      leaseApply.value = null;
-    }
-  }
-);
-
-const totalBalances = computed(() => {
-  const currencies: ExternalCurrency[] = [];
-  const b = balancesStore.balances;
-  const seenDenoms = new Set<string>();
-
-  // Use short protocols from gated protocols API
-  const shortProtocols = configStore.shortProtocolsForCurrentNetwork;
-
-  for (const protocol of shortProtocols) {
-    // Get cached currencies for this protocol
-    const protocolCurrencies = configStore.getCachedProtocolCurrencies(protocol.protocol);
-
-    for (const currency of protocolCurrencies) {
-      // Find matching currency in currenciesData to get full info
-      const key = `${currency.ticker}@${protocol.protocol}`;
-      const currencyInfo = configStore.currenciesData?.[key];
-
-      if (currencyInfo) {
-        const balance = b.find((bal) => bal.denom === currencyInfo.ibcData);
-        // Deduplicate by denom
-        if (balance && !seenDenoms.has(balance.denom)) {
-          seenDenoms.add(balance.denom);
-          currencies.push({ ...currencyInfo, balance: balance } as ExternalCurrency);
-        } else if (!balance && !seenDenoms.has(currencyInfo.ibcData)) {
-          seenDenoms.add(currencyInfo.ibcData);
-          currencies.push({
-            ...currencyInfo,
-            balance: { denom: currencyInfo.ibcData, amount: "0" }
-          } as ExternalCurrency);
-        }
-      }
-    }
-  }
-
-  return currencies;
-});
-
-const currency = computed(() => {
-  return assets.value[selectedCurrency.value];
-});
-
-const selectedLoanOption = computed(() => {
-  return coinList.value[selectedLoanCurrency.value];
-});
-
-const advancedControlBindings = computed(() => {
-  return {
-    ...(errorInsufficientBalance.value ? { inputClass: "text-typography-error" } : {}),
-    ...(currency.value !== undefined ? { selectedCurrencyOption: currency.value } : {})
-  };
-});
-
-const assets = computed(() => {
-  // Backend already filters out ignored assets in /api/protocols/{protocol}/currencies
-  const data = [];
-
-  for (const asset of (totalBalances.value as ExternalCurrency[]) ?? []) {
-    const value = new Dec(asset.balance?.amount.toString() ?? 0, asset.decimal_digits);
-    const balance = formatTokenBalance(value);
-    const exactBalance = value.isZero() ? "0" : value.toString(asset.decimal_digits).replace(/\.?0+$/, "");
-    const denom = asset.ibcData;
-    const price = new Dec(pricesStore.prices[asset.key]?.price ?? 0);
-    const stable = price.mul(value);
-
-    data.push({
-      name: asset.name,
-      value: denom,
-      label: asset.shortName,
-      shortName: asset.shortName,
-      icon: asset.icon,
-      decimal_digits: asset.decimal_digits,
-      balance: {
-        value: exactBalance,
-        customLabel: `${balance} ${asset.shortName}`,
-        ticker: asset.shortName,
-        denom: asset.balance?.denom,
-        amount: asset.balance?.amount
-      },
-      ibcData: (asset as ExternalCurrency).ibcData,
-      native: asset.native,
-      symbol: asset.symbol,
-      ticker: asset.ticker,
-      key: asset.key,
-      stable,
-      price: formatDecAsUsd(stable)
-    });
-  }
-
-  return data.sort((a, b) => {
-    return Number(b.stable.sub(a.stable).toString(8));
-  });
-});
-
-const coinList = computed(() => {
-  // For short positions, the "coin to lease" is determined by the short protocols
-  // Each short protocol represents an asset that can be shorted
-  // Backend already filters out ignored assets based on lease-rules.json
-  const shortProtocols = configStore.shortProtocolsForCurrentNetwork;
-
-  const list = shortProtocols.map((protocol) => {
-    // Get the LPN info from the protocol's lpn_display
-    return {
-      key: `${protocol.lpn}@${protocol.protocol}`,
-      ticker: protocol.lpn,
-      label: protocol.lpn_display?.shortName || protocol.lpn,
-      value: protocol.lpn, // This will be used to find the currency
-      icon: protocol.lpn_display?.icon || "",
-      protocol: protocol.protocol
-    };
-  });
-
-  const sortOrder = new Map(SORT_LEASE.map((t, i) => [t, i]));
-
-  return list.sort((a, b) => {
-    const aIndex = sortOrder.get(a.ticker);
-    const bIndex = sortOrder.get(b.ticker);
-    if (aIndex === undefined && bIndex === undefined) return 0;
-    if (aIndex !== undefined && bIndex === undefined) return -1;
-    if (aIndex === undefined && bIndex !== undefined) return 1;
-    return (aIndex as number) - (bIndex as number);
-  });
-});
-
-const calculatedBalance = computed(() => {
-  const asset = assets.value[selectedCurrency.value];
-  if (!asset) {
-    return formatUsd(0);
-  }
-
-  const price = new Dec(pricesStore.prices[asset.key]?.price ?? 0);
-  const v = amount?.value?.length ? amount?.value : "0";
-  const stable = price.mul(new Dec(v));
-  return formatDecAsUsd(stable);
-});
-
-// For a Short protocol the contract's `leaseTicker` is the stable currency the
-// position is denominated in (e.g., USDC_NOBLE) — NOT the user's down payment.
-// It's exposed in the protocol currencies list with group="lease" (the only one
-// for a Short protocol; `group="lpn"` there is the borrowed asset).
-async function resolveShortLeaseTicker(protocol: string): Promise<string> {
-  const currencies = await configStore.getProtocolCurrencies(protocol);
-  const stable = currencies.find((c) => c.group === "lease");
-  if (!stable) {
-    throw new Error(`Short protocol ${protocol} has no stable (group="lease") currency`);
-  }
-  return stable.ticker;
-}
-
-async function calculate() {
-  try {
-    const downPaymentAmount = amount.value;
-    const selectedDownPaymentCurrency = currency.value;
-    const loanCurrency = coinList.value[selectedLoanCurrency.value];
-    if (downPaymentAmount) {
-      if (selectedDownPaymentCurrency === undefined || loanCurrency === undefined) {
-        throw new Error("down payment or lease currency is not selected");
-      }
-      const denom = selectedDownPaymentCurrency.balance.denom;
-      if (denom === undefined) {
-        throw new Error(`missing bank denom for ${selectedDownPaymentCurrency.key}`);
-      }
-      const microAmount = getMicroAmount(denom, downPaymentAmount);
-
-      const currency = selectedDownPaymentCurrency;
-      const [_c, protocol] = loanCurrency.key.split("@");
-
-      const [downPaymentTicker, _p] = currency.key.split("@");
-      if (protocol === undefined || downPaymentTicker === undefined) {
-        throw new Error(`malformed currency key: ${currency.key} / ${loanCurrency.key}`);
-      }
-      const leaseTicker = await resolveShortLeaseTicker(protocol);
-
-      const cosmWasmClient = await NolusClient.getInstance().getCosmWasmClient();
-
-      const contracts = configStore.contracts[protocol];
-      if (contracts === undefined || contracts.leaser === null) {
-        throw new Error(`no leaser contract configured for protocol ${protocol}`);
-      }
-      const leaserClient = new Leaser(cosmWasmClient, contracts.leaser);
-
-      const makeLeaseApplyResp = await leaserClient.leaseQuote(
-        microAmount.mAmount.amount.toString(),
-        downPaymentTicker,
-        leaseTicker,
-        ltd.value
-      );
-
-      makeLeaseApplyResp.annual_interest_rate =
-        makeLeaseApplyResp.annual_interest_rate / Math.pow(10, INTEREST_DECIMALS);
-      makeLeaseApplyResp.annual_interest_rate_margin =
-        makeLeaseApplyResp.annual_interest_rate_margin / Math.pow(10, INTEREST_DECIMALS);
-
-      leaseApply.value = makeLeaseApplyResp;
-    } else {
-      leaseApply.value = null;
-    }
-  } catch (error) {
-    Logger.error("ShortForm calculate error:", error);
-    amountErrorMsg.value = i18n.t(classifyError(error));
-    leaseApply.value = null;
-  }
-}
-
-async function onOpenLease() {
-  try {
-    isDisabled.value = true;
-    await walletOperation(openLease);
-  } catch (error: unknown) {
-    amountErrorMsg.value = i18n.t(classifyError(error));
-    Logger.error(error);
-  } finally {
-    isDisabled.value = false;
-  }
-}
-
-async function openLease() {
-  const wallet = walletStore.wallet as NolusWallet;
-  if (wallet && (await isDownPaymentAmountValid(currency.value, coinList.value[selectedLoanCurrency.value]))) {
-    try {
-      isLoading.value = true;
-
-      const selectedDownPaymentCurrency = currency.value;
-      const downPayment = amount.value;
-      const selectedCurrency = coinList.value[selectedLoanCurrency.value];
-
-      if (selectedDownPaymentCurrency === undefined || selectedCurrency === undefined) {
-        throw new Error("down payment or lease currency is not selected");
-      }
-      const denom = selectedDownPaymentCurrency.balance.denom;
-      if (denom === undefined) {
-        throw new Error(`missing bank denom for ${selectedDownPaymentCurrency.key}`);
-      }
-      const microAmount = getMicroAmount(denom, downPayment);
-
-      const funds = [
-        {
-          denom: microAmount.coinMinimalDenom,
-          amount: microAmount.mAmount.amount.toString()
-        }
-      ];
-
-      const cosmWasmClient = await NolusClient.getInstance().getCosmWasmClient();
-      const configStore = useConfigStore();
-
-      const [_borrowedTicker, protocol] = selectedCurrency.key.split("@");
-      if (protocol === undefined) {
-        throw new Error(`malformed lease currency key: ${selectedCurrency.key}`);
-      }
-      const leaseTicker = await resolveShortLeaseTicker(protocol);
-
-      const contracts = configStore.contracts[protocol];
-      if (contracts === undefined || contracts.leaser === null) {
-        throw new Error(`no leaser contract configured for protocol ${protocol}`);
-      }
-      const leaserClient = new Leaser(cosmWasmClient, contracts.leaser);
-
-      const {
-        txHash: _txHash,
-        txBytes,
-        usedFee: _usedFee
-      } = await leaserClient.simulateOpenLeaseTx(wallet, leaseTicker, ltd.value, funds);
-
-      const tx = await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
-
-      const item = tx?.events.find((event) => {
-        return event.type === WASM_EVENTS["wasm-ls-request-loan"].key;
-      });
-
-      const data = item?.attributes[WASM_EVENTS["wasm-ls-request-loan"].index];
-      void balancesStore.fetchBalances();
-      void historyStore.loadActivities();
-      reload();
-      onShowToast({
-        type: ToastType.success,
-        message: i18n.t("message.currently-opening")
-      });
-
-      if (data === undefined) {
-        throw new Error("wasm-ls-request-loan event attribute missing from the broadcast result");
-      }
-      void router.push(`/${RouteNames.LEASES}/${data.value}`);
-    } catch (error: unknown) {
-      amountErrorMsg.value = i18n.t(classifyError(error));
-      Logger.error(error);
-    } finally {
-      isLoading.value = false;
-    }
-  }
-}
+  assets,
+  coinList,
+  currency,
+  selectedLoanOption,
+  advancedControlBindings,
+  calculatedBalance,
+  onOpenLease
+} = useShortLeaseForm();
 </script>

--- a/src/modules/leases/components/new-lease/useLeaseForm.ts
+++ b/src/modules/leases/components/new-lease/useLeaseForm.ts
@@ -1,0 +1,291 @@
+import { computed, inject, watch, type ComputedRef } from "vue";
+import { ToastType } from "web-components";
+import { RouteNames } from "@/router";
+import { useWalletStore } from "@/common/stores/wallet";
+import { useBalancesStore } from "@/common/stores/balances";
+import { useConfigStore } from "@/common/stores/config";
+import { usePricesStore } from "@/common/stores/prices";
+import { useHistoryStore } from "@/common/stores/history";
+import { classifyError, getMicroAmount, Logger, walletOperation } from "@/common/utils";
+import { formatDecAsUsd, formatUsd } from "@/common/utils/NumberFormatUtils";
+import { INTEREST_DECIMALS, WASM_EVENTS } from "@/config/global";
+import { Dec } from "@keplr-wallet/unit";
+import { useI18n } from "vue-i18n";
+import type { NolusWallet } from "@nolus/nolusjs";
+import { NolusClient } from "@nolus/nolusjs";
+import { Leaser } from "@nolus/nolusjs/build/contracts";
+import { useRouter } from "vue-router";
+import type { LeaseOpenApi } from "./useLeaseOpen";
+
+// The down-payment asset option produced by each form's `assets` computed.
+// `useLeaseForm` reads only `key` and `balance.denom`; the remaining display
+// fields exist so the same object satisfies the AdvancedFormControl bindings.
+export interface LeaseAssetBalance {
+  value: string;
+  customLabel: string;
+  ticker: string;
+  denom: string | undefined;
+  amount: string | undefined;
+}
+
+export interface LeaseAssetOption {
+  name: string;
+  value: string;
+  label: string;
+  shortName: string;
+  icon: string;
+  decimal_digits: number;
+  balance: LeaseAssetBalance;
+  ibcData: string | undefined;
+  native: boolean;
+  symbol: string;
+  ticker: string;
+  key: string;
+  stable: Dec;
+  price: string;
+}
+
+// The loan (asset-to-lease) option. Long carries `decimal_digits`, Short carries
+// `protocol`; the shared core only ever reads `key`.
+export interface LeaseLoanOption {
+  key: string;
+  ticker: string;
+  label: string;
+  value: string;
+  icon: string;
+  decimal_digits?: number;
+  protocol?: string;
+}
+
+// The leaseQuote / open-lease arguments. Their derivation is the Long-vs-Short
+// asymmetry (see the Short-protocol notes in the project CLAUDE.md), so each
+// form provides it via `resolveQuoteParams` rather than sharing a merged branch.
+export interface LeaseQuoteParams {
+  downPaymentTicker: string;
+  leaseTicker: string;
+  protocol: string;
+}
+
+// The per-position pieces the shared form logic needs. Everything divergent —
+// the collateral list, the loan list, and the ticker/protocol resolution —
+// lives behind this so the reactive validation, quote, and submit flows stay
+// identical across both forms.
+export interface LeaseFormStrategy {
+  currency: ComputedRef<LeaseAssetOption | undefined>;
+  coinList: ComputedRef<LeaseLoanOption[]>;
+  resolveQuoteParams: (downPayment: LeaseAssetOption, loan: LeaseLoanOption) => Promise<LeaseQuoteParams>;
+  logLabel: string;
+}
+
+export function useLeaseForm(base: LeaseOpenApi, strategy: LeaseFormStrategy) {
+  const { currency, coinList, resolveQuoteParams, logLabel } = strategy;
+
+  const walletStore = useWalletStore();
+  const balancesStore = useBalancesStore();
+  const configStore = useConfigStore();
+  const pricesStore = usePricesStore();
+  const historyStore = useHistoryStore();
+  const i18n = useI18n();
+  const router = useRouter();
+
+  const onShowToast = inject("onShowToast", (_data: { type: ToastType; message: string }) => {});
+  const reload = inject("reload", () => {});
+
+  watch(
+    () => configStore.initialized,
+    () => {
+      if (configStore.initialized) {
+        void onInit();
+      }
+    },
+    {
+      immediate: true
+    }
+  );
+
+  async function onInit() {
+    // Free interest is handled by a 3rd party service
+    // Asset filtering (ignore_long/ignore_short) is done by the backend in /api/protocols/{protocol}/currencies
+  }
+
+  // Reactive balance validation MUST run first and short-circuit the quote: a
+  // zero-balance collateral has no denom, so a quote attempt throws and the
+  // catch surfaces a generic error instead of "Insufficient balance" (#192).
+  watch(
+    () => [base.selectedCurrency.value, base.amount.value, base.selectedLoanCurrency.value, base.ltd.value],
+    async () => {
+      base.amountErrorMsg.value = "";
+      if (!base.validateAmountAgainstBalance(currency.value)) {
+        base.leaseApply.value = null;
+        return;
+      }
+      if (await base.validateMinMaxValues(currency.value, coinList.value[base.selectedLoanCurrency.value])) {
+        void calculate();
+      } else {
+        base.leaseApply.value = null;
+      }
+    }
+  );
+
+  const selectedLoanOption = computed(() => {
+    return coinList.value[base.selectedLoanCurrency.value];
+  });
+
+  const advancedControlBindings = computed(() => {
+    return {
+      ...(base.errorInsufficientBalance.value ? { inputClass: "text-typography-error" } : {}),
+      ...(currency.value !== undefined ? { selectedCurrencyOption: currency.value } : {})
+    };
+  });
+
+  const calculatedBalance = computed(() => {
+    const asset = currency.value;
+    if (!asset) {
+      return formatUsd(0);
+    }
+    const price = new Dec(pricesStore.prices[asset.key]?.price ?? 0);
+    const v = base.amount?.value?.length ? base.amount?.value : "0";
+    const stable = price.mul(new Dec(v));
+    return formatDecAsUsd(stable);
+  });
+
+  async function calculate() {
+    try {
+      const selectedDownPaymentCurrency = currency.value;
+      const selectedLoan = coinList.value[base.selectedLoanCurrency.value];
+      const downPayment = base.amount.value;
+
+      if (downPayment) {
+        if (selectedDownPaymentCurrency === undefined || selectedLoan === undefined) {
+          throw new Error("down payment or lease currency is not selected");
+        }
+        const denom = selectedDownPaymentCurrency.balance.denom;
+        if (denom === undefined) {
+          throw new Error(`missing bank denom for ${selectedDownPaymentCurrency.key}`);
+        }
+        const microAmount = getMicroAmount(denom, downPayment);
+
+        const { downPaymentTicker, leaseTicker, protocol } = await resolveQuoteParams(
+          selectedDownPaymentCurrency,
+          selectedLoan
+        );
+
+        const contracts = configStore.contracts[protocol];
+        if (contracts === undefined || contracts.leaser === null) {
+          throw new Error(`no leaser contract configured for protocol ${protocol}`);
+        }
+
+        const cosmWasmClient = await NolusClient.getInstance().getCosmWasmClient();
+        const leaserClient = new Leaser(cosmWasmClient, contracts.leaser);
+
+        const makeLeaseApplyResp = await leaserClient.leaseQuote(
+          microAmount.mAmount.amount.toString(),
+          downPaymentTicker,
+          leaseTicker,
+          base.ltd.value
+        );
+
+        makeLeaseApplyResp.annual_interest_rate =
+          makeLeaseApplyResp.annual_interest_rate / Math.pow(10, INTEREST_DECIMALS);
+        makeLeaseApplyResp.annual_interest_rate_margin =
+          makeLeaseApplyResp.annual_interest_rate_margin / Math.pow(10, INTEREST_DECIMALS);
+
+        base.leaseApply.value = makeLeaseApplyResp;
+      } else {
+        base.leaseApply.value = null;
+      }
+    } catch (error) {
+      Logger.error(`${logLabel} calculate error:`, error);
+      base.amountErrorMsg.value = i18n.t(classifyError(error));
+      base.leaseApply.value = null;
+    }
+  }
+
+  async function onOpenLease() {
+    try {
+      base.isDisabled.value = true;
+      await walletOperation(openLease);
+    } catch (error: unknown) {
+      base.amountErrorMsg.value = i18n.t(classifyError(error));
+      Logger.error(error);
+    } finally {
+      base.isDisabled.value = false;
+    }
+  }
+
+  async function openLease() {
+    const wallet = walletStore.wallet as NolusWallet;
+    if (
+      wallet &&
+      (await base.isDownPaymentAmountValid(currency.value, coinList.value[base.selectedLoanCurrency.value]))
+    ) {
+      try {
+        base.isLoading.value = true;
+
+        const selectedDownPaymentCurrency = currency.value;
+        const downPayment = base.amount.value;
+        const selectedLoan = coinList.value[base.selectedLoanCurrency.value];
+
+        if (selectedDownPaymentCurrency === undefined || selectedLoan === undefined) {
+          throw new Error("down payment or lease currency is not selected");
+        }
+        const denom = selectedDownPaymentCurrency.balance.denom;
+        if (denom === undefined) {
+          throw new Error(`missing bank denom for ${selectedDownPaymentCurrency.key}`);
+        }
+        const microAmount = getMicroAmount(denom, downPayment);
+
+        const funds = [
+          {
+            denom: microAmount.coinMinimalDenom,
+            amount: microAmount.mAmount.amount.toString()
+          }
+        ];
+
+        const { leaseTicker, protocol } = await resolveQuoteParams(selectedDownPaymentCurrency, selectedLoan);
+
+        const contracts = configStore.contracts[protocol];
+        if (contracts === undefined || contracts.leaser === null) {
+          throw new Error(`no leaser contract configured for protocol ${protocol}`);
+        }
+
+        const cosmWasmClient = await NolusClient.getInstance().getCosmWasmClient();
+        const leaserClient = new Leaser(cosmWasmClient, contracts.leaser);
+
+        const { txBytes } = await leaserClient.simulateOpenLeaseTx(wallet, leaseTicker, base.ltd.value, funds);
+
+        const tx = await walletStore.wallet?.broadcastTx(txBytes as Uint8Array);
+
+        const item = tx?.events.find((event) => {
+          return event.type === WASM_EVENTS["wasm-ls-request-loan"].key;
+        });
+
+        const data = item?.attributes[WASM_EVENTS["wasm-ls-request-loan"].index];
+        void balancesStore.fetchBalances();
+        void historyStore.loadActivities();
+        reload();
+        onShowToast({
+          type: ToastType.success,
+          message: i18n.t("message.currently-opening")
+        });
+
+        if (data === undefined) {
+          throw new Error("wasm-ls-request-loan event attribute missing from the broadcast result");
+        }
+        void router.push(`/${RouteNames.LEASES}/${data.value}`);
+      } catch (error: unknown) {
+        base.amountErrorMsg.value = i18n.t(classifyError(error));
+        Logger.error(error);
+      } finally {
+        base.isLoading.value = false;
+      }
+    }
+  }
+
+  return {
+    selectedLoanOption,
+    advancedControlBindings,
+    calculatedBalance,
+    onOpenLease
+  };
+}

--- a/src/modules/leases/components/new-lease/useLeaseOpen.ts
+++ b/src/modules/leases/components/new-lease/useLeaseOpen.ts
@@ -210,3 +210,7 @@ export function useLeaseOpen() {
     isDownPaymentAmountValid
   };
 }
+
+// The reactive/validation base shared by both lease forms. `useLeaseForm`
+// consumes it; the per-position composables spread it back out to the SFC.
+export type LeaseOpenApi = ReturnType<typeof useLeaseOpen>;

--- a/src/modules/leases/components/new-lease/useLongLeaseForm.ts
+++ b/src/modules/leases/components/new-lease/useLongLeaseForm.ts
@@ -1,0 +1,200 @@
+import { computed } from "vue";
+import { useBalancesStore } from "@/common/stores/balances";
+import { useConfigStore } from "@/common/stores/config";
+import { usePricesStore } from "@/common/stores/prices";
+import { formatDecAsUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
+import type { ExternalCurrency } from "@/common/types";
+import { SORT_LEASE } from "@/config/global";
+import { Dec } from "@keplr-wallet/unit";
+import { useLeaseOpen } from "./useLeaseOpen";
+import { useLeaseForm, type LeaseAssetOption, type LeaseLoanOption, type LeaseQuoteParams } from "./useLeaseForm";
+
+// Long form: collateral is any active-protocol asset, the loan currency is the
+// leased asset (`group="lease"`), and the leaseTicker is that leased asset's
+// ticker. The divergent list-building and ticker derivation stay here so the
+// Long-vs-Short asymmetry remains visible (see project CLAUDE.md).
+export function useLongLeaseForm() {
+  const base = useLeaseOpen();
+
+  const balancesStore = useBalancesStore();
+  const configStore = useConfigStore();
+  const pricesStore = usePricesStore();
+
+  const totalBalances = computed(() => {
+    const currencies: ExternalCurrency[] = [];
+    // Use long protocols from gated protocols API
+    const longProtocols = configStore.longProtocolsForCurrentNetwork;
+
+    for (const protocol of longProtocols) {
+      // Get cached currencies for this protocol
+      const protocolCurrencies = configStore.getCachedProtocolCurrencies(protocol.protocol);
+
+      for (const currency of protocolCurrencies) {
+        // Find matching currency in currenciesData to get full info
+        const key = `${currency.ticker}@${protocol.protocol}`;
+        const currencyInfo = configStore.currenciesData?.[key];
+
+        if (currencyInfo) {
+          const balance = balancesStore.balances.find((b) => b.denom === currencyInfo.ibcData);
+          currencies.push({ ...currencyInfo, balance: balance } as ExternalCurrency);
+        }
+      }
+    }
+    return currencies;
+  });
+
+  const isShortEnabled = computed(() => {
+    // Use dynamic check from config store instead of hardcoded protocolsFilter
+    return configStore.hasShortProtocols(configStore.protocolFilter);
+  });
+
+  const isProtocolDisabled = computed(() => {
+    // Use dynamic check from config store instead of hardcoded protocolsFilter
+    return configStore.isNetworkDisabled(configStore.protocolFilter);
+  });
+
+  const assets = computed((): LeaseAssetOption[] => {
+    const data: LeaseAssetOption[] = [];
+    // Use dynamic protocols from config store instead of hardcoded protocolsFilter.hold
+    const activeProtocols = configStore.getActiveProtocolsForNetwork(configStore.protocolFilter);
+    const b = ((balances.value as ExternalCurrency[]) ?? []).filter((item) => {
+      const [_, p] = item.key.split("@");
+
+      if (p === undefined) {
+        console.error(`LongForm: malformed currency key: ${item.key}`);
+        return false;
+      }
+      if (activeProtocols.includes(p)) {
+        return true;
+      }
+      return false;
+    });
+
+    for (const asset of b) {
+      const value = new Dec(asset.balance?.amount.toString() ?? 0, asset.decimal_digits);
+      const balance = formatTokenBalance(value);
+      const exactBalance = value.isZero() ? "0" : value.toString(asset.decimal_digits).replace(/\.?0+$/, "");
+      const denom = asset.ibcData;
+      const price = new Dec(pricesStore.prices[asset.key]?.price ?? 0);
+      const stable = price.mul(value);
+
+      data.push({
+        name: asset.name,
+        value: denom,
+        label: asset.shortName,
+        shortName: asset.shortName,
+        icon: asset.icon,
+        decimal_digits: asset.decimal_digits,
+        balance: {
+          value: exactBalance,
+          customLabel: `${balance} ${asset.shortName}`,
+          ticker: asset.shortName,
+          denom: asset.balance?.denom,
+          amount: asset.balance?.amount
+        },
+        ibcData: (asset as ExternalCurrency).ibcData,
+        native: asset.native,
+        symbol: asset.symbol,
+        ticker: asset.ticker,
+        key: asset.key,
+        stable,
+        price: formatDecAsUsd(stable)
+      });
+    }
+    return data.sort((a, b) => {
+      return Number(b.stable.sub(a.stable).toString(8));
+    });
+  });
+
+  const currency = computed(() => {
+    return assets.value[base.selectedCurrency.value];
+  });
+
+  const coinList = computed((): LeaseLoanOption[] => {
+    if (!currency.value?.key) {
+      return [];
+    }
+
+    const [_ticker, downPaymentProtocol] = currency.value.key.split("@");
+    if (downPaymentProtocol === undefined) {
+      console.error(`LongForm: malformed currency key: ${currency.value.key}`);
+      return [];
+    }
+
+    // Get currencies for the selected protocol that can be leased (group === "lease")
+    const protocolCurrencies = configStore.getCachedProtocolCurrencies(downPaymentProtocol);
+    const leaseCurrencies = protocolCurrencies.filter((c) => c.group === "lease");
+
+    // Backend already filters out ignored assets in /api/protocols/{protocol}/currencies
+    const list = leaseCurrencies.map((item) => {
+      return {
+        decimal_digits: item.decimals,
+        key: `${item.ticker}@${downPaymentProtocol}`,
+        ticker: item.ticker,
+        label: item.shortName,
+        value: item.bank_symbol,
+        icon: item.icon
+      };
+    });
+
+    const sortOrder = new Map(SORT_LEASE.map((t, i) => [t, i]));
+
+    return list.sort((a, b) => {
+      const aIndex = sortOrder.get(a.ticker);
+      const bIndex = sortOrder.get(b.ticker);
+      if (aIndex === undefined && bIndex === undefined) return 0;
+      if (aIndex !== undefined && bIndex === undefined) return -1;
+      if (aIndex === undefined && bIndex !== undefined) return 1;
+      return (aIndex as number) - (bIndex as number);
+    });
+  });
+
+  const balances = computed(() => {
+    // Backend already filters out ignored assets in /api/protocols/{protocol}/currencies
+    return totalBalances.value.filter((item) => {
+      if (!item.key) {
+        return false;
+      }
+
+      const [ticker, protocol] = item.key?.split("@") ?? [];
+      if (protocol === undefined) {
+        console.error(`LongForm: malformed currency key: ${item.key}`);
+        return false;
+      }
+
+      // Get protocol currencies from cache and check if this is valid collateral
+      const protocolCurrencies = configStore.getCachedProtocolCurrencies(protocol);
+      const currencyInfo = protocolCurrencies.find((c) => c.ticker === ticker);
+
+      // Valid collateral: LPN, native, or lease currencies
+      if (currencyInfo) {
+        return currencyInfo.group === "lpn" || currencyInfo.group === "native" || currencyInfo.group === "lease";
+      }
+
+      return false;
+    });
+  });
+
+  // Long: the protocol comes from the down-payment key and the leaseTicker is the
+  // loan asset's own ticker (on Long protocols the LPN IS the stable).
+  async function resolveQuoteParams(downPayment: LeaseAssetOption, loan: LeaseLoanOption): Promise<LeaseQuoteParams> {
+    const [downPaymentTicker, protocol] = downPayment.key.split("@");
+    const [leaseTicker] = loan.key.split("@");
+    if (downPaymentTicker === undefined || protocol === undefined || leaseTicker === undefined) {
+      throw new Error(`malformed currency key: ${downPayment.key} / ${loan.key}`);
+    }
+    return { downPaymentTicker, leaseTicker, protocol };
+  }
+
+  const form = useLeaseForm(base, { currency, coinList, resolveQuoteParams, logLabel: "LongForm" });
+
+  return {
+    ...base,
+    ...form,
+    assets,
+    coinList,
+    currency,
+    isShortEnabled,
+    isProtocolDisabled
+  };
+}

--- a/src/modules/leases/components/new-lease/useShortLeaseForm.ts
+++ b/src/modules/leases/components/new-lease/useShortLeaseForm.ts
@@ -1,0 +1,170 @@
+import { computed } from "vue";
+import { useBalancesStore } from "@/common/stores/balances";
+import { useConfigStore } from "@/common/stores/config";
+import { usePricesStore } from "@/common/stores/prices";
+import { formatDecAsUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
+import type { ExternalCurrency } from "@/common/types";
+import { SORT_LEASE } from "@/config/global";
+import { Dec } from "@keplr-wallet/unit";
+import { useLeaseOpen } from "./useLeaseOpen";
+import { useLeaseForm, type LeaseAssetOption, type LeaseLoanOption, type LeaseQuoteParams } from "./useLeaseForm";
+
+// Short form: the loan currency is the shorted asset (`group="lpn"`), but the
+// contract's leaseTicker is the protocol stable (`group="lease"`, resolved via
+// `resolveShortLeaseTicker`) — NOT the down payment and NOT the LPN. Keeping the
+// list-building and ticker derivation here preserves that asymmetry visibly
+// (see the Short-protocol notes in the project CLAUDE.md).
+export function useShortLeaseForm() {
+  const base = useLeaseOpen();
+
+  const balancesStore = useBalancesStore();
+  const configStore = useConfigStore();
+  const pricesStore = usePricesStore();
+
+  const totalBalances = computed(() => {
+    const currencies: ExternalCurrency[] = [];
+    const b = balancesStore.balances;
+    const seenDenoms = new Set<string>();
+
+    // Use short protocols from gated protocols API
+    const shortProtocols = configStore.shortProtocolsForCurrentNetwork;
+
+    for (const protocol of shortProtocols) {
+      // Get cached currencies for this protocol
+      const protocolCurrencies = configStore.getCachedProtocolCurrencies(protocol.protocol);
+
+      for (const currency of protocolCurrencies) {
+        // Find matching currency in currenciesData to get full info
+        const key = `${currency.ticker}@${protocol.protocol}`;
+        const currencyInfo = configStore.currenciesData?.[key];
+
+        if (currencyInfo) {
+          const balance = b.find((bal) => bal.denom === currencyInfo.ibcData);
+          // Deduplicate by denom
+          if (balance && !seenDenoms.has(balance.denom)) {
+            seenDenoms.add(balance.denom);
+            currencies.push({ ...currencyInfo, balance: balance } as ExternalCurrency);
+          } else if (!balance && !seenDenoms.has(currencyInfo.ibcData)) {
+            seenDenoms.add(currencyInfo.ibcData);
+            currencies.push({
+              ...currencyInfo,
+              balance: { denom: currencyInfo.ibcData, amount: "0" }
+            } as ExternalCurrency);
+          }
+        }
+      }
+    }
+
+    return currencies;
+  });
+
+  const assets = computed((): LeaseAssetOption[] => {
+    // Backend already filters out ignored assets in /api/protocols/{protocol}/currencies
+    const data: LeaseAssetOption[] = [];
+
+    for (const asset of (totalBalances.value as ExternalCurrency[]) ?? []) {
+      const value = new Dec(asset.balance?.amount.toString() ?? 0, asset.decimal_digits);
+      const balance = formatTokenBalance(value);
+      const exactBalance = value.isZero() ? "0" : value.toString(asset.decimal_digits).replace(/\.?0+$/, "");
+      const denom = asset.ibcData;
+      const price = new Dec(pricesStore.prices[asset.key]?.price ?? 0);
+      const stable = price.mul(value);
+
+      data.push({
+        name: asset.name,
+        value: denom,
+        label: asset.shortName,
+        shortName: asset.shortName,
+        icon: asset.icon,
+        decimal_digits: asset.decimal_digits,
+        balance: {
+          value: exactBalance,
+          customLabel: `${balance} ${asset.shortName}`,
+          ticker: asset.shortName,
+          denom: asset.balance?.denom,
+          amount: asset.balance?.amount
+        },
+        ibcData: (asset as ExternalCurrency).ibcData,
+        native: asset.native,
+        symbol: asset.symbol,
+        ticker: asset.ticker,
+        key: asset.key,
+        stable,
+        price: formatDecAsUsd(stable)
+      });
+    }
+
+    return data.sort((a, b) => {
+      return Number(b.stable.sub(a.stable).toString(8));
+    });
+  });
+
+  const currency = computed(() => {
+    return assets.value[base.selectedCurrency.value];
+  });
+
+  const coinList = computed((): LeaseLoanOption[] => {
+    // For short positions, the "coin to lease" is determined by the short protocols
+    // Each short protocol represents an asset that can be shorted
+    // Backend already filters out ignored assets based on lease-rules.json
+    const shortProtocols = configStore.shortProtocolsForCurrentNetwork;
+
+    const list = shortProtocols.map((protocol) => {
+      // Get the LPN info from the protocol's lpn_display
+      return {
+        key: `${protocol.lpn}@${protocol.protocol}`,
+        ticker: protocol.lpn,
+        label: protocol.lpn_display?.shortName || protocol.lpn,
+        value: protocol.lpn, // This will be used to find the currency
+        icon: protocol.lpn_display?.icon || "",
+        protocol: protocol.protocol
+      };
+    });
+
+    const sortOrder = new Map(SORT_LEASE.map((t, i) => [t, i]));
+
+    return list.sort((a, b) => {
+      const aIndex = sortOrder.get(a.ticker);
+      const bIndex = sortOrder.get(b.ticker);
+      if (aIndex === undefined && bIndex === undefined) return 0;
+      if (aIndex !== undefined && bIndex === undefined) return -1;
+      if (aIndex === undefined && bIndex !== undefined) return 1;
+      return (aIndex as number) - (bIndex as number);
+    });
+  });
+
+  // For a Short protocol the contract's `leaseTicker` is the stable currency the
+  // position is denominated in (e.g., USDC_NOBLE) — NOT the user's down payment.
+  // It's exposed in the protocol currencies list with group="lease" (the only one
+  // for a Short protocol; `group="lpn"` there is the borrowed asset).
+  async function resolveShortLeaseTicker(protocol: string): Promise<string> {
+    const currencies = await configStore.getProtocolCurrencies(protocol);
+    const stable = currencies.find((c) => c.group === "lease");
+    if (!stable) {
+      throw new Error(`Short protocol ${protocol} has no stable (group="lease") currency`);
+    }
+    return stable.ticker;
+  }
+
+  // Short: the protocol comes from the loan (shorted-asset) key; the leaseTicker
+  // is the protocol stable, never the down payment and never the LPN.
+  async function resolveQuoteParams(downPayment: LeaseAssetOption, loan: LeaseLoanOption): Promise<LeaseQuoteParams> {
+    const [_c, protocol] = loan.key.split("@");
+    const [downPaymentTicker] = downPayment.key.split("@");
+    if (protocol === undefined || downPaymentTicker === undefined) {
+      throw new Error(`malformed currency key: ${downPayment.key} / ${loan.key}`);
+    }
+    const leaseTicker = await resolveShortLeaseTicker(protocol);
+    return { downPaymentTicker, leaseTicker, protocol };
+  }
+
+  const form = useLeaseForm(base, { currency, coinList, resolveQuoteParams, logLabel: "ShortForm" });
+
+  return {
+    ...base,
+    ...form,
+    assets,
+    coinList,
+    currency
+  };
+}


### PR DESCRIPTION
## Summary

Extract the near-duplicate script bodies of `LongForm.vue` (585→206 LOC) and `ShortForm.vue` (561→204) into a position-parameterized shared composable plus two thin per-position composables, with no behavioural change. Progresses #185 (forms pair; the secondary trio stays tracked there).

## Changes

- New `useLeaseForm.ts` — the shared core: stores, the reactive balance-validation watcher, quote orchestration (`calculate`), and the submit path (`openLease`/`onOpenLease`), driven by a per-form strategy (`currency`, `coinList`, `resolveQuoteParams`, `logLabel`).
- New `useLongLeaseForm.ts` / `useShortLeaseForm.ts` — only the genuinely divergent residue: asset/coin-list building, quote-param resolution (Short keeps `resolveShortLeaseTicker`), Long-only `isShortEnabled`/`isProtocolDisabled`. The Long-vs-Short asymmetry stays visible in separate files rather than positional branches.
- `useLeaseOpen.ts` — additive only: exported `LeaseOpenApi` return-type alias.
- Both SFC templates are verbatim; scripts reduce to a single composable destructure.
- Two dead-code removals reconciled during the merge of the twin bodies: a redundant inner `useConfigStore()` re-declaration in Short's `openLease`, and unused `txHash`/`usedFee` destructure slots.

## Verification

- Ran the full gate: vue-tsc typecheck clean, eslint + style guard + prettier clean, 992/992 tests across 62 files, production build clean. All 18 lease-form characterization tests pass **unmodified**.
- Verified the four invariants documented for these forms survived the move byte-for-byte: balance validation runs first in the reactive watcher and bails before min/max + quote (#192 contract); the submit path reuses the same balance helper; Short's stable ticker resolves only via `resolveShortLeaseTicker` (`group="lease"`); every catch classifies through the shared `classifyError`.
- Confirmed template/spread integrity: every ref, computed, and function each template consumes is present in the returned API; removed-from-destructure names were script-only.
- Confirmed the unified quote-param sourcing is output-equivalent (Long's coin-list keys are built from the down-payment protocol, so loan-protocol ≡ down-payment-protocol by construction; Short awaits the stable-ticker resolution before any client/contract work, preserving throw-before-quote ordering).
- Independent code, security, and conventions reviews of the full diff passed with nothing above LOW; the LOW notes (new composables rely on the mounting component tests rather than dedicated unit tests; the spread API mirrors the pre-refactor surface rather than a minimal one) are recorded below.

## Follow-ups

- Secondary trio from #185: `ShortLeaseDetails.vue` (446), `StopLossDialog.vue` (440), `TakeProfitDialog.vue` (428) — next increments, tracked in #185.
- Optional: dedicated `useLeaseForm.test.ts` to pin the Long/Short asymmetry independently of component mounts.