### PR TITLE
fix: stop /vote 502s from gov vote lookups and surface 5xx errors

### DIFF
--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -1266,7 +1266,7 @@
           "governance"
         ],
         "summary": "List governance proposals",
-        "description": "Returns governance proposals in reverse-chronological order from the\nbackground-refreshed cache. The response carries `Cache-Status: warm`\n(with a `Cache-Age` value in seconds) once the refresh task has populated\nthe cache, or `Cache-Status: cold` with an empty list before the first\nrefresh completes — never 503 — so the frontend's `Promise.allSettled`\nflow can render an empty state without a coordinated rollout.\n\nHidden proposals from the gated UI config are filtered at request time\nagainst the latest config; cached tallies are attached for voting-period\nproposals. The fresh tally for a single proposal is available on the\nper-id `/proposals/{id}/tally` endpoint, which still queries the chain\ndirectly. `?voter=` triggers a live `get_proposal_vote` fan-out across\nvoting-period proposals only — a chain failure on any of those calls\nsurfaces as 502.",
+        "description": "Returns governance proposals in reverse-chronological order from the\nbackground-refreshed cache. The response carries `Cache-Status: warm`\n(with a `Cache-Age` value in seconds) once the refresh task has populated\nthe cache, or `Cache-Status: cold` with an empty list before the first\nrefresh completes — never 503 — so the frontend's `Promise.allSettled`\nflow can render an empty state without a coordinated rollout.\n\nHidden proposals from the gated UI config are filtered at request time\nagainst the latest config; cached tallies are attached for voting-period\nproposals. The fresh tally for a single proposal is available on the\nper-id `/proposals/{id}/tally` endpoint, which still queries the chain\ndirectly. `?voter=` triggers a live `get_proposal_vote` fan-out across\nvoting-period proposals only — a failed lookup is logged and degrades\nthat proposal to `voted: false` (\"hasn't voted\") instead of failing the\nrequest.",
         "operationId": "get_proposals",
         "parameters": [
           {
@@ -1317,16 +1317,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProposalsListResponse"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Upstream chain RPC error on live `?voter=` fan-out",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/backend/src/external/chain.rs
+++ b/backend/src/external/chain.rs
@@ -38,6 +38,49 @@ const RETRYABLE_STATUS_CODES: [u16; 2] = [429, 503];
 /// Milliseconds per second, for `Retry-After` (seconds) → millisecond conversion.
 const MS_PER_SEC: u64 = 1000;
 
+/// gRPC-gateway status code the Cosmos LCD returns for a missing gov vote —
+/// the generic `InvalidArgument`, which it also returns for malformed input,
+/// so the code alone cannot classify a "hasn't voted" response.
+const GRPC_CODE_INVALID_ARGUMENT: i32 = 3;
+
+/// Substring the Cosmos gov module places in the 400 body when a voter has no
+/// vote on a proposal. Paired with `GRPC_CODE_INVALID_ARGUMENT` it marks a
+/// "hasn't voted" response, distinct from e.g. a malformed bech32 address.
+const VOTE_NOT_FOUND_MARKER: &str = "not found for proposal";
+
+/// Maximum characters of an upstream error body embedded in a `ChainRpc`
+/// message. The body can echo request input (e.g. an attacker-supplied voter
+/// address), so an unbounded body would flow uncapped into the client error
+/// envelope and server logs.
+const ERROR_BODY_MAX_CHARS: usize = 256;
+
+/// Cap `body` at `ERROR_BODY_MAX_CHARS` characters for embedding in an error
+/// message, cutting on a char boundary. Classification (`is_vote_not_found`)
+/// must run on the full body before truncation.
+fn truncate_error_body(body: &str) -> &str {
+    body.char_indices()
+        .nth(ERROR_BODY_MAX_CHARS)
+        .map_or(body, |(boundary, _char)| &body[..boundary])
+}
+
+/// Classify a Cosmos LCD 400 body: `true` only for the gov "voter not found
+/// for proposal" signal (gRPC-gateway code 3 **and** the marker substring).
+/// Any other code-3 rejection (e.g. a malformed bech32 address) returns
+/// `false` so it keeps the caller's error path.
+fn is_vote_not_found(body: &str) -> bool {
+    #[derive(Deserialize)]
+    struct GrpcGatewayError {
+        code: i32,
+        message: String,
+    }
+
+    serde_json::from_str::<GrpcGatewayError>(body)
+        .map(|err| {
+            err.code == GRPC_CODE_INVALID_ARGUMENT && err.message.contains(VOTE_NOT_FOUND_MARKER)
+        })
+        .unwrap_or(false)
+}
+
 /// Simple jitter using system time nanoseconds (no rand crate needed).
 fn rand_jitter(max: u64) -> u64 {
     if max == 0 {
@@ -609,9 +652,17 @@ impl ChainClient {
         }
 
         if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            // A missing vote comes back as 400 (not 404) with a gRPC-gateway
+            // "voter not found for proposal" envelope — treat it as "hasn't
+            // voted", like the 404 path above. Every other 400 stays an error.
+            if status == reqwest::StatusCode::BAD_REQUEST && is_vote_not_found(&body) {
+                return Ok(None);
+            }
             return Err(AppError::ChainRpc {
                 chain: "nolus".to_string(),
-                message: format!("HTTP {}", response.status()),
+                message: format!("HTTP {}: {}", status, truncate_error_body(&body)),
             });
         }
 
@@ -1593,5 +1644,107 @@ mod tests {
         let rewards = result.unwrap();
         assert_eq!(rewards.rewards.len(), 1);
         assert_eq!(rewards.total.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn get_proposal_vote_returns_none_when_voter_has_not_voted() {
+        // The Cosmos LCD answers a missing vote with HTTP 400 and a
+        // gRPC-gateway envelope (code 3, "not found for proposal"), NOT 404.
+        // That must map to Ok(None) — "hasn't voted" — not a 502-triggering
+        // ChainRpc error.
+        let mock_server = setup_mock_server().await;
+        let client = create_test_client(&mock_server.uri());
+
+        let body = serde_json::json!({
+            "code": 3,
+            "message": "voter: nolus1abc not found for proposal: 42",
+            "details": []
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/cosmos/gov/v1/proposals/42/votes/nolus1abc"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(&body))
+            .mount(&mock_server)
+            .await;
+
+        let result = client.get_proposal_vote("42", "nolus1abc").await;
+        assert!(
+            matches!(result, Ok(None)),
+            "missing vote (400 code 3) must map to Ok(None), got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_proposal_vote_errors_on_other_400_such_as_malformed_address() {
+        // A malformed bech32 address is also gRPC code 3 but a different
+        // message. It must stay on the error path, not be swallowed as
+        // "hasn't voted".
+        let mock_server = setup_mock_server().await;
+        let client = create_test_client(&mock_server.uri());
+
+        let body = serde_json::json!({
+            "code": 3,
+            "message": "decoding bech32 failed: invalid checksum",
+            "details": []
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/cosmos/gov/v1/proposals/42/votes/badaddr"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(&body))
+            .mount(&mock_server)
+            .await;
+
+        let result = client.get_proposal_vote("42", "badaddr").await;
+        assert!(
+            result.is_err(),
+            "a non-vote-not-found 400 must remain an error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn truncate_error_body_passes_short_bodies_through_unchanged() {
+        let body = "short error body";
+        assert_eq!(truncate_error_body(body), body);
+    }
+
+    #[test]
+    fn truncate_error_body_caps_length_on_char_boundary() {
+        // Multibyte input: a byte-index cut would split a char and panic the
+        // slice; the cap must count chars and land on a boundary.
+        let body = "é".repeat(ERROR_BODY_MAX_CHARS + 10);
+        let truncated = truncate_error_body(&body);
+        assert_eq!(
+            truncated.chars().count(),
+            ERROR_BODY_MAX_CHARS,
+            "truncated body must carry exactly the cap in chars"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_proposal_vote_bounds_oversized_error_body_in_message() {
+        // An upstream 400 with a huge body (which can echo attacker-supplied
+        // input) must not flow unbounded into the error message.
+        let mock_server = setup_mock_server().await;
+        let client = create_test_client(&mock_server.uri());
+
+        let oversized_body = "x".repeat(ERROR_BODY_MAX_CHARS * 4);
+        Mock::given(method("GET"))
+            .and(path("/cosmos/gov/v1/proposals/42/votes/nolus1abc"))
+            .respond_with(ResponseTemplate::new(400).set_body_string(oversized_body))
+            .mount(&mock_server)
+            .await;
+
+        let result = client.get_proposal_vote("42", "nolus1abc").await;
+        match result {
+            Err(AppError::ChainRpc { message, .. }) => {
+                let prefix_overhead = 64;
+                assert!(
+                    message.chars().count() <= ERROR_BODY_MAX_CHARS + prefix_overhead,
+                    "error message must embed at most the truncated body, got {} chars",
+                    message.chars().count()
+                );
+            }
+            other => panic!("expected ChainRpc error for oversized 400 body, got {other:?}"),
+        }
     }
 }

--- a/backend/src/handlers/governance.rs
+++ b/backend/src/handlers/governance.rs
@@ -9,9 +9,9 @@ use axum::{
     http::{HeaderMap, HeaderValue},
     Json,
 };
-use futures::future::try_join_all;
+use futures::future;
 use serde::{Deserialize, Serialize};
-use tracing::debug;
+use tracing::{debug, warn};
 use utoipa::{IntoParams, ToSchema};
 
 use crate::{error::AppError, external::chain, AppState};
@@ -117,8 +117,9 @@ pub struct PaginationInfo {
 /// proposals. The fresh tally for a single proposal is available on the
 /// per-id `/proposals/{id}/tally` endpoint, which still queries the chain
 /// directly. `?voter=` triggers a live `get_proposal_vote` fan-out across
-/// voting-period proposals only — a chain failure on any of those calls
-/// surfaces as 502.
+/// voting-period proposals only — a failed lookup is logged and degrades
+/// that proposal to `voted: false` ("hasn't voted") instead of failing the
+/// request.
 #[utoipa::path(
     get,
     path = "/api/governance/proposals",
@@ -134,7 +135,6 @@ pub struct PaginationInfo {
                 ("Cache-Age" = String, description = "Age in seconds of the cached snapshot. Present on `warm` responses, omitted on `cold`."),
             ),
         ),
-        (status = 502, description = "Upstream chain RPC error on live `?voter=` fan-out", body = crate::error::ErrorResponse),
     ),
 )]
 pub async fn get_proposals(
@@ -184,9 +184,9 @@ pub async fn get_proposals(
     let page: Vec<chain::Proposal> = visible.into_iter().take(limit).collect();
 
     // Live `?voter=` fan-out — only voting-period proposals trigger a vote
-    // call. A single chain error fails the whole request with 502; the
-    // 502 response shape is exactly what the frontend already handles for
-    // this endpoint.
+    // call. Lookups run concurrently and are tolerant: one failing lookup
+    // must not fail the whole list, so a per-proposal error degrades to the
+    // same "hasn't voted" shape (voted=false) rather than propagating.
     let voted_map: std::collections::HashMap<String, bool> =
         if let Some(voter) = query.voter.as_deref().filter(|v| !v.is_empty()) {
             let voting_ids: Vec<String> = page
@@ -200,15 +200,29 @@ pub async fn get_proposals(
                 let chain_client = chain_client.clone();
                 let voter = voter.clone();
                 async move {
-                    let res = chain_client.get_proposal_vote(&id, &voter).await?;
-                    let voted = match res {
-                        Some(vote_response) => !vote_response.vote.options.is_empty(),
-                        None => false,
-                    };
-                    Ok::<_, AppError>((id, voted))
+                    let outcome = chain_client.get_proposal_vote(&id, &voter).await;
+                    (id, outcome)
                 }
             });
-            try_join_all(futs).await?.into_iter().collect()
+            future::join_all(futs)
+                .await
+                .into_iter()
+                .map(|(id, outcome)| {
+                    let voted = match outcome {
+                        Ok(Some(vote_response)) => !vote_response.vote.options.is_empty(),
+                        Ok(None) => false,
+                        Err(error) => {
+                            warn!(
+                                proposal_id = %id,
+                                error = %error,
+                                "governance vote lookup failed; treating proposal as not voted"
+                            );
+                            false
+                        }
+                    };
+                    (id, voted)
+                })
+                .collect()
         } else {
             std::collections::HashMap::new()
         };
@@ -973,22 +987,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn governance_proposals_with_voter_upstream_failure_on_vote_returns_502() {
-        // Renamed from `governance_proposals_upstream_failure_returns_502`.
-        // After the cache refactor, the list endpoint without `?voter` no
-        // longer touches the chain — so a chain failure can only surface
-        // when fanning out vote calls. Populate the cache, mock vote 500,
-        // expect 502.
+    async fn governance_proposals_tolerates_vote_lookup_failure_and_degrades_to_not_voted() {
+        // A per-proposal vote lookup failure must NOT 502 the whole list: the
+        // failing proposal degrades to the "hasn't voted" shape (voted=false)
+        // while a sibling proposal whose lookup succeeds still reports its real
+        // vote. The response stays 200.
         let mock = MockServer::start().await;
         let state = state_with_chain_url(&mock.uri()).await;
         populate_proposals_cache(
             &state,
-            vec![sample_proposal("1", "PROPOSAL_STATUS_VOTING_PERIOD")],
+            vec![
+                sample_proposal("1", "PROPOSAL_STATUS_VOTING_PERIOD"),
+                sample_proposal("2", "PROPOSAL_STATUS_VOTING_PERIOD"),
+            ],
         );
 
+        // Proposal 1 vote lookup fails hard (500).
         Mock::given(wm_method("GET"))
             .and(wm_path("/cosmos/gov/v1/proposals/1/votes/nolus1xxxx"))
             .respond_with(ResponseTemplate::new(500).set_body_string("vote rpc unavailable"))
+            .mount(&mock)
+            .await;
+        // Proposal 2 vote lookup succeeds with a YES vote.
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/cosmos/gov/v1/proposals/2/votes/nolus1xxxx"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "vote": {
+                    "proposal_id": "2",
+                    "voter": "nolus1xxxx",
+                    "options": [{ "option": "VOTE_OPTION_YES", "weight": "1.0" }]
+                }
+            })))
             .mount(&mock)
             .await;
 
@@ -1002,6 +1031,30 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = collect_body_str(resp).await;
+        let json: serde_json::Value =
+            serde_json::from_str(&body).expect("response body parses as JSON");
+        let proposals = json["proposals"]
+            .as_array()
+            .expect("response carries a proposals array");
+        let voted_of = |id: &str| {
+            proposals
+                .iter()
+                .find(|p| p["id"] == id)
+                .unwrap_or_else(|| panic!("proposal {id} present in response, body: {body}"))
+                ["voted"]
+                .clone()
+        };
+        assert_eq!(
+            voted_of("1"),
+            serde_json::json!(false),
+            "failed lookup must degrade proposal 1 to voted=false, body: {body}"
+        );
+        assert_eq!(
+            voted_of("2"),
+            serde_json::json!(true),
+            "successful lookup must report proposal 2 as voted=true, body: {body}"
+        );
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use axum::{
+    extract::ConnectInfo,
     middleware as axum_middleware,
     routing::{delete, get, post},
     Router,
@@ -231,9 +232,12 @@ async fn main() -> anyhow::Result<()> {
     // Start server
     info!("Starting server on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal(sigterm))
-        .await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal(sigterm))
+    .await?;
     info!("Server shut down gracefully");
 
     Ok(())
@@ -286,6 +290,14 @@ fn build_cors_layer(server: &ServerConfig) -> CorsLayer {
                 .allow_headers(Any)
         }
     }
+}
+
+/// Pull the peer `ConnectInfo` that `into_make_service_with_connect_info`
+/// stores in the request extensions. Lets the rate limiter key a request with
+/// no forwarding headers on the connection's socket address instead of
+/// collapsing every header-less caller into one shared bucket.
+fn connect_info_of<B>(req: &axum::http::Request<B>) -> Option<ConnectInfo<SocketAddr>> {
+    req.extensions().get::<ConnectInfo<SocketAddr>>().copied()
 }
 
 fn create_router(state: Arc<AppState>) -> Router {
@@ -519,7 +531,8 @@ fn create_router(state: Arc<AppState>) -> Router {
         )
         .layer(axum_middleware::from_fn(move |req, next| {
             let state = standard_rate_limit.clone();
-            async move { rate_limit_middleware(state, None, req, next).await }
+            let connect_info = connect_info_of(&req);
+            async move { rate_limit_middleware(state, connect_info, req, next).await }
         }));
 
     // Write API routes (strict rate limit)
@@ -564,7 +577,8 @@ fn create_router(state: Arc<AppState>) -> Router {
         .route("/intercom/hash", post(handlers::admin::intercom_hash))
         .layer(axum_middleware::from_fn(move |req, next| {
             let state = strict_rate_limit.clone();
-            async move { rate_limit_middleware(state, None, req, next).await }
+            let connect_info = connect_info_of(&req);
+            async move { rate_limit_middleware(state, connect_info, req, next).await }
         }));
 
     // Admin routes (protected with authentication middleware)

--- a/backend/src/middleware/rate_limit.rs
+++ b/backend/src/middleware/rate_limit.rs
@@ -605,9 +605,10 @@ mod tests {
     /// limiting is a blunt control applied uniformly to all connections. Nginx +
     /// authentication + CORS are the real security boundaries.
     ///
-    /// If you're considering changing this to fail-closed without headers, first
-    /// wire ConnectInfo through the router at main.rs::create_router (currently
-    /// hardcoded `None`), otherwise you'll reject all requests.
+    /// ConnectInfo is wired through main.rs (`into_make_service_with_connect_info`
+    /// plus the rate-limit closures in `create_router`), so a request with no
+    /// forwarding headers keys its bucket on the connection's peer address via
+    /// the fallback below instead of being rejected.
     #[test]
     fn extract_client_ip_trusts_xff_unconditionally_intentional() {
         // An attacker-controlled XFF value is returned verbatim. That's fine
@@ -644,6 +645,27 @@ mod tests {
             .header("x-forwarded-for", ip)
             .body(Body::empty())
             .expect("request builder cannot fail with valid header")
+    }
+
+    /// Router whose rate-limit layer receives a fixed peer `ConnectInfo`,
+    /// mirroring what `into_make_service_with_connect_info` supplies in
+    /// production. Lets header-less requests exercise the peer-addr fallback.
+    fn handler_router_with_peer(state: Arc<RateLimitState>, peer: SocketAddr) -> Router {
+        Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(axum_middleware::from_fn(move |req, next| {
+                let state = state.clone();
+                async move {
+                    rate_limit_middleware(state, Some(ConnectInfo(peer)), req, next).await
+                }
+            }))
+    }
+
+    fn headerless_request() -> axum::http::Request<Body> {
+        axum::http::Request::builder()
+            .uri("/")
+            .body(Body::empty())
+            .expect("request builder cannot fail")
     }
 
     #[tokio::test]
@@ -736,6 +758,112 @@ mod tests {
                 resp.status(),
                 StatusCode::OK,
                 "whitelisted request {i} must pass"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn rate_limit_middleware_falls_back_to_peer_addr_when_no_headers() {
+        // With no XFF / X-Real-IP header, the middleware must key the bucket on
+        // the connection's peer address and allow the request, not blanket
+        // reject it with 429. A second header-less request from the same peer
+        // exhausts the burst, proving the peer addr is the bucket key.
+        let state = create_rate_limit_state(RateLimitConfig {
+            requests_per_second: 1,
+            burst_size: 1,
+            enabled: true,
+            whitelist: vec![],
+        });
+        let peer: SocketAddr = "203.0.113.9:54321"
+            .parse()
+            .expect("hard-coded peer socket addr parses");
+        let app = handler_router_with_peer(state, peer);
+
+        let r1 = app
+            .clone()
+            .oneshot(headerless_request())
+            .await
+            .expect("first header-less request completes");
+        assert_eq!(
+            r1.status(),
+            StatusCode::OK,
+            "header-less request must be allowed via peer-addr fallback"
+        );
+
+        let r2 = app
+            .oneshot(headerless_request())
+            .await
+            .expect("second header-less request completes");
+        assert_eq!(
+            r2.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "second header-less request from same peer must be limited"
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_limit_middleware_peer_addr_fallback_is_per_peer() {
+        // Two different peers, both header-less: each gets its own bucket.
+        // Exhausting peer A must not affect peer B.
+        let state = create_rate_limit_state(RateLimitConfig {
+            requests_per_second: 1,
+            burst_size: 1,
+            enabled: true,
+            whitelist: vec![],
+        });
+        let peer_a: SocketAddr = "203.0.113.9:1111".parse().expect("peer a parses");
+        let peer_b: SocketAddr = "198.51.100.7:2222".parse().expect("peer b parses");
+
+        let app_a = handler_router_with_peer(state.clone(), peer_a);
+        let app_b = handler_router_with_peer(state, peer_b);
+
+        let a1 = app_a
+            .clone()
+            .oneshot(headerless_request())
+            .await
+            .expect("peer A first request completes");
+        assert_eq!(a1.status(), StatusCode::OK);
+        let a2 = app_a
+            .oneshot(headerless_request())
+            .await
+            .expect("peer A second request completes");
+        assert_eq!(a2.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        let b1 = app_b
+            .oneshot(headerless_request())
+            .await
+            .expect("peer B request completes");
+        assert_eq!(
+            b1.status(),
+            StatusCode::OK,
+            "peer B must be unaffected by peer A's exhausted bucket"
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_limit_middleware_whitelisted_peer_addr_bypasses_limit_without_headers() {
+        // Whitelist preservation: a peer whose IP is whitelisted bypasses the
+        // limit even with no forwarding headers — the whitelist applies to the
+        // peer-addr fallback key too.
+        let peer: SocketAddr = "203.0.113.9:33333".parse().expect("peer parses");
+        let state = create_rate_limit_state(RateLimitConfig {
+            requests_per_second: 1,
+            burst_size: 1,
+            enabled: true,
+            whitelist: vec![peer.ip()],
+        });
+        let app = handler_router_with_peer(state, peer);
+
+        for i in 0..5 {
+            let resp = app
+                .clone()
+                .oneshot(headerless_request())
+                .await
+                .expect("whitelisted peer request completes");
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "whitelisted peer request {i} must pass"
             );
         }
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,6 +36,13 @@ BackendApi.onRateLimited = () => {
   });
 };
 
+BackendApi.onServerError = () => {
+  onShowToast({
+    type: ToastType.error,
+    message: i18n.t("message.unexpected-error")
+  });
+};
+
 onMounted(() => {
   void initWorker();
   const language = getCookie(LANGUAGE_KEY);

--- a/src/common/api/BackendApi.test.ts
+++ b/src/common/api/BackendApi.test.ts
@@ -222,6 +222,67 @@ describe("BackendApi", () => {
     });
   });
 
+  describe("doFetch - 5xx server errors", () => {
+    it("should invoke onServerError once for a burst of 5xx responses (throttled)", async () => {
+      vi.useFakeTimers();
+      const api = new BackendApiClient();
+      const cb = vi.fn();
+      api.onServerError = cb;
+
+      fetchMock.mockResolvedValueOnce(jsonResponse({ error: { code: "bad_gateway", message: "502" } }, 502));
+      await expect(api.getEarnStats()).rejects.toBeInstanceOf(ApiError);
+      fetchMock.mockResolvedValueOnce(jsonResponse({ error: { code: "bad_gateway", message: "502" } }, 502));
+      await expect(api.getEarnStats()).rejects.toBeInstanceOf(ApiError);
+      fetchMock.mockResolvedValueOnce(jsonResponse({ error: { code: "service_unavailable", message: "503" } }, 503));
+      await expect(api.getEarnStats()).rejects.toBeInstanceOf(ApiError);
+
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledWith(502, expect.stringContaining("/api/earn/stats"));
+    });
+
+    it("should invoke onServerError again after the throttle interval elapses", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const api = new BackendApiClient();
+      const cb = vi.fn();
+      api.onServerError = cb;
+
+      fetchMock.mockResolvedValueOnce(jsonResponse({}, 500));
+      await expect(api.getEarnStats()).rejects.toBeInstanceOf(ApiError);
+
+      vi.setSystemTime(new Date("2026-01-01T00:00:11Z"));
+      fetchMock.mockResolvedValueOnce(jsonResponse({}, 500));
+      await expect(api.getEarnStats()).rejects.toBeInstanceOf(ApiError);
+
+      expect(cb).toHaveBeenCalledTimes(2);
+    });
+
+    it("should NOT invoke onServerError for a non-429 4xx response", async () => {
+      const api = new BackendApiClient();
+      const cb = vi.fn();
+      api.onServerError = cb;
+
+      fetchMock.mockResolvedValueOnce(jsonResponse({ error: { code: "bad_request", message: "nope" } }, 400));
+      await expect(api.getEarnStats()).rejects.toBeInstanceOf(ApiError);
+
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it("should invoke onRateLimited (not onServerError) on 429", async () => {
+      const api = new BackendApiClient();
+      const rateLimited = vi.fn();
+      const serverError = vi.fn();
+      api.onRateLimited = rateLimited;
+      api.onServerError = serverError;
+
+      fetchMock.mockResolvedValueOnce(jsonResponse({ error: { code: "rate_limited", message: "slow down" } }, 429));
+      await expect(api.getEarnStats()).rejects.toBeInstanceOf(ApiError);
+
+      expect(rateLimited).toHaveBeenCalledTimes(1);
+      expect(serverError).not.toHaveBeenCalled();
+    });
+  });
+
   describe("doFetch - non-429 errors", () => {
     it("throws when 400 JSON body present (ApiError with status/code/message from body)", async () => {
       const api = new BackendApiClient();

--- a/src/common/api/BackendApi.ts
+++ b/src/common/api/BackendApi.ts
@@ -102,6 +102,8 @@ import {
 // Backend URL from environment, falls back to same-origin (for Vite dev proxy)
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || "";
 
+const SERVER_ERROR_TOAST_INTERVAL_MS = 10_000;
+
 /**
  * Main Backend API Client
  *
@@ -125,6 +127,16 @@ export class BackendApiClient {
    */
   onRateLimited: (() => void) | null = null;
   private rateLimitToastTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Callback invoked when the backend returns a server error (status >= 500).
+   * Set by App.vue to show a toast notification. Throttled to one invocation
+   * per SERVER_ERROR_TOAST_INTERVAL_MS so a burst of failing boot-time calls
+   * (many sitting inside Promise.allSettled) surfaces a single toast rather
+   * than one per failed request.
+   */
+  onServerError: ((status: number, url: string) => void) | null = null;
+  private lastServerErrorToastAt: number | null = null;
 
   constructor(baseUrl: string = BACKEND_URL) {
     this.baseUrl = baseUrl;
@@ -227,6 +239,16 @@ export class BackendApiClient {
         this.rateLimitToastTimeout = setTimeout(() => {
           this.rateLimitToastTimeout = null;
         }, 5000);
+      }
+      if (response.status >= 500 && this.onServerError) {
+        const now = Date.now();
+        if (
+          this.lastServerErrorToastAt === null ||
+          now - this.lastServerErrorToastAt >= SERVER_ERROR_TOAST_INTERVAL_MS
+        ) {
+          this.lastServerErrorToastAt = now;
+          this.onServerError(response.status, urlString);
+        }
       }
       const errorData = await response.json().catch(() => ({}));
       throw new ApiErrorClass(


### PR DESCRIPTION
## Summary
Fix the /vote page failing to load for connected wallets. `GET /api/governance/proposals?voter=` returned a deterministic 502 whenever the wallet had not voted on a voting-period proposal: the Cosmos LCD reports a missing gov vote as HTTP 400 (gRPC `InvalidArgument`, "voter ... not found for proposal"), not 404, and the per-proposal vote fan-out was fail-fast, so one failed lookup killed the whole cache-served list. Verified live against staging (proposal 337): 24% of voter-variant requests 502'd over the last 30 days vs 0% for the plain variant.

## Changes
- `chain.rs`: classify an LCD 400 with gRPC code 3 + "not found for proposal" as "hasn't voted" (`Ok(None)`, same as 404); any other 400 (e.g. malformed bech32 — also code 3) stays an error. Upstream bodies embedded in chain error messages are now capped at 256 chars (they can echo request input).
- `governance.rs`: voter fan-out switched from fail-fast to tolerant — a per-proposal lookup failure logs a warning and degrades that proposal to `voted: false` instead of failing the request. Response shape unchanged; the endpoint's doc comment and OpenAPI spec drop the now-unreachable `502` response (snapshot regenerated via `UPDATE_OPENAPI_SNAPSHOT=1 cargo test openapi`; diff confined to `paths./api/governance/proposals.get`).
- Rate limiter: header-less requests now key on the connection peer address (`into_make_service_with_connect_info` wired through both limiter tiers) instead of collapsing into one shared bucket that kept on-box probes permanently 429'd. Header precedence and `RATE_LIMIT_WHITELIST` behavior unchanged.
- Frontend: `BackendApi` fires a new `onServerError` hook for status >= 500 (throttled to one per 10s via timestamp comparison, no timers), wired in `App.vue` to the same toast as the existing 429 path, reusing `message.unexpected-error`. Previously every non-429 failure was invisible — boot-time calls sit inside `Promise.allSettled`, so backend 502s produced silently dead views.

## Verification
- Reproduced the 502 live on the staging box pre-fix: LCD vote query for a non-voted wallet returns 400 "not found for proposal"; the backend emitted the 502 itself (JSON `CHAIN_ERROR` envelope, no nginx upstream errors at any of the 14 historical 502 timestamps).
- Ran the backend gate: `cargo build`, `cargo fmt --check`, `cargo clippy -D warnings` (with the CI `-A` set), `scripts/style-check.sh`, `cargo test` — 482 passed, including the OpenAPI snapshot guard (snapshot unchanged) and new tests for vote-not-found→None, malformed-400 staying an error, per-id fan-out degradation, peer-addr fallback / per-peer isolation / whitelist bypass, and error-body truncation (incl. multibyte boundary).
- Ran the frontend gate: `npm run typecheck`, `lint`, `lint:style`, `format:check`, `vitest` — 1002 passed, including 4 new BackendApi tests (throttled 5xx burst fires once, refires after the interval, non-429 4xx is a no-op, 429 path unchanged).
- Ran three independent reviews over the branch diff (generic correctness, security, project-conventions); all raised findings were fixed in-branch: stale ConnectInfo comment in `rate_limit.rs`, per-id vote assertions, descriptive expect messages, upstream-body cap.

## Follow-ups
- Pre-existing, unchanged here: `X-Forwarded-For` is trusted unconditionally (first hop, no trusted-proxy validation), so a client reaching the backend directly can rotate XFF to evade limits or forge a whitelisted IP; mitigated while nginx overwrites XFF.
- Pre-existing, unchanged here: `chain_get`'s retry-exhausted path and `query_contract` still embed full upstream bodies in error messages (the gov vote path now caps them).
