### PR TITLE
test(leases): dedicated unit tests for the extracted lease composables

### DIFF
--- a/src/modules/leases/components/new-lease/useLongLeaseDetails.test.ts
+++ b/src/modules/leases/components/new-lease/useLongLeaseDetails.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Direct unit tests for the useLongLeaseDetails composable — the Long-position
+ * mirror of useShortLeaseDetails.test.ts, pinning the strategy residue the
+ * shared core wires per position: the calculateLiquidation(unitAsset,
+ * stableAsset) argument order (inverted versus Short — a swap is the same
+ * inverse-liquidation bug class), the Skip route target being the leased asset
+ * itself (not the stable), the negative percentLique sign, the 600 ms debounce
+ * floor, and per-instance timer teardown (two mounted instances own
+ * independent timers). Mocked at the boundary: stores, SkipRouter, LeaseMath,
+ * CurrencyUtils.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, nextTick, reactive } from "vue";
+import { Dec } from "@keplr-wallet/unit";
+
+const hoisted = vi.hoisted(() => ({
+  getRoute: vi.fn(),
+  calculateLiquidation: vi.fn(),
+  currenciesData: {} as Record<string, unknown>,
+  prices: {} as Record<string, { price: string }>
+}));
+
+vi.mock("@/common/stores/prices", () => ({
+  usePricesStore: () => ({
+    get prices() {
+      return hoisted.prices;
+    }
+  })
+}));
+
+vi.mock("@/common/stores/config", () => ({
+  useConfigStore: () => ({
+    get currenciesData() {
+      return hoisted.currenciesData;
+    }
+  })
+}));
+
+vi.mock("@/common/utils", () => ({
+  LeaseMath: {
+    calculateLiquidation: hoisted.calculateLiquidation
+  }
+}));
+
+vi.mock("@/common/utils/CurrencyLookup", () => ({
+  getCurrencyByTicker: (ticker: string) => ({
+    key: `${ticker}@osmosis-1`,
+    ticker,
+    decimal_digits: ticker === "ALL_BTC" ? 8 : 6,
+    ibcData: `ibc/${ticker}`
+  }),
+  getLpnByProtocol: () => ({ key: "USDC@osmosis-1", ibcData: "ibc/LPN", decimal_digits: 6 })
+}));
+
+vi.mock("@/common/utils/NumberFormatUtils", () => ({
+  getAdaptivePriceDecimals: () => 2,
+  formatPrice: (v: string) => v
+}));
+
+vi.mock("@/common/utils/SkipRoute", () => ({
+  SkipRouter: { getRoute: hoisted.getRoute }
+}));
+
+vi.mock("@nolus/nolusjs", () => ({
+  CurrencyUtils: {
+    convertDenomToMinimalDenom: () => ({ amount: "1000000" })
+  }
+}));
+
+import { useLongLeaseDetails } from "./useLongLeaseDetails";
+import type { LeaseDetailsProps } from "./useLeaseDetailsCore";
+
+type LongApi = ReturnType<typeof useLongLeaseDetails>;
+
+function makeLease(overrides: Record<string, unknown> = {}) {
+  return {
+    total: { ticker: "USDC_NOBLE", amount: "2000000000" },
+    borrow: { ticker: "ALL_BTC", amount: "500000000" },
+    annual_interest_rate: 0,
+    annual_interest_rate_margin: 0,
+    ...overrides
+  };
+}
+
+function setup(lease: LeaseDetailsProps["lease"] = null) {
+  const state = reactive<LeaseDetailsProps>({
+    lease,
+    loanCurrency: "ALL_BTC@osmosis-1",
+    downpaymenAmount: "10",
+    downpaymentCurrency: "ATOM@osmosis-1"
+  });
+  let api!: LongApi;
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        api = useLongLeaseDetails(state);
+        return () => null;
+      }
+    })
+  );
+  return { api, wrapper, state };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hoisted.getRoute.mockResolvedValue({ usd_amount_in: "1", usd_amount_out: "1", swap_price_impact_percent: "0" });
+  hoisted.calculateLiquidation.mockReturnValue(new Dec("1234"));
+  hoisted.currenciesData = {
+    "ALL_BTC@osmosis-1": { key: "ALL_BTC@osmosis-1", ibcData: "ibc/BTC", decimal_digits: 6 },
+    "ATOM@osmosis-1": { key: "ATOM@osmosis-1", ibcData: "ibc/ATOM", decimal_digits: 6 },
+    "USDC_NOBLE@osmosis-1": { key: "USDC_NOBLE@osmosis-1", ibcData: "ibc/USDCN", decimal_digits: 6 }
+  };
+  hoisted.prices = {
+    "ALL_BTC@osmosis-1": { price: "2000000" },
+    "ATOM@osmosis-1": { price: "10" },
+    "USDC@osmosis-1": { price: "1" }
+  };
+});
+
+describe("useLongLeaseDetails — setSwapFee 600 ms debounce (shared core, Long instance)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("collapses three rapid lease changes into a single Skip fire (two legs) after 600 ms", async () => {
+    const { wrapper, state } = setup(null);
+
+    state.lease = makeLease({ borrow: { ticker: "ALL_BTC", amount: "1" } });
+    await nextTick();
+    state.lease = makeLease({ borrow: { ticker: "ALL_BTC", amount: "2" } });
+    await nextTick();
+    state.lease = makeLease({ borrow: { ticker: "ALL_BTC", amount: "3" } });
+    await nextTick();
+
+    expect(hoisted.getRoute, "no fire before the debounce window elapses").not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(
+      hoisted.getRoute,
+      "the collapsed fire issues exactly the two route legs, not three x two"
+    ).toHaveBeenCalledTimes(2);
+    wrapper.unmount();
+  });
+
+  it("does not fire before the 600 ms floor is reached", async () => {
+    const { wrapper, state } = setup(null);
+    state.lease = makeLease();
+    await nextTick();
+
+    await vi.advanceTimersByTimeAsync(599);
+    expect(hoisted.getRoute, "the fee call waits for the full 600 ms floor").not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(hoisted.getRoute, "the fee call fires once the floor is crossed").toHaveBeenCalledTimes(2);
+    wrapper.unmount();
+  });
+});
+
+describe("useLongLeaseDetails — Skip route legs target the leased asset", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("routes both the down payment and the borrowed LPN into the leased asset, not the stable", async () => {
+    const { wrapper, state } = setup(null);
+    state.lease = makeLease();
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(hoisted.getRoute).toHaveBeenCalledTimes(2);
+    const downPaymentLeg = hoisted.getRoute.mock.calls[0];
+    const borrowLeg = hoisted.getRoute.mock.calls[1];
+    if (downPaymentLeg === undefined || borrowLeg === undefined) {
+      throw new Error("expected both Skip route legs to have fired");
+    }
+
+    expect(downPaymentLeg[0], "down payment leg starts from the down payment currency").toBe("ibc/ATOM");
+    expect(downPaymentLeg[1], "down payment leg swaps into the leased asset").toBe("ibc/BTC");
+    expect(borrowLeg[0], "borrow leg starts from the borrowed LPN").toBe("ibc/LPN");
+    expect(borrowLeg[1], "borrow leg swaps into the leased asset, not the stable").toBe("ibc/BTC");
+    wrapper.unmount();
+  });
+});
+
+describe("useLongLeaseDetails — liquidation argument order", () => {
+  it("passes unitAsset (from borrow) then stableAsset (from total) to calculateLiquidation", () => {
+    const { api, wrapper } = setup(makeLease());
+
+    void api.calculateLique.value;
+
+    expect(hoisted.calculateLiquidation).toHaveBeenCalledTimes(1);
+    const call = hoisted.calculateLiquidation.mock.calls[0];
+    if (call === undefined) throw new Error("expected calculateLiquidation to have been called");
+    const [unitAsset, stableAsset] = call;
+    // borrow 500_000_000 at 8 dp = 5; total 2_000_000_000 at 6 dp = 2000.
+    expect(Number(unitAsset.toString()), "first arg is the borrowed unit (5), not the stable").toBe(5);
+    expect(Number(stableAsset.toString()), "second arg is the stable total (2000), not the unit").toBe(2000);
+    wrapper.unmount();
+  });
+});
+
+describe("useLongLeaseDetails — percentLique sign", () => {
+  it("reports the liquidation distance as a negative percentage", () => {
+    // Asset price 2_000_000 at 6 dp = 2; liquidation 1 -> (2 - 1) / 2 = 50%, Long-signed.
+    hoisted.calculateLiquidation.mockReturnValue(new Dec("1"));
+    const { api, wrapper } = setup(makeLease());
+
+    expect(api.percentLique.value, "Long liquidation distance carries a leading minus").toBe("-50");
+    wrapper.unmount();
+  });
+
+  it("reports zero without a sign when the liquidation price is zero", () => {
+    hoisted.calculateLiquidation.mockReturnValue(new Dec("0"));
+    const { api, wrapper } = setup(makeLease());
+
+    expect(api.percentLique.value, "zero liquidation short-circuits to unsigned zero").toBe("0");
+    wrapper.unmount();
+  });
+});
+
+describe("useLongLeaseDetails — teardown on unmount (per-instance timers)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("clears exactly one pending debounce timer when the instance unmounts", () => {
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    const { wrapper } = setup(makeLease());
+
+    const before = clearSpy.mock.calls.length;
+    wrapper.unmount();
+
+    expect(clearSpy.mock.calls.length - before, "onUnmounted clears the timer exactly once for this instance").toBe(1);
+  });
+
+  it("cancels a pending Skip fire so an unmounted instance never hits the backend", async () => {
+    const { wrapper, state } = setup(null);
+    state.lease = makeLease();
+    await nextTick(); // arms the 600 ms timer
+
+    wrapper.unmount(); // must clear it
+
+    await vi.advanceTimersByTimeAsync(600);
+    expect(hoisted.getRoute, "the cancelled timer issues no route call after unmount").not.toHaveBeenCalled();
+  });
+
+  it("keeps a second instance's pending fire alive when the first unmounts", async () => {
+    const first = setup(null);
+    const second = setup(null);
+    first.state.lease = makeLease({ borrow: { ticker: "ALL_BTC", amount: "1" } });
+    second.state.lease = makeLease({ borrow: { ticker: "ALL_BTC", amount: "2" } });
+    await nextTick(); // arms both timers
+
+    first.wrapper.unmount(); // must clear only its own timer
+
+    await vi.advanceTimersByTimeAsync(600);
+    expect(hoisted.getRoute, "only the surviving instance fires — exactly its two route legs").toHaveBeenCalledTimes(2);
+    second.wrapper.unmount();
+  });
+});

--- a/src/modules/leases/components/new-lease/useShortLeaseDetails.test.ts
+++ b/src/modules/leases/components/new-lease/useShortLeaseDetails.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Direct unit tests for the useShortLeaseDetails composable, which had no
+ * direct coverage (ShortForm.test.ts stubs ShortLeaseDetails.vue to a <div/>).
+ * Pins the behaviors the extraction made fragile: the 600 ms setSwapFee
+ * debounce that keeps rapid quote changes under the backend's 2 RPS
+ * /api/swap/route limit, the two Skip route legs both settling into the
+ * position's stable ticker (a source->source route is a no-op that returns a
+ * zero fee), the
+ * calculateLiquidationShort(stableAsset, unitAsset) argument order (a swap is
+ * an inverse-liquidation bug), and a single timer teardown on unmount.
+ * Mocked at the boundary: stores, SkipRouter, LeaseMath, CurrencyUtils.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, nextTick, reactive } from "vue";
+import { Dec } from "@keplr-wallet/unit";
+
+const hoisted = vi.hoisted(() => ({
+  getRoute: vi.fn(),
+  calculateLiquidationShort: vi.fn(),
+  currenciesData: {} as Record<string, unknown>,
+  prices: {} as Record<string, { price: string }>
+}));
+
+vi.mock("@/common/stores/prices", () => ({
+  usePricesStore: () => ({
+    get prices() {
+      return hoisted.prices;
+    }
+  })
+}));
+
+vi.mock("@/common/stores/config", () => ({
+  useConfigStore: () => ({
+    get currenciesData() {
+      return hoisted.currenciesData;
+    }
+  })
+}));
+
+vi.mock("@/common/utils", () => ({
+  LeaseMath: {
+    calculateLiquidationShort: hoisted.calculateLiquidationShort
+  }
+}));
+
+vi.mock("@/common/utils/CurrencyLookup", () => ({
+  getCurrencyByTicker: (ticker: string) => ({
+    key: `${ticker}@osmosis-1`,
+    ticker,
+    decimal_digits: ticker === "ALL_BTC" ? 8 : 6,
+    ibcData: `ibc/${ticker}`
+  }),
+  getLpnByProtocol: () => ({ key: "USDC@osmosis-1", ibcData: "ibc/LPN", decimal_digits: 6 })
+}));
+
+vi.mock("@/common/utils/NumberFormatUtils", () => ({
+  getAdaptivePriceDecimals: () => 2,
+  formatPrice: (v: string) => v
+}));
+
+vi.mock("@/common/utils/SkipRoute", () => ({
+  SkipRouter: { getRoute: hoisted.getRoute }
+}));
+
+vi.mock("@nolus/nolusjs", () => ({
+  CurrencyUtils: {
+    convertDenomToMinimalDenom: () => ({ amount: "1000000" })
+  }
+}));
+
+import { useShortLeaseDetails, type ShortLeaseDetailsProps } from "./useShortLeaseDetails";
+
+type ShortApi = ReturnType<typeof useShortLeaseDetails>;
+
+function makeLease(overrides: Record<string, unknown> = {}) {
+  return {
+    total: { ticker: "USDC_NOBLE", amount: "2000000000" },
+    borrow: { ticker: "ALL_BTC", amount: "500000000" },
+    annual_interest_rate: 0,
+    annual_interest_rate_margin: 0,
+    ...overrides
+  };
+}
+
+function setup(lease: ShortLeaseDetailsProps["lease"] = null) {
+  const state = reactive<ShortLeaseDetailsProps>({
+    lease,
+    loanCurrency: "ALL_BTC@osmosis-1",
+    downpaymenAmount: "10",
+    downpaymentCurrency: "ATOM@osmosis-1"
+  });
+  let api!: ShortApi;
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        api = useShortLeaseDetails(state);
+        return () => null;
+      }
+    })
+  );
+  return { api, wrapper, state };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hoisted.getRoute.mockResolvedValue({ usd_amount_in: "1", usd_amount_out: "1", swap_price_impact_percent: "0" });
+  hoisted.calculateLiquidationShort.mockReturnValue(new Dec("1234"));
+  hoisted.currenciesData = {
+    "ALL_BTC@osmosis-1": { key: "ALL_BTC@osmosis-1", ibcData: "ibc/BTC", decimal_digits: 8 },
+    "ATOM@osmosis-1": { key: "ATOM@osmosis-1", ibcData: "ibc/ATOM", decimal_digits: 6 },
+    "USDC_NOBLE@osmosis-1": { key: "USDC_NOBLE@osmosis-1", ibcData: "ibc/USDCN", decimal_digits: 6 }
+  };
+  hoisted.prices = {
+    "ALL_BTC@osmosis-1": { price: "100000" },
+    "ATOM@osmosis-1": { price: "10" },
+    "USDC@osmosis-1": { price: "1" }
+  };
+});
+
+describe("useShortLeaseDetails — setSwapFee 600 ms debounce", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("collapses three rapid lease changes into a single Skip fire (two legs) after 600 ms", async () => {
+    const { wrapper, state } = setup(null);
+
+    // Three distinct lease references inside the window, each re-arming the timer.
+    state.lease = makeLease({ borrow: { ticker: "ALL_BTC", amount: "1" } });
+    await nextTick();
+    state.lease = makeLease({ borrow: { ticker: "ALL_BTC", amount: "2" } });
+    await nextTick();
+    state.lease = makeLease({ borrow: { ticker: "ALL_BTC", amount: "3" } });
+    await nextTick();
+
+    expect(hoisted.getRoute, "no fire before the debounce window elapses").not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(
+      hoisted.getRoute,
+      "the collapsed fire issues exactly the two route legs, not three x two"
+    ).toHaveBeenCalledTimes(2);
+    wrapper.unmount();
+  });
+
+  it("does not fire before the 600 ms floor is reached", async () => {
+    const { wrapper, state } = setup(null);
+    state.lease = makeLease();
+    await nextTick();
+
+    await vi.advanceTimersByTimeAsync(599);
+    expect(hoisted.getRoute, "the fee call waits for the full 600 ms floor").not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(hoisted.getRoute, "the fee call fires once the floor is crossed").toHaveBeenCalledTimes(2);
+    wrapper.unmount();
+  });
+});
+
+describe("useShortLeaseDetails — Skip route legs target the stable ticker", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("routes both the down payment and the borrowed LPN into the position stable (lease.total.ticker)", async () => {
+    const { wrapper, state } = setup(null);
+    state.lease = makeLease();
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(hoisted.getRoute).toHaveBeenCalledTimes(2);
+    const downPaymentLeg = hoisted.getRoute.mock.calls[0];
+    const borrowLeg = hoisted.getRoute.mock.calls[1];
+    if (downPaymentLeg === undefined || borrowLeg === undefined) {
+      throw new Error("expected both Skip route legs to have fired");
+    }
+
+    expect(downPaymentLeg[0], "down payment leg starts from the down payment currency").toBe("ibc/ATOM");
+    expect(downPaymentLeg[1], "down payment leg settles into the stable, not itself").toBe("ibc/USDCN");
+    expect(borrowLeg[0], "borrow leg starts from the borrowed LPN").toBe("ibc/LPN");
+    expect(borrowLeg[1], "borrow leg settles into the stable, not the shorted asset").toBe("ibc/USDCN");
+    wrapper.unmount();
+  });
+});
+
+describe("useShortLeaseDetails — liquidation argument order", () => {
+  it("passes stableAsset (from total) then unitAsset (from borrow) to calculateLiquidationShort", () => {
+    const { api, wrapper } = setup(makeLease());
+
+    // Reading calculateLique drives getLquidation -> calculateLiquidationShort.
+    void api.calculateLique.value;
+
+    expect(hoisted.calculateLiquidationShort).toHaveBeenCalledTimes(1);
+    const call = hoisted.calculateLiquidationShort.mock.calls[0];
+    if (call === undefined) throw new Error("expected calculateLiquidationShort to have been called");
+    const [stableAsset, unitAsset] = call;
+    // total 2_000_000_000 at 6 dp = 2000; borrow 500_000_000 at 8 dp = 5.
+    expect(Number(stableAsset.toString()), "first arg is the stable total (2000), not the unit").toBe(2000);
+    expect(Number(unitAsset.toString()), "second arg is the borrowed unit (5), not the stable").toBe(5);
+    wrapper.unmount();
+  });
+});
+
+describe("useShortLeaseDetails — teardown on unmount", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("clears exactly one pending debounce timer when the instance unmounts", () => {
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    const { wrapper } = setup(makeLease());
+
+    const before = clearSpy.mock.calls.length;
+    wrapper.unmount();
+
+    expect(clearSpy.mock.calls.length - before, "onUnmounted clears the timer exactly once for this instance").toBe(1);
+  });
+
+  it("cancels a pending Skip fire so an unmounted instance never hits the backend", async () => {
+    const { wrapper, state } = setup(null);
+    state.lease = makeLease();
+    await nextTick(); // arms the 600 ms timer
+
+    wrapper.unmount(); // must clear it
+
+    await vi.advanceTimersByTimeAsync(600);
+    expect(hoisted.getRoute, "the cancelled timer issues no route call after unmount").not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/leases/components/single-lease/useTriggerDialog.test.ts
+++ b/src/modules/leases/components/single-lease/useTriggerDialog.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Direct unit tests for the useTriggerDialog composable — the mode/position
+ * asymmetries the mounted-SFC characterization suites (StopLossDialog.test.ts,
+ * TakeProfitDialog.test.ts) only touch tangentially. This file pins, at the
+ * composable boundary, the four mode x position comparison-sign branches of
+ * isAmountValid, the stop-loss-only error_percent guard, the mode-selected
+ * success toast, and the getPercent zero-divisor guards (both branches, which
+ * now mirror). The composable exposes amount + amountErrorMsg + the
+ * onSendClick submit path; isAmountValid runs through the amount watcher and
+ * getPercent through the submit path, so both are observed via that surface
+ * rather than reaching into internals.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as VueRouter from "vue-router";
+import type * as NolusJs from "@nolus/nolusjs";
+import { setActivePinia, createPinia } from "pinia";
+
+const hoisted = vi.hoisted(() => {
+  const broadcastTx = vi.fn();
+  const fetchBalances = vi.fn();
+  const loadActivities = vi.fn();
+  const getLease = vi.fn();
+  const getLeaseDisplayData = vi.fn();
+  const walletOperationMock = vi.fn(async (op: () => Promise<void> | void) => {
+    await op();
+  });
+  const loggerError = vi.fn();
+  const routerPush = vi.fn();
+
+  const routeRef = { params: { id: "lease-1" } };
+  const walletRef: { value: { broadcastTx: typeof broadcastTx; address: string } | null } = {
+    value: { broadcastTx, address: "nolus1abc" }
+  };
+  const configRef = {
+    currenciesData: {
+      "ATOM@osmosis-1": {
+        key: "ATOM@osmosis-1",
+        name: "Cosmos",
+        symbol: "ATOM",
+        shortName: "ATOM",
+        ticker: "ATOM",
+        icon: "",
+        decimal_digits: 6,
+        ibcData: "ibc/ATOM",
+        native: false
+      }
+    },
+    positionType: "Long" as "Long" | "Short"
+  };
+
+  return {
+    broadcastTx,
+    fetchBalances,
+    loadActivities,
+    getLease,
+    getLeaseDisplayData,
+    walletOperationMock,
+    loggerError,
+    routerPush,
+    routeRef,
+    walletRef,
+    configRef
+  };
+});
+
+vi.mock("vue-router", async () => {
+  const actual = await vi.importActual<typeof VueRouter>("vue-router");
+  return {
+    ...actual,
+    useRoute: () => hoisted.routeRef,
+    useRouter: () => ({ push: hoisted.routerPush })
+  };
+});
+
+vi.mock("@/router", () => ({ RouteNames: { LEASES: "leases" } }));
+
+vi.mock("@/common/stores/wallet", () => ({
+  useWalletStore: () => ({
+    get wallet() {
+      return hoisted.walletRef.value;
+    }
+  })
+}));
+
+vi.mock("@/common/stores/balances", () => ({
+  useBalancesStore: () => ({ fetchBalances: hoisted.fetchBalances })
+}));
+
+vi.mock("@/common/stores/config", () => ({
+  useConfigStore: () => ({
+    get currenciesData() {
+      return hoisted.configRef.currenciesData;
+    },
+    getPositionType: (_p: string) => hoisted.configRef.positionType
+  })
+}));
+
+vi.mock("@/common/stores/prices", () => ({
+  usePricesStore: () => ({ prices: {} })
+}));
+
+vi.mock("@/common/stores/history", () => ({
+  useHistoryStore: () => ({ loadActivities: hoisted.loadActivities })
+}));
+
+vi.mock("@/common/stores/leases", () => ({
+  useLeasesStore: () => ({
+    getLease: hoisted.getLease,
+    getLeaseDisplayData: hoisted.getLeaseDisplayData
+  })
+}));
+
+vi.mock("@/common/utils", () => ({
+  Logger: { error: hoisted.loggerError },
+  walletOperation: hoisted.walletOperationMock,
+  classifyError: () => "message.unexpected-error"
+}));
+
+vi.mock("@/common/utils/NumberFormatUtils", () => ({
+  formatNumber: (v: string) => v,
+  formatPriceUsd: (v: string | number) => `$${v}`
+}));
+
+vi.mock("@/common/utils/CurrencyLookup", () => ({
+  getLpnByProtocol: () => ({
+    key: "USDC@osmosis-1",
+    shortName: "USDC",
+    ibcData: "ibc/USDC",
+    decimal_digits: 6
+  }),
+  getCurrencyByTicker: () => ({ key: "USDC@osmosis-1", decimal_digits: 6, shortName: "USDC" })
+}));
+
+vi.mock("@nolus/nolusjs", async () => {
+  const actual = await vi.importActual<typeof NolusJs>("@nolus/nolusjs");
+  return {
+    ...actual,
+    NolusClient: { getInstance: () => ({ getCosmWasmClient: async () => ({}) }) }
+  };
+});
+
+vi.mock("@nolus/nolusjs/build/contracts", () => ({
+  Lease: class {
+    async simulateChangeClosePolicyTx() {
+      return { txHash: "0x1", txBytes: new Uint8Array([1]), usedFee: {} };
+    }
+  }
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k })
+}));
+
+vi.mock("web-components", () => ({
+  Dialog: {},
+  ToastType: { success: "success", error: "error" }
+}));
+
+import { mount, flushPromises } from "@vue/test-utils";
+import { defineComponent } from "vue";
+import { Dec } from "@keplr-wallet/unit";
+import { useTriggerDialog, type TriggerMode } from "./useTriggerDialog";
+
+type TriggerApi = ReturnType<typeof useTriggerDialog>;
+
+function makeLease(overrides: Record<string, unknown> = {}) {
+  return {
+    address: "nolus1lease",
+    status: "opened",
+    protocol: "osmosis-1",
+    amount: { ticker: "ATOM", amount: "1000000000" },
+    close_policy: { take_profit: 100, stop_loss: 200 },
+    etl_data: undefined,
+    ...overrides
+  };
+}
+
+function displayData(overrides: Record<string, unknown> = {}) {
+  return {
+    openingPrice: new Dec("10"),
+    totalDebt: new Dec("0"),
+    stableAsset: new Dec("1"),
+    unitAsset: new Dec("1"),
+    ...overrides
+  };
+}
+
+function setup(mode: TriggerMode, onShowToast = vi.fn()) {
+  let api!: TriggerApi;
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        api = useTriggerDialog(mode);
+        return () => null;
+      }
+    }),
+    { global: { provide: { onShowToast, reload: vi.fn() } } }
+  );
+  return { api, wrapper, onShowToast };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setActivePinia(createPinia());
+  hoisted.walletRef.value = { broadcastTx: hoisted.broadcastTx, address: "nolus1abc" };
+  hoisted.configRef.positionType = "Long";
+  hoisted.getLease.mockReturnValue(makeLease());
+  hoisted.getLeaseDisplayData.mockReturnValue(displayData());
+});
+
+describe("useTriggerDialog — isAmountValid comparison-sign branches (mode x position)", () => {
+  it("stop-loss / Long rejects an amount above the opening price with the max-amount error", async () => {
+    hoisted.configRef.positionType = "Long";
+    hoisted.getLeaseDisplayData.mockReturnValue(displayData({ openingPrice: new Dec("10") }));
+    const { api, wrapper } = setup("stop-loss");
+    await wrapper.vm.$nextTick();
+
+    api.amount.value = "50"; // 50 > opening price 10, percent 1/50 well under the guard
+    await flushPromises();
+
+    expect(api.amountErrorMsg.value, "stop-loss Long flags amount above opening price").toBe(
+      "message.lease-only-max-error"
+    );
+    wrapper.unmount();
+  });
+
+  it("stop-loss / Short rejects an amount below the opening price with the min-amount error", async () => {
+    hoisted.configRef.positionType = "Short";
+    hoisted.getLeaseDisplayData.mockReturnValue(displayData({ openingPrice: new Dec("10") }));
+    const { api, wrapper } = setup("stop-loss");
+    await wrapper.vm.$nextTick();
+
+    api.amount.value = "0.1"; // opening price 10 > 0.1, percent 0.1 under the guard
+    await flushPromises();
+
+    expect(api.amountErrorMsg.value, "stop-loss Short flags amount below opening price").toBe(
+      "message.take-profit-min-amount-error"
+    );
+    wrapper.unmount();
+  });
+
+  it("take-profit / Long rejects an amount at or below the opening price with the min-amount error", async () => {
+    hoisted.configRef.positionType = "Long";
+    hoisted.getLeaseDisplayData.mockReturnValue(displayData({ openingPrice: new Dec("10") }));
+    const { api, wrapper } = setup("take-profit");
+    await wrapper.vm.$nextTick();
+
+    api.amount.value = "5"; // 5 <= opening price 10
+    await flushPromises();
+
+    expect(api.amountErrorMsg.value, "take-profit Long flags amount not above opening price").toBe(
+      "message.take-profit-min-amount-error"
+    );
+    wrapper.unmount();
+  });
+
+  it("take-profit / Short rejects an amount above the opening price with the max-amount error", async () => {
+    hoisted.configRef.positionType = "Short";
+    hoisted.getLeaseDisplayData.mockReturnValue(displayData({ openingPrice: new Dec("10") }));
+    const { api, wrapper } = setup("take-profit");
+    await wrapper.vm.$nextTick();
+
+    api.amount.value = "50"; // 50 > opening price 10
+    await flushPromises();
+
+    expect(api.amountErrorMsg.value, "take-profit Short flags amount above opening price").toBe(
+      "message.lease-only-max-error"
+    );
+    wrapper.unmount();
+  });
+
+  it("clears the error for a valid stop-loss / Long amount within the opening price", async () => {
+    hoisted.configRef.positionType = "Long";
+    hoisted.getLeaseDisplayData.mockReturnValue(displayData({ openingPrice: new Dec("100") }));
+    const { api, wrapper } = setup("stop-loss");
+    await wrapper.vm.$nextTick();
+
+    api.amount.value = "50"; // 50 <= 100, percent 1/50 under the guard
+    await flushPromises();
+
+    expect(api.amountErrorMsg.value, "a valid stop-loss amount leaves no error").toBe("");
+    wrapper.unmount();
+  });
+});
+
+describe("useTriggerDialog — error_percent guard is stop-loss only", () => {
+  it("stop-loss flags a position that exceeds the liquidation percent with the stop-loss error", async () => {
+    hoisted.configRef.positionType = "Long";
+    // stableAsset 100 / (amount 1 * unitAsset 1) = 100 >= error_percent 0.9
+    hoisted.getLeaseDisplayData.mockReturnValue(
+      displayData({ openingPrice: new Dec("100"), stableAsset: new Dec("100"), unitAsset: new Dec("1") })
+    );
+    const { api, wrapper } = setup("stop-loss");
+    await wrapper.vm.$nextTick();
+
+    api.amount.value = "1";
+    await flushPromises();
+
+    expect(api.amountErrorMsg.value, "stop-loss enforces the error_percent liquidation guard").toBe(
+      "message.stop-loss-error"
+    );
+    wrapper.unmount();
+  });
+
+  it("take-profit does not apply the stop-loss error_percent guard for the same position shape", async () => {
+    hoisted.configRef.positionType = "Long";
+    hoisted.getLeaseDisplayData.mockReturnValue(
+      displayData({ openingPrice: new Dec("100"), stableAsset: new Dec("100"), unitAsset: new Dec("1") })
+    );
+    const { api, wrapper } = setup("take-profit");
+    await wrapper.vm.$nextTick();
+
+    api.amount.value = "1"; // 1 <= opening price 100 -> take-profit min-amount branch, never stop-loss-error
+    await flushPromises();
+
+    expect(api.amountErrorMsg.value, "take-profit never emits the stop-loss error").toBe(
+      "message.take-profit-min-amount-error"
+    );
+    wrapper.unmount();
+  });
+});
+
+describe("useTriggerDialog — mode-selected success toast", () => {
+  it("emits the stop-loss toast on a completed stop-loss submit", async () => {
+    hoisted.configRef.positionType = "Long";
+    hoisted.getLeaseDisplayData.mockReturnValue(displayData({ openingPrice: new Dec("100") }));
+    const { api, wrapper, onShowToast } = setup("stop-loss");
+    await wrapper.vm.$nextTick();
+    api.amount.value = "50"; // valid: 50 <= 100, percent under guard
+    await flushPromises();
+
+    await api.onSendClick();
+    await flushPromises();
+
+    expect(hoisted.loggerError, "a clean stop-loss submit logs no error").not.toHaveBeenCalled();
+    expect(onShowToast, "stop-loss submit surfaces the stop-loss toast key").toHaveBeenCalledWith(
+      expect.objectContaining({ message: "message.stop-loss-toast" })
+    );
+    wrapper.unmount();
+  });
+
+  it("emits the take-profit toast on a completed take-profit submit", async () => {
+    hoisted.configRef.positionType = "Long";
+    hoisted.getLeaseDisplayData.mockReturnValue(displayData({ openingPrice: new Dec("1") }));
+    const { api, wrapper, onShowToast } = setup("take-profit");
+    await wrapper.vm.$nextTick();
+    api.amount.value = "50"; // valid take-profit Long: 50 > opening price 1
+    await flushPromises();
+
+    await api.onSendClick();
+    await flushPromises();
+
+    expect(hoisted.loggerError, "a clean take-profit submit logs no error").not.toHaveBeenCalled();
+    expect(onShowToast, "take-profit submit surfaces the take-profit toast key").toHaveBeenCalledWith(
+      expect.objectContaining({ message: "message.take-profit-toast" })
+    );
+    wrapper.unmount();
+  });
+});
+
+describe("useTriggerDialog — getPercent zero-divisor guards (both branches mirror)", () => {
+  it("stop-loss / Long tolerates a zero unit asset in isAmountValid without throwing", async () => {
+    hoisted.configRef.positionType = "Long";
+    hoisted.getLeaseDisplayData.mockReturnValue(
+      displayData({ openingPrice: new Dec("100"), stableAsset: new Dec("1"), unitAsset: new Dec("0") })
+    );
+    const { api, wrapper } = setup("stop-loss");
+    await wrapper.vm.$nextTick();
+
+    api.amount.value = "50"; // amount*unitAsset = 0 -> guard yields 0, no divide-by-zero
+    await flushPromises();
+
+    expect(api.amountErrorMsg.value, "zero unit asset skips the percent guard, reaches sign check").toBe("");
+    wrapper.unmount();
+  });
+
+  it("stop-loss / Short tolerates a zero unit asset in isAmountValid without throwing", async () => {
+    hoisted.configRef.positionType = "Short";
+    hoisted.getLeaseDisplayData.mockReturnValue(
+      displayData({ openingPrice: new Dec("1"), stableAsset: new Dec("1"), unitAsset: new Dec("0") })
+    );
+    const { api, wrapper } = setup("stop-loss");
+    await wrapper.vm.$nextTick();
+
+    api.amount.value = "50"; // unitAsset zero -> guard yields 0, no divide-by-zero
+    await flushPromises();
+
+    // opening price 1 not > 50, so the short sign check passes; guard must not have thrown
+    expect(api.amountErrorMsg.value, "zero unit asset does not throw on the short path").toBe("");
+    wrapper.unmount();
+  });
+
+  it("take-profit / Long submits without throwing when the unit asset is zero (getPercent guard)", async () => {
+    hoisted.configRef.positionType = "Long";
+    hoisted.getLeaseDisplayData.mockReturnValue(
+      displayData({ openingPrice: new Dec("1"), stableAsset: new Dec("1"), unitAsset: new Dec("0") })
+    );
+    const { api, wrapper, onShowToast } = setup("take-profit");
+    await wrapper.vm.$nextTick();
+    api.amount.value = "50"; // valid take-profit Long
+    await flushPromises();
+
+    await api.onSendClick();
+    await flushPromises();
+
+    expect(hoisted.loggerError, "zero unit asset does not surface as a swallowed error").not.toHaveBeenCalled();
+    expect(onShowToast, "the submit still completes and toasts").toHaveBeenCalledWith(
+      expect.objectContaining({ message: "message.take-profit-toast" })
+    );
+    wrapper.unmount();
+  });
+
+  it("take-profit / Short submits without throwing when the unit asset is zero (getPercent guard)", async () => {
+    hoisted.configRef.positionType = "Short";
+    hoisted.getLeaseDisplayData.mockReturnValue(
+      displayData({ openingPrice: new Dec("100"), stableAsset: new Dec("1"), unitAsset: new Dec("0") })
+    );
+    const { api, wrapper, onShowToast } = setup("take-profit");
+    await wrapper.vm.$nextTick();
+    api.amount.value = "50"; // valid take-profit Short: 50 <= opening price 100
+    await flushPromises();
+
+    await api.onSendClick();
+    await flushPromises();
+
+    expect(hoisted.loggerError, "zero unit asset does not surface as a swallowed error").not.toHaveBeenCalled();
+    expect(onShowToast, "the submit still completes and toasts").toHaveBeenCalledWith(
+      expect.objectContaining({ message: "message.take-profit-toast" })
+    );
+    wrapper.unmount();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -281,19 +281,33 @@ export default mergeConfig(
           },
           // Extracted lease composables with dedicated direct unit tests.
           // Floors sit just below current actuals; untested computeds
-          // (payout branches, the short quote-derivation getters) are
-          // intentionally out of scope for these logic-pinning suites.
+          // (payout branches, the per-position quote-derivation getters) are
+          // intentionally out of scope for these logic-pinning suites. The
+          // debounce/route/teardown machinery attributes to the shared core;
+          // the per-position files keep the strategy residue + getters.
           "src/modules/leases/components/single-lease/useTriggerDialog.ts": {
             lines: 85,
             branches: 65,
             functions: 90,
             statements: 85
           },
-          "src/modules/leases/components/new-lease/useShortLeaseDetails.ts": {
-            lines: 55,
+          "src/modules/leases/components/new-lease/useLeaseDetailsCore.ts": {
+            lines: 75,
             branches: 45,
             functions: 95,
+            statements: 75
+          },
+          "src/modules/leases/components/new-lease/useLongLeaseDetails.ts": {
+            lines: 55,
+            branches: 70,
+            functions: 95,
             statements: 55
+          },
+          "src/modules/leases/components/new-lease/useShortLeaseDetails.ts": {
+            lines: 35,
+            branches: 55,
+            functions: 95,
+            statements: 35
           },
           "src/router/index.ts": {
             lines: 75,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -279,6 +279,22 @@ export default mergeConfig(
             functions: 50,
             statements: 65
           },
+          // Extracted lease composables with dedicated direct unit tests.
+          // Floors sit just below current actuals; untested computeds
+          // (payout branches, the short quote-derivation getters) are
+          // intentionally out of scope for these logic-pinning suites.
+          "src/modules/leases/components/single-lease/useTriggerDialog.ts": {
+            lines: 85,
+            branches: 65,
+            functions: 90,
+            statements: 85
+          },
+          "src/modules/leases/components/new-lease/useShortLeaseDetails.ts": {
+            lines: 55,
+            branches: 45,
+            functions: 95,
+            statements: 55
+          },
           "src/router/index.ts": {
             lines: 75,
             branches: 70,


### PR DESCRIPTION
## Summary

Add direct unit tests for the composables extracted during the #185 series — 28 tests pinning the load-bearing contracts that were previously exercised only through mounted SFCs. Test-only diff (3 new suites + coverage-floor config). Closes #262.

## Changes

- `useTriggerDialog.test.ts` (13): all four mode×position comparison-sign branches of the amount validation, the stop-loss-only `error_percent` guard, mode-selected toasts (including the #266 fix), and the zero-divisor guards on all four `getPercent` branches — driven through the public surface (watcher + submit path), no internals exposed.
- `useShortLeaseDetails.test.ts` (6): the 600 ms debounce floor proven at the 599-vs-600 boundary with fake timers, rapid changes collapsing to a single two-leg fire, both Skip legs targeting the position stable, `calculateLiquidationShort(stable, unit)` argument order pinned with distinguishable values (a swap fails), exactly-one teardown, unmount cancels a pending fire.
- `useLongLeaseDetails.test.ts` (9): the mirror — legs to the leased asset (not the stable), `calculateLiquidation(unit, stable)` inverted order, negative percent sign + unsigned zero short-circuit, and per-instance timer independence across two mounted instances.
- `vitest.config.ts`: four net-new per-file coverage floors (useTriggerDialog 85/65/90/85, useLeaseDetailsCore 75/45/95/75, useLongLeaseDetails 55/70/95/55, useShortLeaseDetails 35/55/95/35). No pre-existing floor lowered.

## Verification

- The Short suite was written against the pre-#267 implementation and passed **byte-unchanged** after rebasing onto the unified core+strategy shape — a genuine refactor-stability proof for the extraction.
- Ran the full gate: typecheck, lint, style guard, format check, 1026 tests / 65 files with all floors enforced (verified failing before the floor blocks were tuned, passing after), build — all clean.
- Independent code, security, and conventions reviews passed; one conventions finding (72-char commit subject) reworded before push. Two LOW test-hygiene nits recorded for a future touch-up: the `clearTimeout` spy isn't explicitly restored (harmless — fake timers reset per test), and one teardown test's name slightly overstates what it proves (the sibling pending-fire test covers the stronger claim).