### PR TITLE
fix(leases): take-profit toast key and getPercent zero guards

### DIFF
--- a/backend/config/locales/cn.json
+++ b/backend/config/locales/cn.json
@@ -317,6 +317,7 @@
     "take-profit": "止盈",
     "take-profit-price-per": "止盈价（每",
     "take-profit-min-amount-error": "最小金额为 {amount}",
+    "take-profit-toast": "已设置止盈",
     "submit-btn": "提交",
     "stop-loss-toast": "已设置止损",
     "per": "每",

--- a/backend/config/locales/en.json
+++ b/backend/config/locales/en.json
@@ -339,6 +339,7 @@
     "take-profit": "Take Profit",
     "take-profit-price-per": "Take Profit price per",
     "take-profit-min-amount-error": "The minimum amount is {amount}",
+    "take-profit-toast": "Take Profit Set",
     "submit-btn": "Submit",
     "stop-loss-toast": "Stop Loss Set",
     "per": "per",

--- a/backend/config/locales/es.json
+++ b/backend/config/locales/es.json
@@ -317,6 +317,7 @@
     "take-profit": "Take Profit",
     "take-profit-price-per": "Precio de Take Profit por",
     "take-profit-min-amount-error": "El importe mínimo es {amount}",
+    "take-profit-toast": "Take Profit establecido",
     "submit-btn": "Enviar",
     "stop-loss-toast": "Stop Loss establecido",
     "per": "por",

--- a/backend/config/locales/fr.json
+++ b/backend/config/locales/fr.json
@@ -317,6 +317,7 @@
     "take-profit": "Take Profit",
     "take-profit-price-per": "Prix du Take Profit par",
     "take-profit-min-amount-error": "Le montant minimum est {amount}",
+    "take-profit-toast": "Take Profit défini",
     "submit-btn": "Soumettre",
     "stop-loss-toast": "Stop Loss défini",
     "per": "par",

--- a/backend/config/locales/gr.json
+++ b/backend/config/locales/gr.json
@@ -317,6 +317,7 @@
     "take-profit": "Take Profit",
     "take-profit-price-per": "Τιμή Take Profit ανά",
     "take-profit-min-amount-error": "Το ελάχιστο ποσό είναι {amount}",
+    "take-profit-toast": "Ορίστηκε Take Profit",
     "submit-btn": "Υποβολή",
     "stop-loss-toast": "Ορίστηκε Stop Loss",
     "per": "ανά",

--- a/backend/config/locales/id.json
+++ b/backend/config/locales/id.json
@@ -317,6 +317,7 @@
     "take-profit": "Take Profit",
     "take-profit-price-per": "Harga Take Profit per",
     "take-profit-min-amount-error": "Jumlah minimum adalah {amount}",
+    "take-profit-toast": "Take Profit Diatur",
     "submit-btn": "Kirim",
     "stop-loss-toast": "Stop Loss Diatur",
     "per": "per",

--- a/backend/config/locales/jp.json
+++ b/backend/config/locales/jp.json
@@ -317,6 +317,7 @@
     "take-profit": "テイクプロフィット",
     "take-profit-price-per": "テイクプロフィット価格（単位）",
     "take-profit-min-amount-error": "最小金額は{amount}です",
+    "take-profit-toast": "テイクプロフィットを設定しました",
     "submit-btn": "送信",
     "stop-loss-toast": "ストップロスを設定しました",
     "per": "あたり",

--- a/backend/config/locales/kr.json
+++ b/backend/config/locales/kr.json
@@ -317,6 +317,7 @@
     "take-profit": "Take Profit",
     "take-profit-price-per": "Take Profit 가격:",
     "take-profit-min-amount-error": "최소 금액은 {amount}입니다",
+    "take-profit-toast": "Take Profit가 설정되었습니다",
     "submit-btn": "제출",
     "stop-loss-toast": "Stop Loss가 설정되었습니다",
     "per": "당",

--- a/backend/config/locales/ru.json
+++ b/backend/config/locales/ru.json
@@ -317,6 +317,7 @@
     "take-profit": "Take Profit",
     "take-profit-price-per": "Цена Take Profit за",
     "take-profit-min-amount-error": "Минимальная сумма — {amount}",
+    "take-profit-toast": "Take Profit установлен",
     "submit-btn": "Подтвердить",
     "stop-loss-toast": "Stop Loss установлен",
     "per": "за",

--- a/backend/config/locales/tr.json
+++ b/backend/config/locales/tr.json
@@ -317,6 +317,7 @@
     "take-profit": "Take Profit",
     "take-profit-price-per": "Take Profit fiyatı (birim)",
     "take-profit-min-amount-error": "Minimum tutar {amount}",
+    "take-profit-toast": "Take Profit Ayarlandı",
     "submit-btn": "Gönder",
     "stop-loss-toast": "Stop Loss Ayarlandı",
     "per": "başına",

--- a/src/modules/leases/components/single-lease/StopLossDialog.test.ts
+++ b/src/modules/leases/components/single-lease/StopLossDialog.test.ts
@@ -194,7 +194,7 @@ vi.mock("web-components", () => ({
   ToastType: { success: "success", error: "error" }
 }));
 
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { Dec } from "@keplr-wallet/unit";
 import StopLossDialog from "./StopLossDialog.vue";
 
@@ -219,7 +219,7 @@ function makeLease(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function factory() {
+function factory(provide: Record<string, unknown> = {}) {
   return mount(StopLossDialog, {
     global: {
       mocks: {
@@ -227,7 +227,8 @@ function factory() {
       },
       provide: {
         onShowToast: vi.fn(),
-        reload: vi.fn()
+        reload: vi.fn(),
+        ...provide
       }
     }
   });
@@ -283,6 +284,27 @@ describe("StopLossDialog.vue", () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.text()).toContain("message.stoppings-payout");
     expect(wrapper.text()).not.toContain('message.stoppings-payout {"amount":"0"}');
+    wrapper.unmount();
+  });
+
+  // the mode-selected toast must keep emitting the stop-loss key on the
+  // stop-loss path after the take-profit path is split off.
+  it("emits the stop-loss success toast on a completed submit", async () => {
+    hoisted.getLeaseDisplayData.mockReturnValue({
+      openingPrice: new Dec("100"),
+      totalDebt: new Dec("0"),
+      stableAsset: new Dec("1"),
+      unitAsset: new Dec("1")
+    });
+    const onShowToast = vi.fn();
+    const wrapper = factory({ onShowToast });
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("50");
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="submit"]').trigger("click");
+    await flushPromises();
+    expect(hoisted.loggerError).not.toHaveBeenCalled();
+    expect(onShowToast).toHaveBeenCalledWith(expect.objectContaining({ message: "message.stop-loss-toast" }));
     wrapper.unmount();
   });
 });

--- a/src/modules/leases/components/single-lease/TakeProfitDialog.test.ts
+++ b/src/modules/leases/components/single-lease/TakeProfitDialog.test.ts
@@ -195,7 +195,7 @@ vi.mock("web-components", () => ({
   ToastType: { success: "success", error: "error" }
 }));
 
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { Dec } from "@keplr-wallet/unit";
 import TakeProfitDialog from "./TakeProfitDialog.vue";
 
@@ -220,7 +220,7 @@ function makeLease(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function factory() {
+function factory(provide: Record<string, unknown> = {}) {
   return mount(TakeProfitDialog, {
     global: {
       mocks: {
@@ -228,7 +228,8 @@ function factory() {
       },
       provide: {
         onShowToast: vi.fn(),
-        reload: vi.fn()
+        reload: vi.fn(),
+        ...provide
       }
     }
   });
@@ -284,6 +285,63 @@ describe("TakeProfitDialog.vue", () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.text()).toContain("message.stoppings-payout");
     expect(wrapper.text()).not.toContain('message.stoppings-payout {"amount":"0"}');
+    wrapper.unmount();
+  });
+
+  // take-profit success must surface the take-profit toast, not the
+  // stop-loss toast both original SFCs unconditionally emitted.
+  it("emits the take-profit success toast on a completed submit", async () => {
+    const onShowToast = vi.fn();
+    const wrapper = factory({ onShowToast });
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("5");
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="submit"]').trigger("click");
+    await flushPromises();
+    expect(hoisted.loggerError).not.toHaveBeenCalled();
+    expect(onShowToast).toHaveBeenCalledWith(expect.objectContaining({ message: "message.take-profit-toast" }));
+    wrapper.unmount();
+  });
+
+  // getPercent take-profit branch must guard the zero divisor the
+  // stop-loss branch already guards; without the guard quo() throws, the
+  // submit is swallowed by operation()'s catch, and no toast is emitted.
+  it("completes the submit without throwing when the unit asset is zero (Long)", async () => {
+    hoisted.getLeaseDisplayData.mockReturnValue({
+      openingPrice: new Dec("1"),
+      totalDebt: new Dec("0"),
+      stableAsset: new Dec("1"),
+      unitAsset: new Dec("0")
+    });
+    const onShowToast = vi.fn();
+    const wrapper = factory({ onShowToast });
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("5");
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="submit"]').trigger("click");
+    await flushPromises();
+    expect(hoisted.loggerError).not.toHaveBeenCalled();
+    expect(onShowToast).toHaveBeenCalledWith(expect.objectContaining({ message: "message.take-profit-toast" }));
+    wrapper.unmount();
+  });
+
+  it("completes the submit without throwing when the unit asset is zero (Short)", async () => {
+    hoisted.configRef.positionType = "Short";
+    hoisted.getLeaseDisplayData.mockReturnValue({
+      openingPrice: new Dec("1"),
+      totalDebt: new Dec("0"),
+      stableAsset: new Dec("1"),
+      unitAsset: new Dec("0")
+    });
+    const onShowToast = vi.fn();
+    const wrapper = factory({ onShowToast });
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="amount"]').setValue("0.5");
+    await wrapper.vm.$nextTick();
+    await wrapper.find('[data-test="submit"]').trigger("click");
+    await flushPromises();
+    expect(hoisted.loggerError).not.toHaveBeenCalled();
+    expect(onShowToast).toHaveBeenCalledWith(expect.objectContaining({ message: "message.take-profit-toast" }));
     wrapper.unmount();
   });
 });

--- a/src/modules/leases/components/single-lease/useTriggerDialog.ts
+++ b/src/modules/leases/components/single-lease/useTriggerDialog.ts
@@ -369,7 +369,7 @@ export function useTriggerDialog(mode: TriggerMode) {
         dialog?.value?.close();
         onShowToast({
           type: ToastType.success,
-          message: i18n.t("message.stop-loss-toast")
+          message: i18n.t(mode === "stop-loss" ? "message.stop-loss-toast" : "message.take-profit-toast")
         });
       } catch (error: unknown) {
         Logger.error(error);
@@ -399,10 +399,17 @@ export function useTriggerDialog(mode: TriggerMode) {
         return displayData.value.stableAsset.quo(displayData.value.unitAsset).mul(value);
       }
     } else {
-      const value = new Dec(amount.value);
+      const value = new Dec(amount.value.length === 0 ? 0 : amount.value);
       if (positionType === "Long") {
-        return displayData.value.stableAsset.quo(value.mul(displayData.value.unitAsset));
+        const v = value.mul(displayData.value.unitAsset);
+        if (v.isZero()) {
+          return new Dec(0);
+        }
+        return displayData.value.stableAsset.quo(v);
       } else {
+        if (displayData.value.unitAsset.isZero()) {
+          return new Dec(0);
+        }
         return displayData.value.stableAsset.quo(displayData.value.unitAsset).mul(value);
       }
     }


### PR DESCRIPTION
## Summary

Fix two latent defects in the take-profit dialog path (surfaced by review during the #185 extraction, preserved there by mandate): the success toast showed the stop-loss message for both modes, and the take-profit `getPercent` branch lacked the zero/empty guards its stop-loss sibling has — a reachable division-by-zero. Closes #261.

## Changes

- `useTriggerDialog.ts`: toast key selected by mode (`stop-loss-toast` / new `take-profit-toast`); take-profit `getPercent` branch now mirrors the stop-loss guards verbatim (empty-amount coercion, Long `v.isZero()`, Short `unitAsset.isZero()`).
- New `take-profit-toast` key added to all 10 locale files (`backend/config/locales/{en,id,ru,kr,jp,tr,fr,gr,es,cn}.json`), phrased per each locale's stop-loss-toast style.
- Tests first (failing before the fix): take-profit toast assertion, Long + Short zero-divisor cases (both previously threw `RangeError: Division by zero`), plus a stop-loss toast non-regression test.

## Verification

- Confirmed all three new tests fail for the right reasons against the unfixed code, then pass after; full suite 998/998, complete gate green (typecheck, lint, style, format, build).
- Verified the guard mirror is byte-identical to the stop-loss branch and the mode union is closed, so the ternary cannot mis-route.
- Validated all 10 locale files parse and carry the key with consistent placement.
- Independent code, security, and conventions reviews passed after one round: three test comments carried issue-number prefixes (banned category) and were stripped.

## Deployment — manual step required

`backend/config/locales/` is **excluded from the deploy rclone sync** (persistent on the frontends server). Merging does NOT ship the new key — until it's applied, a completed take-profit shows the raw path `message.take-profit-toast`. After merge, on the frontends server (`ssh root@10.133.133.11`): add the `take-profit-toast` key to the locale files under `/opt/deploy/builds/app-dev/config/locales/` and `/opt/deploy/builds/app/config/locales/` (copy the 10 values from this PR), then restart `webapp-dev` / `webapp-prod` to clear the backend's in-memory locale cache.