### PR TITLE
chore(backend): delete dead search_leases ETL client

### DIFF
--- a/backend/src/external/etl.rs
+++ b/backend/src/external/etl.rs
@@ -182,39 +182,6 @@ impl EtlClient {
             .await
     }
 
-    /// Search leases by address
-    pub async fn search_leases(
-        &self,
-        address: &str,
-        skip: u32,
-        limit: u32,
-        search: Option<&str>,
-    ) -> Result<Vec<String>, AppError> {
-        let skip_str = skip.to_string();
-        let limit_str = limit.to_string();
-        let url = self.url().with_optional_query(
-            "leases-search",
-            &[
-                ("address", Some(address)),
-                ("skip", Some(&skip_str)),
-                ("limit", Some(&limit_str)),
-                ("search", search),
-            ],
-        );
-        debug!("Searching leases from {}", url);
-
-        self.client
-            .get(&url)
-            .send()
-            .await
-            .with_context(API_NAME, "search leases")
-            .await?
-            .check_status(API_NAME, "leases search")
-            .await?
-            .parse_json(API_NAME, "leases search")
-            .await
-    }
-
     /// Fetch transaction history
     pub async fn fetch_transactions(
         &self,
@@ -475,7 +442,7 @@ pub struct EtlTvlResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::{method, path, query_param, query_param_is_missing};
+    use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_client(url: &str) -> EtlClient {
@@ -862,49 +829,6 @@ mod tests {
             .unwrap();
         assert_eq!(resp.total, Some(1));
         assert_eq!(resp.data.len(), 1);
-    }
-
-    // ---- search_leases (88-89) ----
-
-    #[tokio::test]
-    async fn etl_search_leases_omits_none_search_param() {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/api/leases-search"))
-            .and(query_param("address", "nolus1user"))
-            .and(query_param("skip", "0"))
-            .and(query_param("limit", "20"))
-            .and(query_param_is_missing("search"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
-            .mount(&server)
-            .await;
-
-        let client = test_client(&server.uri());
-        let leases = client
-            .search_leases("nolus1user", 0, 20, None)
-            .await
-            .unwrap();
-        assert!(leases.is_empty());
-    }
-
-    #[tokio::test]
-    async fn etl_search_leases_includes_search_when_some() {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/api/leases-search"))
-            .and(query_param("search", "foo"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(serde_json::json!(["nolus1a", "nolus1b"])),
-            )
-            .mount(&server)
-            .await;
-
-        let client = test_client(&server.uri());
-        let leases = client
-            .search_leases("nolus1user", 0, 20, Some("foo"))
-            .await
-            .unwrap();
-        assert_eq!(leases.len(), 2);
     }
 
     // ---- fetch_transactions (90-91) ----

--- a/backend/src/http_utils.rs
+++ b/backend/src/http_utils.rs
@@ -119,20 +119,6 @@ impl UrlBuilder {
             format!("{}?{}", self.endpoint(endpoint), query.join("&"))
         }
     }
-
-    /// Build a URL with optional query parameters (skips None values)
-    pub fn with_optional_query(&self, endpoint: &str, params: &[(&str, Option<&str>)]) -> String {
-        let query: Vec<String> = params
-            .iter()
-            .filter_map(|(k, v)| v.map(|val| format!("{}={}", k, urlencoding::encode(val))))
-            .collect();
-
-        if query.is_empty() {
-            self.endpoint(endpoint)
-        } else {
-            format!("{}?{}", self.endpoint(endpoint), query.join("&"))
-        }
-    }
 }
 
 #[cfg(test)]
@@ -151,18 +137,6 @@ mod tests {
         let url = builder.with_query("search", &[("q", "test"), ("limit", "10")]);
         assert!(url.contains("q=test"));
         assert!(url.contains("limit=10"));
-    }
-
-    #[test]
-    fn test_url_builder_with_optional_query() {
-        let builder = UrlBuilder::new("https://api.example.com");
-        let url = builder.with_optional_query(
-            "search",
-            &[("q", Some("test")), ("filter", None), ("limit", Some("10"))],
-        );
-        assert!(url.contains("q=test"));
-        assert!(url.contains("limit=10"));
-        assert!(!url.contains("filter"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Delete the dead `EtlClient::search_leases` method and the helper it orphans. The live `/api/etl/leases-search` route is served by the generic passthrough (`etl_proxy_generic` allowlist), which is the only path the frontend uses; the deleted method additionally modeled the response incorrectly (`Vec<String>` vs the live paginated wrapper), so removing it leaves exactly one model of the contract. Closes #249.

## Changes

- `backend/src/external/etl.rs` — remove `search_leases` (zero non-test callers), its two unit tests, and a now-unused test-helper import (−78).
- `backend/src/http_utils.rs` — remove `UrlBuilder::with_optional_query` + its test (−26): its sole production caller was the deleted method, and an unused `pub fn` in a binary crate trips `dead_code` under `-D warnings`. The sibling `with_query` stays (still used at four call sites).

## Verification

- Confirmed the deletion is reference-clean: repo-wide grep for `search_leases` / `with_optional_query` returns zero hits post-change; the frontend `BackendApi.searchLeases` reaches ETL only via the passthrough, whose allowlist still contains `leases-search`.
- Ran the backend gate: cargo build (all targets), fmt check, clippy with the CI lint config (no warnings), 474 tests including the OpenAPI snapshot drift guard, house style-check script. The pre-commit hook also ran the full frontend gate.
- Independent code, security, and conventions reviews all passed with zero findings.