### PR TITLE
chore(ts): remove dead code in asset composables and PriceWidget

### DIFF
--- a/src/modules/assets/components/useReceiveForm.ts
+++ b/src/modules/assets/components/useReceiveForm.ts
@@ -431,14 +431,12 @@ export function useReceiveForm() {
           isLoading.value = true;
 
           const wallets = await getWallets();
-          const addresses: Record<string, string> = {};
 
           for (const [key, chainWallet] of Object.entries(wallets)) {
             const walletAddress = chainWallet.address;
             if (!walletAddress) {
               throw new Error(`Wallet address not available for ${key}`);
             }
-            addresses[key] = walletAddress;
           }
 
           setHistory();

--- a/src/modules/assets/components/useSendForm.ts
+++ b/src/modules/assets/components/useSendForm.ts
@@ -565,14 +565,12 @@ export function useSendForm() {
         try {
           isLoading.value = true;
           const wallets = await getWallets();
-          const addresses: Record<string, string> = {};
 
           for (const [key, chainWallet] of Object.entries(wallets)) {
             const walletAddress = chainWallet.address;
             if (!walletAddress) {
               throw new Error(`Wallet address not available for ${key}`);
             }
-            addresses[key] = walletAddress;
           }
 
           setHistory();

--- a/src/modules/assets/components/useSwapForm.ts
+++ b/src/modules/assets/components/useSwapForm.ts
@@ -409,14 +409,12 @@ export function useSwapForm() {
       loadingTx.value = true;
 
       const wallets = await getWallets();
-      const addresses: Record<string, string> = {};
 
       for (const [key, chainWallet] of Object.entries(wallets)) {
         const walletAddress = chainWallet.address;
         if (!walletAddress) {
           throw new Error(`Wallet address not available for ${key}`);
         }
-        addresses[key] = walletAddress;
       }
 
       if (!route) {

--- a/src/modules/leases/components/SingleLease.vue
+++ b/src/modules/leases/components/SingleLease.vue
@@ -47,10 +47,7 @@
         </template>
       </Alert>
 
-      <PriceWidget
-        :lease="lease"
-        :display-data="displayData"
-      />
+      <PriceWidget :lease="lease" />
       <PositionSummaryWidget
         :lease="lease"
         :display-data="displayData"

--- a/src/modules/leases/components/single-lease/PriceWidget.vue
+++ b/src/modules/leases/components/single-lease/PriceWidget.vue
@@ -29,14 +29,12 @@ import { ref } from "vue";
 import { Dropdown, type DropdownOption, Widget } from "web-components";
 import { CHART_RANGES } from "@/config/global";
 import type { LeaseInfo } from "@/common/api";
-import type { LeaseDisplayData } from "@/common/stores/leases";
 
 import WidgetHeader from "@/common/components/WidgetHeader.vue";
 import PriceOverTimeChart from "./PriceOverTimeChart.vue";
 
 defineProps<{
   lease?: LeaseInfo | null;
-  displayData?: LeaseDisplayData | null;
 }>();
 
 const chartTimeRange = ref(CHART_RANGES["1"]);


### PR DESCRIPTION
## Summary

Remove the dead code enumerated in #250: three write-only `addresses` records in the asset composables and the unused `displayData` prop on `PriceWidget`. Net −11 lines, no behavioural change. Closes #250.

## Changes

- `useSendForm.ts` / `useReceiveForm.ts` / `useSwapForm.ts` — drop the `addresses` record declaration and its accumulation; the enclosing loops stay as pure validation passes (they still throw on a missing wallet address before `setHistory()`).
- `PriceWidget.vue` — remove the never-read `displayData` prop and the `LeaseDisplayData` type import it orphans (`LeaseInfo` retained, still used).
- `SingleLease.vue` — remove only the `:display-data` binding on `<PriceWidget>`; the `displayData` computed stays (bound to other widgets, read twice, and provided via `provide()`).

## Verification

- Confirmed every deletion is reference-clean (zero remaining `addresses` references in the three composables; zero `displayData`/`LeaseDisplayData` references in PriceWidget; its template only consumes `lease`).
- Confirmed the validation loops preserve the exact throw condition — only the record accumulation was dropped.
- Ran the full gate: typecheck, lint, style guard, format check, 992 tests, coverage floors held (not weakened), production build.
- Independent code, security, and conventions reviews all passed with zero findings; the pre-existing `NETWORK_DATA` deprecation notices in these files were deliberately left untouched (out of scope).