### PR TITLE
refactor(leases): unify Long/Short lease details behind shared core

### DIFF
--- a/src/modules/leases/components/new-lease/LongLeaseDetails.vue
+++ b/src/modules/leases/components/new-lease/LongLeaseDetails.vue
@@ -122,25 +122,9 @@ import type { LeaseApply } from "@nolus/nolusjs/build/contracts";
 import BigNumber from "@/common/components/BigNumber.vue";
 import PositionPreviewChart from "./PositionPreviewChart.vue";
 import { SvgIcon } from "web-components";
-import { computed, onMounted, onUnmounted, ref, watch } from "vue";
-import { MONTHS, NATIVE_CURRENCY } from "@/config/global";
-import { getAdaptivePriceDecimals, formatPrice } from "@/common/utils/NumberFormatUtils";
-import { usePricesStore } from "@/common/stores/prices";
-import { useConfigStore } from "@/common/stores/config";
-import { LeaseMath } from "@/common/utils";
-import { getCurrencyByTicker, getLpnByProtocol } from "@/common/utils/CurrencyLookup";
-
+import { NATIVE_CURRENCY } from "@/config/global";
 import { Dec } from "@keplr-wallet/unit";
-import { CurrencyUtils } from "@nolus/nolusjs";
-import { SkipRouter } from "@/common/utils/SkipRoute";
-
-// Debounce window for the two Promise.all'd Skip API calls fired when the
-// lease quote changes. Must stay comfortably above the Leaser contract call
-// latency so rapid slider drags collapse to a single fire — a shorter window
-// let slow contract responses trigger back-to-back setSwapFee runs and hit
-// the backend's /api/swap/route strict rate limit (2 RPS, burst 5).
-const timeOut = 600;
-let time: NodeJS.Timeout;
+import { useLongLeaseDetails } from "./useLongLeaseDetails";
 
 const props = defineProps<{
   lease: LeaseApply | null | undefined;
@@ -148,240 +132,26 @@ const props = defineProps<{
   downpaymenAmount: string;
   downpaymentCurrency: string;
 }>();
-const pricesStore = usePricesStore();
-const configStore = useConfigStore();
-const swapFee = ref(0);
-const swapStableFee = ref(0);
 
-onMounted(async () => {
-  // Free interest is handled by a 3rd party service
-});
-
-onUnmounted(() => {
-  clearTimeout(time);
-});
-
-watch(
-  () => [props.lease],
-  () => {
-    void setSwapFee();
-  }
-);
-
-const isFreeLease = computed(() => {
-  // Free interest is handled by a 3rd party service
-  return false;
-});
-
-const annualInterestRate = computed(() => {
-  return ((props.lease?.annual_interest_rate ?? 0) + (props.lease?.annual_interest_rate_margin ?? 0)) / MONTHS;
-});
-
-const sizeAmount = computed(() => {
-  if (!props.lease?.total?.amount) {
-    return "0";
-  }
-
-  const total = new Dec(props.lease?.total.amount ?? "0").sub(swapFeeAmount.value);
-  return total.truncate().toString();
-});
-
-const stable = computed(() => {
-  const price = new Dec(pricesStore.prices[asset.value?.key as string]?.price ?? 0);
-  const v = props.lease?.total?.amount ?? "0";
-  const stable = price.mul(new Dec(v, asset.value?.decimal_digits ?? 0)).sub(new Dec(swapStableFee.value));
-
-  return stable.toString();
-});
-
-const asset = computed(() => {
-  const currency = configStore.currenciesData?.[props.loanCurrency];
-  return currency;
-});
-
-const lpn = computed(() => {
-  const dpa = downPaymentAsset.value;
-  if (dpa === undefined) {
-    return null;
-  }
-  const [, p] = dpa.key.split("@");
-  if (p === undefined) {
-    return null;
-  }
-  return getLpnByProtocol(p);
-});
-
-const downPaymentAsset = computed(() => {
-  const currency = configStore.currenciesData?.[props.downpaymentCurrency];
-  return currency;
-});
-
-const downPaymentAmount = computed(() => {
-  const dpa = downPaymentAsset.value;
-  if (dpa === undefined) {
-    return "0";
-  }
-  const price = new Dec(pricesStore.prices[dpa.key]?.price ?? 0);
-  const decimals = new Dec(10 ** dpa.decimal_digits);
-  const v = downPaymentStable.value;
-  const amount = v.quo(price).mul(decimals);
-  return amount.truncate().toString();
-});
-
-const downPaymentStable = computed(() => {
-  const dpa = downPaymentAsset.value;
-  if (dpa === undefined) {
-    return new Dec(0);
-  }
-  const price = new Dec(pricesStore.prices[dpa.key]?.price ?? 0);
-  const v = props.downpaymenAmount.length === 0 ? "0" : props.downpaymenAmount;
-  const stable = price.mul(new Dec(v));
-  return stable;
-});
-
-const borrowAmount = computed(() => {
-  const a = asset.value;
-  if (a === undefined) {
-    return "0";
-  }
-  const price = new Dec(pricesStore.prices[a.key]?.price ?? 0);
-  const decimals = new Dec(10 ** a.decimal_digits);
-  const v = borrowStable.value;
-  const amount = v.quo(price).mul(decimals);
-  return amount.truncate().toString();
-});
-
-const swapFeeAmount = computed(() => {
-  const a = asset.value;
-  if (a === undefined) {
-    return new Dec(0);
-  }
-  const price = new Dec(pricesStore.prices[a.key]?.price ?? 0);
-  const decimals = new Dec(10 ** a.decimal_digits);
-  const v = new Dec(swapStableFee.value);
-  const amount = v.quo(price).mul(decimals);
-  return amount;
-});
-
-const borrowStable = computed(() => {
-  const l = lpn.value;
-  if (l === null) {
-    return new Dec(0);
-  }
-  const price = new Dec(pricesStore.prices[l.key]?.price ?? 0);
-  const v = props.lease?.borrow?.amount ?? "0";
-  const stable = price.mul(new Dec(v, l.decimal_digits));
-  return stable;
-});
-
-const currentPriceDecimals = computed(() => {
-  return getAdaptivePriceDecimals(Number(pricesStore.prices[props.loanCurrency]?.price ?? 0));
-});
-
-const calculateLique = computed(() => {
-  const d = getLquidation();
-  if (d.isZero()) {
-    return `${d.toString(2)}`;
-  }
-  return formatPrice(d.toString(8));
-});
-
-const percentLique = computed(() => {
-  const a = asset.value;
-  // Use the currency key to get the price, not ibcData
-  const price = new Dec(pricesStore.prices[a?.key as string]?.price ?? "0", a?.decimal_digits ?? 0);
-  const lprice = getLquidation();
-
-  if (lprice.isZero() || price.isZero()) {
-    return `0`;
-  }
-
-  const p = price.sub(lprice).quo(price);
-  return `-${p.abs().mul(new Dec(100)).toString(0)}`;
-});
-
-function getLquidation() {
-  const lease = props.lease;
-  if (lease && lease.borrow.ticker && lease.total.ticker) {
-    const unitAssetInfo = getCurrencyByTicker(lease.borrow.ticker);
-    const stableAssetInfo = getCurrencyByTicker(lease.total.ticker);
-
-    const unitAsset = new Dec(getBorrowedAmount(), Number(unitAssetInfo.decimal_digits));
-
-    const stableAsset = new Dec(getTotalAmount(), Number(stableAssetInfo.decimal_digits));
-    return LeaseMath.calculateLiquidation(unitAsset, stableAsset);
-  }
-
-  return new Dec(0);
-}
-
-function getBorrowedAmount() {
-  const borrow = props.lease?.borrow;
-
-  if (borrow) {
-    const amount = new Dec(borrow?.amount ?? 0).truncate();
-    return amount;
-  }
-
-  return new Dec(0).truncate();
-}
-
-function getTotalAmount() {
-  const total = props.lease?.total;
-  return new Dec(total?.amount ?? 0).truncate();
-}
-
-async function setSwapFee() {
-  clearTimeout(time);
-  const lease = props.lease;
-  if (lease) {
-    time = setTimeout(() => {
-      void (async () => {
-        const currency = downPaymentAsset.value;
-        const a = asset.value;
-        if (currency === undefined || a === undefined) return;
-        const [_, p] = a.key.split("@");
-        if (p === undefined) return;
-
-        const microAmount = CurrencyUtils.convertDenomToMinimalDenom(
-          props.downpaymenAmount,
-          currency.ibcData,
-          currency.decimal_digits
-        ).amount.toString();
-
-        const lpn = getLpnByProtocol(p);
-        if (lpn === null) return;
-        let amountIn = 0;
-        let amountOut = 0;
-        await Promise.all([
-          SkipRouter.getRoute(currency.ibcData, a.ibcData, microAmount).then((data) => {
-            amountIn += Number(data.usd_amount_in ?? 0);
-            amountOut += Number(data.usd_amount_out ?? 0);
-
-            return Number(data?.swap_price_impact_percent ?? 0);
-          }),
-          SkipRouter.getRoute(lpn.ibcData, a.ibcData, lease.borrow.amount).then((data) => {
-            amountIn += Number(data.usd_amount_in ?? 0);
-            amountOut += Number(data.usd_amount_out ?? 0);
-
-            return Number(data?.swap_price_impact_percent ?? 0);
-          })
-        ]);
-        const out_a = Math.max(amountOut, amountIn);
-        const in_a = Math.min(amountOut, amountIn);
-
-        const diff = out_a - in_a;
-        swapStableFee.value = diff;
-        let fee = 0;
-
-        if (in_a > 0) {
-          fee = diff / in_a;
-        }
-        swapFee.value = fee;
-      })();
-    }, timeOut);
-  }
-}
+const {
+  pricesStore,
+  swapStableFee,
+  sizeAmount,
+  asset,
+  stable,
+  borrowStable,
+  borrowAmount,
+  downPaymentStable,
+  downPaymentAmount,
+  downPaymentAsset,
+  annualInterestRate,
+  isFreeLease,
+  percentLique,
+  calculateLique,
+  currentPriceDecimals,
+  lpn,
+  swapFeeAmount
+} = useLongLeaseDetails(props);
 </script>
 <style lang="scss" scoped>
 .fadeHeight-enter-active,

--- a/src/modules/leases/components/new-lease/useLeaseDetailsCore.ts
+++ b/src/modules/leases/components/new-lease/useLeaseDetailsCore.ts
@@ -1,0 +1,228 @@
+import type { LeaseApply } from "@nolus/nolusjs/build/contracts";
+import { computed, onUnmounted, ref, watch, type ComputedRef } from "vue";
+import { MONTHS } from "@/config/global";
+import { getAdaptivePriceDecimals, formatPrice } from "@/common/utils/NumberFormatUtils";
+import { usePricesStore } from "@/common/stores/prices";
+import { useConfigStore } from "@/common/stores/config";
+import { getCurrencyByTicker, getLpnByProtocol } from "@/common/utils/CurrencyLookup";
+import type { CurrencyInfo } from "@/common/api/types/config";
+
+import { Dec } from "@keplr-wallet/unit";
+import { CurrencyUtils } from "@nolus/nolusjs";
+import { SkipRouter } from "@/common/utils/SkipRoute";
+
+export interface LeaseDetailsProps {
+  lease: LeaseApply | null | undefined;
+  loanCurrency: string;
+  downpaymenAmount: string;
+  downpaymentCurrency: string;
+}
+
+// The Long-vs-Short residue the shared core wires into its reactive skeleton. Each
+// field is a load-bearing asymmetry the two positions keep in their own clearly
+// named composable rather than buried behind a mode conditional here.
+export interface LeaseDetailsStrategy {
+  // The lpn currency backing the borrow. Short reads it from the loan (shorted-asset)
+  // protocol; Long from the down-payment protocol — different source, same shape.
+  lpn: ComputedRef<CurrencyInfo | null>;
+  // The Skip-route destination for both setSwapFee legs. Short settles into the
+  // protocol stable (lease.total.ticker); Long swaps into the leased asset itself.
+  // Returning null aborts the refresh (Short: stable currency not resolvable).
+  resolveRouteTarget: (asset: CurrencyInfo, protocol: string, lease: LeaseApply) => string | null;
+  // The liquidation price. The argument order is inverted between positions —
+  // Short calls calculateLiquidationShort(stable, unit), Long calls
+  // calculateLiquidation(unit, stable) — so the LeaseMath call itself is the hook.
+  liquidate: (unitAsset: Dec, stableAsset: Dec) => Dec;
+}
+
+// Shared primitives both the per-position residue and the core read. Kept in one
+// place so `asset`/`downPaymentAsset` are a single reactive source and the
+// strategy (which needs them) can be built before the core is wired.
+export function useLeaseDetailsBase(props: LeaseDetailsProps) {
+  const pricesStore = usePricesStore();
+  const configStore = useConfigStore();
+  const swapStableFee = ref(0);
+
+  const asset = computed(() => configStore.currenciesData?.[props.loanCurrency]);
+  const downPaymentAsset = computed(() => configStore.currenciesData?.[props.downpaymentCurrency]);
+
+  function getBorrowedAmount() {
+    const borrow = props.lease?.borrow;
+
+    if (borrow) {
+      const amount = new Dec(borrow?.amount ?? 0).truncate();
+      return amount;
+    }
+
+    return new Dec(0).truncate();
+  }
+
+  function getTotalAmount() {
+    const total = props.lease?.total;
+    return new Dec(total?.amount ?? 0).truncate();
+  }
+
+  return { pricesStore, configStore, swapStableFee, asset, downPaymentAsset, getBorrowedAmount, getTotalAmount };
+}
+
+export function useLeaseDetailsCore(
+  props: LeaseDetailsProps,
+  base: ReturnType<typeof useLeaseDetailsBase>,
+  strategy: LeaseDetailsStrategy
+) {
+  const { pricesStore, swapStableFee, asset, downPaymentAsset, getBorrowedAmount, getTotalAmount } = base;
+  const { lpn, resolveRouteTarget, liquidate } = strategy;
+
+  // Debounce window for the two Promise.all'd Skip API calls fired when the
+  // lease quote changes. Must stay comfortably above the Leaser contract call
+  // latency so rapid slider drags collapse to a single fire — a shorter window
+  // let slow contract responses trigger back-to-back setSwapFee runs and hit
+  // the backend's /api/swap/route strict rate limit (2 RPS, burst 5).
+  const timeOut = 600;
+  let time: NodeJS.Timeout;
+
+  onUnmounted(() => {
+    clearTimeout(time);
+  });
+
+  watch(
+    () => [props.lease],
+    () => {
+      void setSwapFee();
+    }
+  );
+
+  const isFreeLease = computed(() => {
+    // Free interest is handled by a 3rd party service
+    return false;
+  });
+
+  const annualInterestRate = computed(() => {
+    return ((props.lease?.annual_interest_rate ?? 0) + (props.lease?.annual_interest_rate_margin ?? 0)) / MONTHS;
+  });
+
+  const downPaymentStable = computed(() => {
+    const dpa = downPaymentAsset.value;
+    if (dpa === undefined) {
+      return new Dec(0);
+    }
+    const price = new Dec(pricesStore.prices[dpa.key]?.price ?? 0);
+    const v = props.downpaymenAmount.length === 0 ? "0" : props.downpaymenAmount;
+    const stable = price.mul(new Dec(v));
+    return stable;
+  });
+
+  const downPaymentAmount = computed(() => {
+    const dpa = downPaymentAsset.value;
+    if (dpa === undefined) {
+      return "0";
+    }
+    const price = new Dec(pricesStore.prices[dpa.key]?.price ?? 0);
+    const decimals = new Dec(10 ** dpa.decimal_digits);
+    const v = downPaymentStable.value;
+    const amount = v.quo(price).mul(decimals);
+    return amount.truncate().toString();
+  });
+
+  const borrowStable = computed(() => {
+    const l = lpn.value;
+    if (l === null) {
+      return new Dec(0);
+    }
+    const price = new Dec(pricesStore.prices[l.key]?.price ?? 0);
+    const v = props.lease?.borrow?.amount ?? "0";
+    const stable = price.mul(new Dec(v, l.decimal_digits));
+    return stable;
+  });
+
+  const currentPriceDecimals = computed(() => {
+    return getAdaptivePriceDecimals(Number(pricesStore.prices[props.loanCurrency]?.price ?? 0));
+  });
+
+  const calculateLique = computed(() => {
+    const d = getLiquidation();
+    if (d.isZero()) {
+      return `${d.toString(2)}`;
+    }
+    return formatPrice(d.toString(8));
+  });
+
+  function getLiquidation() {
+    const lease = props.lease;
+    if (lease && lease.borrow.ticker && lease.total.ticker) {
+      const unitAssetInfo = getCurrencyByTicker(lease.borrow.ticker);
+      const stableAssetInfo = getCurrencyByTicker(lease.total.ticker);
+
+      const unitAsset = new Dec(getBorrowedAmount(), Number(unitAssetInfo.decimal_digits));
+
+      const stableAsset = new Dec(getTotalAmount(), Number(stableAssetInfo.decimal_digits));
+      return liquidate(unitAsset, stableAsset);
+    }
+
+    return new Dec(0);
+  }
+
+  async function setSwapFee() {
+    clearTimeout(time);
+    const lease = props.lease;
+    if (!lease) return;
+    time = setTimeout(() => {
+      void (async () => {
+        const currency = downPaymentAsset.value;
+        const a = asset.value;
+        if (currency === undefined || a === undefined) return;
+        const [_, p] = a.key.split("@");
+        if (p === undefined) return;
+
+        const target = resolveRouteTarget(a, p, lease);
+        if (target === null) return;
+
+        const microAmount = CurrencyUtils.convertDenomToMinimalDenom(
+          props.downpaymenAmount,
+          currency.ibcData,
+          currency.decimal_digits
+        ).amount.toString();
+
+        const lpn = getLpnByProtocol(p);
+        if (lpn === null) return;
+        let amountIn = 0;
+        let amountOut = 0;
+        await Promise.all([
+          SkipRouter.getRoute(currency.ibcData, target, microAmount).then((data) => {
+            amountIn += Number(data.usd_amount_in ?? 0);
+            amountOut += Number(data.usd_amount_out ?? 0);
+
+            return Number(data?.swap_price_impact_percent ?? 0);
+          }),
+          SkipRouter.getRoute(lpn.ibcData, target, lease.borrow.amount).then((data) => {
+            amountIn += Number(data.usd_amount_in ?? 0);
+            amountOut += Number(data.usd_amount_out ?? 0);
+
+            return Number(data?.swap_price_impact_percent ?? 0);
+          })
+        ]);
+        const out_a = Math.max(amountOut, amountIn);
+        const in_a = Math.min(amountOut, amountIn);
+
+        const diff = out_a - in_a;
+        swapStableFee.value = diff;
+      })();
+    }, timeOut);
+  }
+
+  return {
+    pricesStore,
+    swapStableFee,
+    asset,
+    downPaymentAsset,
+    lpn,
+    borrowStable,
+    downPaymentAmount,
+    downPaymentStable,
+    currentPriceDecimals,
+    annualInterestRate,
+    isFreeLease,
+    getLiquidation,
+    calculateLique
+  };
+}

--- a/src/modules/leases/components/new-lease/useLongLeaseDetails.ts
+++ b/src/modules/leases/components/new-lease/useLongLeaseDetails.ts
@@ -1,0 +1,109 @@
+import { computed } from "vue";
+import { LeaseMath } from "@/common/utils";
+import { getLpnByProtocol } from "@/common/utils/CurrencyLookup";
+import type { CurrencyInfo } from "@/common/api/types/config";
+
+import { Dec } from "@keplr-wallet/unit";
+import { useLeaseDetailsBase, useLeaseDetailsCore, type LeaseDetailsProps } from "./useLeaseDetailsCore";
+
+export type LongLeaseDetailsProps = LeaseDetailsProps;
+
+export function useLongLeaseDetails(props: LeaseDetailsProps) {
+  const base = useLeaseDetailsBase(props);
+  const { pricesStore, swapStableFee, asset, downPaymentAsset } = base;
+
+  // Long: the lpn/protocol comes from the down-payment key.
+  const lpn = computed<CurrencyInfo | null>(() => {
+    const dpa = downPaymentAsset.value;
+    if (dpa === undefined) {
+      return null;
+    }
+    const [, p] = dpa.key.split("@");
+    if (p === undefined) {
+      return null;
+    }
+    return getLpnByProtocol(p);
+  });
+
+  const core = useLeaseDetailsCore(props, base, {
+    lpn,
+    // Long swaps the down payment and the borrowed LPN into the leased asset itself.
+    resolveRouteTarget: (a) => a.ibcData,
+    liquidate: (unitAsset, stableAsset) => LeaseMath.calculateLiquidation(unitAsset, stableAsset)
+  });
+
+  const swapFeeAmount = computed(() => {
+    const a = asset.value;
+    if (a === undefined) {
+      return new Dec(0);
+    }
+    const price = new Dec(pricesStore.prices[a.key]?.price ?? 0);
+    const decimals = new Dec(10 ** a.decimal_digits);
+    const v = new Dec(swapStableFee.value);
+    const amount = v.quo(price).mul(decimals);
+    return amount;
+  });
+
+  const sizeAmount = computed(() => {
+    if (!props.lease?.total?.amount) {
+      return "0";
+    }
+
+    const total = new Dec(props.lease?.total.amount ?? "0").sub(swapFeeAmount.value);
+    return total.truncate().toString();
+  });
+
+  const stable = computed(() => {
+    const price = new Dec(pricesStore.prices[asset.value?.key as string]?.price ?? 0);
+    const v = props.lease?.total?.amount ?? "0";
+    const stable = price.mul(new Dec(v, asset.value?.decimal_digits ?? 0)).sub(new Dec(swapStableFee.value));
+
+    return stable.toString();
+  });
+
+  const borrowAmount = computed(() => {
+    const a = asset.value;
+    if (a === undefined) {
+      return "0";
+    }
+    const price = new Dec(pricesStore.prices[a.key]?.price ?? 0);
+    const decimals = new Dec(10 ** a.decimal_digits);
+    const v = core.borrowStable.value;
+    const amount = v.quo(price).mul(decimals);
+    return amount.truncate().toString();
+  });
+
+  const percentLique = computed(() => {
+    const a = asset.value;
+    // Use the currency key to get the price, not ibcData
+    const price = new Dec(pricesStore.prices[a?.key as string]?.price ?? "0", a?.decimal_digits ?? 0);
+    const lprice = core.getLiquidation();
+
+    if (lprice.isZero() || price.isZero()) {
+      return `0`;
+    }
+
+    const p = price.sub(lprice).quo(price);
+    return `-${p.abs().mul(new Dec(100)).toString(0)}`;
+  });
+
+  return {
+    pricesStore,
+    swapStableFee,
+    sizeAmount,
+    asset,
+    stable,
+    borrowStable: core.borrowStable,
+    borrowAmount,
+    downPaymentStable: core.downPaymentStable,
+    downPaymentAmount: core.downPaymentAmount,
+    downPaymentAsset,
+    annualInterestRate: core.annualInterestRate,
+    isFreeLease: core.isFreeLease,
+    percentLique,
+    calculateLique: core.calculateLique,
+    currentPriceDecimals: core.currentPriceDecimals,
+    lpn,
+    swapFeeAmount
+  };
+}

--- a/src/modules/leases/components/new-lease/useShortLeaseDetails.ts
+++ b/src/modules/leases/components/new-lease/useShortLeaseDetails.ts
@@ -1,47 +1,44 @@
-import type { LeaseApply } from "@nolus/nolusjs/build/contracts";
-import { computed, onUnmounted, ref, watch } from "vue";
-import { MONTHS } from "@/config/global";
-import { getAdaptivePriceDecimals, formatPrice } from "@/common/utils/NumberFormatUtils";
-import { usePricesStore } from "@/common/stores/prices";
-import { useConfigStore } from "@/common/stores/config";
+import { computed } from "vue";
 import { LeaseMath } from "@/common/utils";
 import { getCurrencyByTicker, getLpnByProtocol } from "@/common/utils/CurrencyLookup";
+import type { CurrencyInfo } from "@/common/api/types/config";
 
 import { Dec } from "@keplr-wallet/unit";
-import { CurrencyUtils } from "@nolus/nolusjs";
-import { SkipRouter } from "@/common/utils/SkipRoute";
+import { useLeaseDetailsBase, useLeaseDetailsCore, type LeaseDetailsProps } from "./useLeaseDetailsCore";
 
-export interface ShortLeaseDetailsProps {
-  lease: LeaseApply | null | undefined;
-  loanCurrency: string;
-  downpaymenAmount: string;
-  downpaymentCurrency: string;
-}
+export type ShortLeaseDetailsProps = LeaseDetailsProps;
 
-export function useShortLeaseDetails(props: ShortLeaseDetailsProps) {
-  // Debounce window for the two Promise.all'd Skip API calls fired when the
-  // lease quote changes. Must stay comfortably above the Leaser contract call
-  // latency so rapid slider drags collapse to a single fire — a shorter window
-  // let slow contract responses trigger back-to-back setSwapFee runs and hit
-  // the backend's /api/swap/route strict rate limit (2 RPS, burst 5).
-  const timeOut = 600;
-  let time: NodeJS.Timeout;
+export function useShortLeaseDetails(props: LeaseDetailsProps) {
+  const base = useLeaseDetailsBase(props);
+  const { pricesStore, configStore, swapStableFee, asset, downPaymentAsset } = base;
 
-  const pricesStore = usePricesStore();
-  const configStore = useConfigStore();
-  const swapFee = ref(0);
-  const swapStableFee = ref(0);
-
-  onUnmounted(() => {
-    clearTimeout(time);
+  // Short: the lpn/protocol comes from the loan (shorted-asset) key.
+  const lpn = computed<CurrencyInfo | null>(() => {
+    const loan = asset.value;
+    if (loan === undefined) {
+      return null;
+    }
+    const [_t, p] = loan.key.split("@");
+    if (p === undefined) {
+      return null;
+    }
+    return getLpnByProtocol(p);
   });
 
-  watch(
-    () => [props.lease],
-    (_value) => {
-      void setSwapFee();
-    }
-  );
+  const core = useLeaseDetailsCore(props, base, {
+    lpn,
+    resolveRouteTarget: (_a, p, lease) => {
+      // For a Short position the on-chain flow swaps both the down payment and
+      // the borrowed LPN to the stable the position settles in (lease.total.ticker,
+      // e.g. USDC_NOBLE) — NOT to asset.value (the borrowed/shorted asset, which
+      // on a Short protocol is the same as the LPN). Routing source→source is a
+      // no-op and Skip returns a zero fee, so the UI showed 0.00 BTC.
+      const stableTicker = lease.total?.ticker;
+      const stable = stableTicker ? configStore.currenciesData?.[`${stableTicker}@${p}`] : null;
+      return stable?.ibcData ?? null;
+    },
+    liquidate: (unitAsset, stableAsset) => LeaseMath.calculateLiquidationShort(stableAsset, unitAsset)
+  });
 
   /** The currency for lease.total (stable currency for shorts, e.g., USDC) */
   const totalAsset = computed(() => {
@@ -59,15 +56,6 @@ export function useShortLeaseDetails(props: ShortLeaseDetailsProps) {
     const fee = new Dec(swapStableFee.value, decimals);
     const total = new Dec(props.lease?.total.amount ?? "0").sub(fee);
     return total.truncate().toString();
-  });
-
-  const isFreeLease = computed(() => {
-    // Free interest is handled by a 3rd party service
-    return false;
-  });
-
-  const annualInterestRate = computed(() => {
-    return ((props.lease?.annual_interest_rate ?? 0) + (props.lease?.annual_interest_rate_margin ?? 0)) / MONTHS;
   });
 
   const totalLoan = computed(() => {
@@ -89,56 +77,6 @@ export function useShortLeaseDetails(props: ShortLeaseDetailsProps) {
     return amount.toString(a.decimal_digits);
   });
 
-  const asset = computed(() => {
-    const currency = configStore.currenciesData?.[props.loanCurrency];
-    return currency;
-  });
-
-  const lpn = computed(() => {
-    const loan = loanAsset.value;
-    if (loan === undefined) {
-      return null;
-    }
-    const [_t, p] = loan.key.split("@");
-    if (p === undefined) {
-      return null;
-    }
-    return getLpnByProtocol(p);
-  });
-
-  const downPaymentAsset = computed(() => {
-    const currency = configStore.currenciesData?.[props.downpaymentCurrency];
-    return currency;
-  });
-
-  const loanAsset = computed(() => {
-    const currency = configStore.currenciesData[props.loanCurrency];
-    return currency;
-  });
-
-  const downPaymentAmount = computed(() => {
-    const dpa = downPaymentAsset.value;
-    if (dpa === undefined) {
-      return "0";
-    }
-    const price = new Dec(pricesStore.prices[dpa.key]?.price ?? 0);
-    const decimals = new Dec(10 ** dpa.decimal_digits);
-    const v = downPaymentStable.value;
-    const amount = v.quo(price).mul(decimals);
-    return amount.truncate().toString();
-  });
-
-  const downPaymentStable = computed(() => {
-    const dpa = downPaymentAsset.value;
-    if (dpa === undefined) {
-      return new Dec(0);
-    }
-    const price = new Dec(pricesStore.prices[dpa.key]?.price ?? 0);
-    const v = props.downpaymenAmount.length === 0 ? "0" : props.downpaymenAmount;
-    const stable = price.mul(new Dec(v));
-    return stable;
-  });
-
   const borrowAmount = computed(() => {
     const a = asset.value;
     const l = lpn.value;
@@ -147,7 +85,7 @@ export function useShortLeaseDetails(props: ShortLeaseDetailsProps) {
     }
     const price = new Dec(pricesStore.prices[a.key]?.price ?? 0);
     const decimals = new Dec(10 ** l.decimal_digits);
-    const v = borrowStable.value;
+    const v = core.borrowStable.value;
     const amount = v.quo(price).mul(decimals);
     return amount.truncate().toString();
   });
@@ -165,29 +103,6 @@ export function useShortLeaseDetails(props: ShortLeaseDetailsProps) {
     return amount;
   });
 
-  const borrowStable = computed(() => {
-    const l = lpn.value;
-    if (l === null) {
-      return new Dec(0);
-    }
-    const price = new Dec(pricesStore.prices[l.key]?.price ?? 0);
-    const v = props.lease?.borrow?.amount ?? "0";
-    const stable = price.mul(new Dec(v, l.decimal_digits));
-    return stable;
-  });
-
-  const currentPriceDecimals = computed(() => {
-    return getAdaptivePriceDecimals(Number(pricesStore.prices[props.loanCurrency]?.price ?? 0));
-  });
-
-  const calculateLique = computed(() => {
-    const d = getLquidation();
-    if (d.isZero()) {
-      return `${d.toString(2)}`;
-    }
-    return formatPrice(d.toString(8));
-  });
-
   const percentLique = computed(() => {
     try {
       const a = asset.value;
@@ -201,7 +116,7 @@ export function useShortLeaseDetails(props: ShortLeaseDetailsProps) {
       }
 
       const price = new Dec(pricesStore.prices[lpn.key]?.price ?? "0", a.decimal_digits);
-      const lprice = getLquidation();
+      const lprice = core.getLiquidation();
 
       if (lprice.isZero() || price.isZero()) {
         return `0`;
@@ -215,114 +130,23 @@ export function useShortLeaseDetails(props: ShortLeaseDetailsProps) {
     }
   });
 
-  function getLquidation() {
-    const lease = props.lease;
-    if (lease && lease.borrow.ticker && lease.total.ticker) {
-      const unitAssetInfo = getCurrencyByTicker(lease.borrow.ticker);
-      const stableAssetInfo = getCurrencyByTicker(lease.total.ticker);
-
-      const unitAsset = new Dec(getBorrowedAmount(), Number(unitAssetInfo.decimal_digits));
-
-      const stableAsset = new Dec(getTotalAmount(), Number(stableAssetInfo.decimal_digits));
-      return LeaseMath.calculateLiquidationShort(stableAsset, unitAsset);
-    }
-
-    return new Dec(0);
-  }
-
-  function getBorrowedAmount() {
-    const borrow = props.lease?.borrow;
-
-    if (borrow) {
-      const amount = new Dec(borrow?.amount ?? 0).truncate();
-      return amount;
-    }
-
-    return new Dec(0).truncate();
-  }
-
-  function getTotalAmount() {
-    const total = props.lease?.total;
-    return new Dec(total?.amount ?? 0).truncate();
-  }
-
-  const setSwapFee = async () => {
-    clearTimeout(time);
-    const lease = props.lease;
-    if (!lease) return;
-    time = setTimeout(() => {
-      void (async () => {
-        const currency = downPaymentAsset.value;
-        const a = asset.value;
-        if (currency === undefined || a === undefined) return;
-        const [_, p] = a.key.split("@");
-        if (p === undefined) return;
-
-        // For a Short position the on-chain flow swaps both the down payment and
-        // the borrowed LPN to the stable the position settles in (lease.total.ticker,
-        // e.g. USDC_NOBLE) — NOT to asset.value (the borrowed/shorted asset, which
-        // on a Short protocol is the same as the LPN). Routing source→source is a
-        // no-op and Skip returns a zero fee, so the UI showed 0.00 BTC.
-        const stableTicker = lease.total?.ticker;
-        const stable = stableTicker ? configStore.currenciesData?.[`${stableTicker}@${p}`] : null;
-        if (!stable) return;
-
-        const microAmount = CurrencyUtils.convertDenomToMinimalDenom(
-          props.downpaymenAmount,
-          currency.ibcData,
-          currency.decimal_digits
-        ).amount.toString();
-
-        const lpn = getLpnByProtocol(p);
-        if (lpn === null) return;
-        let amountIn = 0;
-        let amountOut = 0;
-        await Promise.all([
-          SkipRouter.getRoute(currency.ibcData, stable.ibcData, microAmount).then((data) => {
-            amountIn += Number(data.usd_amount_in ?? 0);
-            amountOut += Number(data.usd_amount_out ?? 0);
-
-            return Number(data?.swap_price_impact_percent ?? 0);
-          }),
-          SkipRouter.getRoute(lpn.ibcData, stable.ibcData, lease.borrow.amount).then((data) => {
-            amountIn += Number(data.usd_amount_in ?? 0);
-            amountOut += Number(data.usd_amount_out ?? 0);
-
-            return Number(data?.swap_price_impact_percent ?? 0);
-          })
-        ]);
-        const out_a = Math.max(amountOut, amountIn);
-        const in_a = Math.min(amountOut, amountIn);
-
-        const diff = out_a - in_a;
-        swapStableFee.value = diff;
-        let fee = 0;
-
-        if (in_a > 0) {
-          fee = diff / in_a;
-        }
-        swapFee.value = fee;
-      })();
-    }, timeOut);
-  };
-
   return {
     pricesStore,
     swapStableFee,
     totalAsset,
     sizeAmount,
-    isFreeLease,
-    annualInterestRate,
+    isFreeLease: core.isFreeLease,
+    annualInterestRate: core.annualInterestRate,
     totalLoan,
     asset,
     downPaymentAsset,
-    downPaymentAmount,
-    downPaymentStable,
+    downPaymentAmount: core.downPaymentAmount,
+    downPaymentStable: core.downPaymentStable,
     borrowAmount,
     swapFeeAmount,
-    borrowStable,
-    currentPriceDecimals,
-    calculateLique,
+    borrowStable: core.borrowStable,
+    currentPriceDecimals: core.currentPriceDecimals,
+    calculateLique: core.calculateLique,
     percentLique
   };
 }


### PR DESCRIPTION
## Summary

Unify `LongLeaseDetails.vue` (396→166 LOC, script drained) and `useShortLeaseDetails.ts` (258→147) behind a shared `useLeaseDetailsCore`, and delete the dead `swapFee` refs from both positions. No behavioural change. Closes #263.

## Changes

- New `useLeaseDetailsCore.ts`: the shared skeleton — 600 ms-debounced `setSwapFee` (single-sourced, per-instance timers, exactly one `onUnmounted` teardown), the watch, and all position-identical computeds. Per-position behavior injected via a small strategy (`lpn`, `resolveRouteTarget`, `liquidate`).
- New `useLongLeaseDetails.ts` / rewritten `useShortLeaseDetails.ts`: only the genuine asymmetries, each a named one-liner — fee-routing target (Short → stable from `lease.total.ticker`; Long → `asset.ibcData`), liquidation call + argument order (`calculateLiquidationShort(stable, unit)` vs `calculateLiquidation(unit, stable)`), percent sign, size math, position-only computeds. A mode flag would have buried nine conditionals in shared computeds; the strategy shape keeps them visible (same reasoning as the lease-forms trio).
- `ShortLeaseDetails.vue` untouched (return keys preserved); `LongLeaseDetails.vue` template + style byte-identical.
- Dead `swapFee` refs removed from both positions — each independently verified as write-only on main before removal, along with the orphaned block feeding them.

## Verification

- Ran the full gate: typecheck, lint, style guard, format check, 994/994 tests unchanged, build — all clean.
- Independent review verified all three load-bearing contracts against the pre-refactor originals: per-instance debounce timers with a single teardown each (no duplicate-teardown regression), both liquidation argument orders and the percent-sign inversion, and both fee-routing targets; also confirmed the Short `lpn` source change (`asset` ≡ old `loanAsset`, both resolve `currenciesData[loanCurrency]`) and that every template binding of both SFCs exists in the returned APIs.
- Code, security, and conventions reviews all passed; single LOW advisory (direct composable tests deferred to #262 as planned).

## Follow-ups

- Direct unit tests for the details composables land under #262 (debounce floor, per-position liquidation orders, route targets).