### PR TITLE
refactor(wallet): migrate encode.ts off cosmjs-types-legacy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "@nolus/nolusjs": "^3.7.6",
         "@observablehq/plot": "^0.6.17",
         "cosmjs-types": "^0.11.0",
-        "cosmjs-types-legacy": "npm:cosmjs-types@0.8.0",
         "d3": "^7.9.0",
         "dompurify": "^3.4.12",
         "marked": "^17.0.0",
@@ -2240,70 +2239,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
-      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
@@ -3569,12 +3504,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -5351,43 +5280,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.19"
-      }
-    },
-    "node_modules/cosmjs-types-legacy": {
-      "name": "cosmjs-types",
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
-      "integrity": "sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
-      }
-    },
-    "node_modules/cosmjs-types-legacy/node_modules/protobufjs": {
-      "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
-      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
       }
     },
     "node_modules/create-ecdh": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@nolus/nolusjs": "^3.7.6",
     "@observablehq/plot": "^0.6.17",
     "cosmjs-types": "^0.11.0",
-    "cosmjs-types-legacy": "npm:cosmjs-types@0.8.0",
     "d3": "^7.9.0",
     "dompurify": "^3.4.12",
     "marked": "^17.0.0",

--- a/src/networks/cosm/encode.test.ts
+++ b/src/networks/cosm/encode.test.ts
@@ -60,6 +60,32 @@ describe("encodePubkey", () => {
   });
 });
 
+describe("wire compatibility (regression anchor)", () => {
+  // Known-good protobuf wire output for SECP_KEY captured against the pre-migration
+  // cosmjs-types-legacy@0.8.0 codec. The secp256k1 PubKey message is a single bytes
+  // field (tag 0x0a, length 0x21=33, then the 33 key bytes). Migrating to
+  // cosmjs-types@0.11.0 must emit these exact bytes — a mismatch is codec drift.
+  const SECP_PUBKEY_WIRE = new Uint8Array([
+    10, 33, 2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+    29, 30, 31, 32
+  ]);
+
+  it("encodes a secp256k1 pubkey to the exact known-good wire bytes", () => {
+    const pubkey: Pubkey = { type: "tendermint/PubKeySecp256k1", value: SECP_KEY_B64 };
+    const any = encodePubkey(pubkey);
+    expect(any.typeUrl).toBe("/cosmos.crypto.secp256k1.PubKey");
+    expect(Array.from(any.value)).toEqual(Array.from(SECP_PUBKEY_WIRE));
+  });
+
+  it("decodes the known-good wire bytes back to the original amino pubkey", () => {
+    const any = Any.fromPartial({
+      typeUrl: "/cosmos.crypto.secp256k1.PubKey",
+      value: SECP_PUBKEY_WIRE
+    });
+    expect(decodePubkey(any)).toEqual({ type: "tendermint/PubKeySecp256k1", value: SECP_KEY_B64 });
+  });
+});
+
 describe("decodePubkey", () => {
   it("returns null when pubkey is undefined", () => {
     expect(decodePubkey(undefined)).toBeNull();

--- a/src/networks/cosm/encode.ts
+++ b/src/networks/cosm/encode.ts
@@ -10,7 +10,7 @@ import { fromBase64 } from "@cosmjs/encoding";
 import { Uint53 } from "@cosmjs/math";
 import { PubKey as CosmosCryptoEd25519Pubkey } from "cosmjs-types/cosmos/crypto/ed25519/keys";
 import { LegacyAminoPubKey } from "cosmjs-types/cosmos/crypto/multisig/keys";
-import { PubKey as CosmosCryptoSecp256k1Pubkey } from "cosmjs-types-legacy/cosmos/crypto/secp256k1/keys";
+import { PubKey as CosmosCryptoSecp256k1Pubkey } from "cosmjs-types/cosmos/crypto/secp256k1/keys";
 import { Any } from "cosmjs-types/google/protobuf/any";
 
 export function encodePubkey(pubkey: Pubkey): Any {


### PR DESCRIPTION
## Summary

Migrate `src/networks/cosm/encode.ts` — the sole consumer of `cosmjs-types-legacy@0.8.0` — to the already-present `cosmjs-types@0.11.0` and delete the legacy dependency, clearing the repo's last npm critical (protobufjs 6.x, GHSA-xq3m-2v4x-88gg arbitrary code execution + 10 more advisories spanning all of 6.x) and the cosmjs-types-legacy high. Progresses #255 (the issue stays open to track the staging sign-and-broadcast smoke before the next prod tag).

## Changes

- `encode.ts`: one-line import swap — `PubKey` now comes from `cosmjs-types/cosmos/crypto/secp256k1/keys`. The 0.8.0 and 0.11.0 codecs are interface-identical for this type (single `key` bytes field, same field number; 0.11.0's own `BinaryWriter` replaces the protobufjs writer with the same `.finish()` contract). Consumers (`accountParser`, `setupTxExtension`, `BaseWallet`) unchanged.
- `encode.test.ts`: new wire-compatibility regression anchor — the exact protobuf bytes of a fixed secp256k1 `PubKey` Any were captured from the **legacy** codec before the swap and asserted in both directions (encode-to-exact-bytes, decode-from-exact-bytes). The constant passed unchanged against the new codec: byte-identical wire output.
- `package.json` / `package-lock.json`: `cosmjs-types-legacy` removed; lockfile delta is removals-only (legacy package + its nested protobufjs 6.11.4 + `@protobufjs/*` helpers), no new packages, no version drift.

## Verification

- Captured the wire-format anchor against the legacy codec first and confirmed it passes byte-for-byte against 0.11.0 after the swap — the constant was never adjusted.
- Ran the full gate: typecheck, lint, style guard, format check, 994 tests, production build — all clean.
- Verified `npm audit`: 10 advisories (1 critical, 1 high, 8 low) → 8 low; the remaining lows are the pre-existing `@nolus/nolusjs` transitive crypto chain, blocked upstream.
- Grepped the repo for residual `cosmjs-types-legacy` references: none functional (imports, lockfile, vite/vitest/tsconfig aliases all clean); the only match is the provenance comment in the new test.
- Independent code, security, and conventions reviews of the diff all passed with zero findings above informational; the security pass independently decoded the wire constant and audited the lockfile delta package-by-package.

## Follow-ups

- Manual staging sign-and-broadcast smoke before the next prod tag (no live-ledger e2e exists) — tracked in #255, which closes after that smoke.
- Upstream `@nolus/nolusjs` crypto-chain bumps (the remaining 8 lows) — needs work in the nolusjs repo.