### PR TITLE
refactor(stores): harden WS merge seams against partial payloads

### DIFF
--- a/src/common/stores/config/index.test.ts
+++ b/src/common/stores/config/index.test.ts
@@ -528,6 +528,11 @@ describe("ConfigStore", () => {
   //   3. Log failures at error level (console.error), not just warn.
   //   4. Drop stale assets when a switch fails — never leave the previous
   //      network's assets visible under the new filter.
+  //   5. A superseded in-flight response never commits — if a newer filter
+  //      switch lands while a fetch is still pending, that slow response (or
+  //      its error-branch null) must not overwrite the current network's
+  //      assets. Guarded by a monotonic request token, not a filter-equality
+  //      check (initialize() fetches while protocolFilter is still "").
 
   /** Helper: prime the store so initialize() is a no-op past the first cycle. */
   async function primeInitializedStore() {
@@ -643,6 +648,95 @@ describe("ConfigStore", () => {
       await flushPromises();
 
       expect(store.assetsResponse).toBeNull();
+    } finally {
+      consoleErr.mockRestore();
+    }
+  });
+
+  it("watcher_superseded_in_flight_response_never_commits", async () => {
+    // Rule 5. Keplr(OSMOSIS) → Phantom connect fires a slow fetchNetworkAssets("SOLANA");
+    // reconnect Keplr before it resolves → watcher early-returns (OSMOSIS already fetched),
+    // and the late SOLANA response must NOT commit under the OSMOSIS filter.
+    api.getConfig.mockResolvedValueOnce(makeConfig());
+    api.getCurrencies.mockResolvedValueOnce(makeCurrencies());
+    api.getNetworkAssets.mockResolvedValueOnce({
+      assets: [{ ticker: "OSMO", networks: ["OSMOSIS"], protocols: ["OSMOSIS"], icon: "" }]
+    });
+    api.getGatedProtocols.mockResolvedValueOnce({ protocols: [] });
+    api.getGasFeeConfig.mockResolvedValueOnce({ gas_prices: {}, gas_multiplier: 1 });
+
+    const store = useConfigStore();
+    await store.initialize();
+    expect(store.assets.map((a) => a.ticker)).toEqual(["OSMO"]);
+
+    // SOLANA fetch is slow — resolved manually after the supersede lands.
+    let resolveSolana!: (v: { assets: unknown[] }) => void;
+    const solanaPending = new Promise<{ assets: unknown[] }>((res) => {
+      resolveSolana = res;
+    });
+    api.getNetworkAssets.mockReturnValueOnce(solanaPending);
+
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      store.setProtocolFilter("SOLANA");
+      await flushPromises(); // watcher kicks off the SOLANA fetch (now in-flight)
+
+      // Reconnect Keplr → OSMOSIS. Already fetched → watcher early-returns, but this
+      // switch supersedes the in-flight SOLANA request.
+      store.setProtocolFilter("OSMOSIS");
+      await flushPromises();
+
+      // SOLANA response arrives late.
+      resolveSolana({ assets: [{ ticker: "SOL", networks: ["SOLANA"], protocols: ["SOLANA"], icon: "" }] });
+      await flushPromises();
+      await flushPromises();
+
+      // Stale SOLANA assets must NOT have committed under the OSMOSIS filter.
+      expect(store.assets.map((a) => a.ticker)).toEqual(["OSMO"]);
+    } finally {
+      consoleErr.mockRestore();
+    }
+  });
+
+  it("watcher_superseded_failed_fetch_does_not_clear_current_assets", async () => {
+    // Rule 5, failure branch: the error-branch "clear stale assets" null is just as
+    // dangerous when superseded — a slow SOLANA fetch that REJECTS after the user has
+    // switched back to OSMOSIS must not wipe the committed OSMOSIS assets.
+    api.getConfig.mockResolvedValueOnce(makeConfig());
+    api.getCurrencies.mockResolvedValueOnce(makeCurrencies());
+    api.getNetworkAssets.mockResolvedValueOnce({
+      assets: [{ ticker: "OSMO", networks: ["OSMOSIS"], protocols: ["OSMOSIS"], icon: "" }]
+    });
+    api.getGatedProtocols.mockResolvedValueOnce({ protocols: [] });
+    api.getGasFeeConfig.mockResolvedValueOnce({ gas_prices: {}, gas_multiplier: 1 });
+
+    const store = useConfigStore();
+    await store.initialize();
+    expect(store.assets.map((a) => a.ticker)).toEqual(["OSMO"]);
+
+    // SOLANA fetch is slow and will fail — rejected manually after the supersede lands.
+    let rejectSolana!: (e: Error) => void;
+    const solanaPending = new Promise<never>((_res, rej) => {
+      rejectSolana = rej;
+    });
+    api.getNetworkAssets.mockReturnValueOnce(solanaPending);
+
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      store.setProtocolFilter("SOLANA");
+      await flushPromises(); // watcher kicks off the SOLANA fetch (now in-flight)
+
+      // Switch back to OSMOSIS → already fetched, early-return, but supersedes SOLANA.
+      store.setProtocolFilter("OSMOSIS");
+      await flushPromises();
+
+      // SOLANA rejects late — superseded, so the error-branch null must NOT apply.
+      rejectSolana(new Error("solana down"));
+      await flushPromises();
+      await flushPromises();
+
+      expect(store.assetsResponse).not.toBeNull();
+      expect(store.assets.map((a) => a.ticker)).toEqual(["OSMO"]);
     } finally {
       consoleErr.mockRestore();
     }

--- a/src/common/stores/config/index.ts
+++ b/src/common/stores/config/index.ts
@@ -713,19 +713,39 @@ export const useConfigStore = defineStore("config", () => {
   }
 
   /**
+   * Start a network-assets fetch, returning the request's token id alongside its
+   * completion promise. The id is captured synchronously here (a rejected promise
+   * carries no value, so it cannot be returned via await) — callers that need to
+   * guard their own error handling compare this returned id against the live token
+   * instead of re-reading the shared counter after the call.
+   */
+  function startNetworkAssetsFetch(network: string): { requestId: number; completion: Promise<void> } {
+    const requestId = ++assetRequestToken;
+    const completion = (async () => {
+      assetsLoading.value = true;
+
+      try {
+        const response = await BackendApi.getNetworkAssets(network);
+        // Ignore a superseded in-flight response: a newer filter switch bumped the
+        // token, so this now-stale network's assets must not overwrite the current ones.
+        if (requestId === assetRequestToken) {
+          assetsResponse.value = response;
+        }
+      } catch (e) {
+        console.error("[ConfigStore] Failed to fetch network assets:", e);
+        throw e;
+      } finally {
+        assetsLoading.value = false;
+      }
+    })();
+    return { requestId, completion };
+  }
+
+  /**
    * Fetch assets for a specific network using /api/networks/{network}/assets
    */
   async function fetchNetworkAssets(network: string): Promise<void> {
-    assetsLoading.value = true;
-
-    try {
-      assetsResponse.value = await BackendApi.getNetworkAssets(network);
-    } catch (e) {
-      console.error("[ConfigStore] Failed to fetch network assets:", e);
-      throw e;
-    } finally {
-      assetsLoading.value = false;
-    }
+    await startNetworkAssetsFetch(network).completion;
   }
 
   /**
@@ -786,6 +806,15 @@ export const useConfigStore = defineStore("config", () => {
   // the backend on every subsequent toggle back to the same filter within the session.
   const fetchedNetworks = new Set<string>();
 
+  // Monotonic request token for network-asset fetches. A fetch captures the token
+  // current when it starts and commits its result only while that token is still the
+  // latest; every qualifying filter switch bumps it — including a switch to an
+  // already-fetched network, which early-returns without fetching. This cancels a
+  // slow in-flight response for a network the user has since switched away from. A
+  // filter-equality guard would be wrong: initialize() fetches while protocolFilter
+  // is still "".
+  let assetRequestToken = 0;
+
   // Networks the wallet-driven mapping in `walletProtocolFilter.ts` can produce.
   // Even when the backend has no protocol entry for one of these yet (e.g. SOLANA
   // before the first Solana protocol ships), the watcher must still attempt the
@@ -809,6 +838,11 @@ export const useConfigStore = defineStore("config", () => {
   //   3. Failed fetch → console.error, clear assetsResponse so stale data from
   //      the previous network does not survive the failed switch, AND record
   //      the network in fetchedNetworks so we do not retry-storm.
+  //   4. Superseded in-flight response → never commits. A newer filter switch
+  //      (including one to an already-fetched network) bumps the request token;
+  //      a stale fetch's success-commit and this error-branch null both check it,
+  //      so a slow response for a network the user switched away from cannot
+  //      overwrite the current one.
   watch(protocolFilter, async (newFilter) => {
     if (!initialized.value) return;
     if (!newFilter) return;
@@ -819,17 +853,27 @@ export const useConfigStore = defineStore("config", () => {
     }
 
     const upperFilter = newFilter.toUpperCase();
-    if (fetchedNetworks.has(upperFilter)) return;
+    if (fetchedNetworks.has(upperFilter)) {
+      // Already fetched → no request, but this switch still supersedes any in-flight
+      // fetch for a now-stale network so its late response cannot commit.
+      assetRequestToken++;
+      return;
+    }
 
+    const { requestId, completion } = startNetworkAssetsFetch(newFilter);
     try {
-      await fetchNetworkAssets(newFilter);
+      await completion;
       await prefetchProtocolCurrenciesForNetwork(newFilter);
       fetchedNetworks.add(upperFilter);
     } catch (err) {
       console.error("[ConfigStore] Failed to fetch assets for network:", upperFilter, err);
-      // Drop stale assets so the previous network's data is not visible under
-      // the new filter, then record the failure to prevent retry-storms.
-      assetsResponse.value = null;
+      // Drop stale assets so the previous network's data is not visible under the new
+      // filter — but only while this request is still the latest, so a superseded
+      // failure cannot wipe the current network's assets. Record the failure either
+      // way to prevent retry-storms.
+      if (requestId === assetRequestToken) {
+        assetsResponse.value = null;
+      }
       fetchedNetworks.add(upperFilter);
     }
   });

--- a/src/common/stores/earn/index.test.ts
+++ b/src/common/stores/earn/index.test.ts
@@ -475,7 +475,7 @@ describe("useEarnStore", () => {
     expect(BackendApi.getEarnPositions).not.toHaveBeenCalled();
   });
 
-  it("ws callback replaces positions when address matches", async () => {
+  it("ws callback builds a placeholder for an unmatched position and keeps the REST total", async () => {
     BackendApi.getEarnPositions.mockResolvedValueOnce({ positions: [], total_deposited_usd: "0" });
 
     const store = useEarnStore();
@@ -489,12 +489,14 @@ describe("useEarnStore", () => {
           protocol: "p1",
           lpp_address: "l1",
           deposited_asset: "5",
-          deposited_lpn: "5"
+          deposited_lpn: "5",
+          rewards: "0"
         }
       ],
       "5.0"
     );
 
+    // No existing REST record for p1 → placeholder reconstruction (REST fields unknown yet).
     expect(store.positions.length).toBe(1);
     expect(store.positions[0]).toMatchObject({
       protocol: "p1",
@@ -505,7 +507,117 @@ describe("useEarnStore", () => {
       lpp_price: "1.0",
       current_apy: 0
     });
-    expect(store.totalDepositedUsd).toBe("5.0");
+    // Backend hardcodes total_deposited_usd="0.00" on WS pushes; the REST value ("0") is kept.
+    expect(store.totalDepositedUsd).toBe("0");
+  });
+
+  it("ws earn update ignores the WS total_deposited_usd and preserves the REST-derived value", async () => {
+    BackendApi.getEarnPositions.mockResolvedValueOnce({
+      positions: [
+        {
+          protocol: "p1",
+          lpp_address: "l1",
+          currency: "USDC",
+          deposited_nlpn: "100",
+          deposited_lpn: "100",
+          deposited_usd: "250.00",
+          lpp_price: "1.0",
+          current_apy: 5
+        }
+      ],
+      total_deposited_usd: "250.00"
+    });
+
+    const store = useEarnStore();
+    await store.setAddress("nolus1x");
+    expect(store.totalDepositedUsd).toBe("250.00");
+
+    // Backend hardcodes "0.00" on every WS push — it must NOT clobber the REST total.
+    emitEarn(
+      "nolus1x",
+      [{ protocol: "p1", lpp_address: "l1", deposited_asset: "100", deposited_lpn: "100", rewards: "0" }],
+      "0.00"
+    );
+
+    expect(store.totalDepositedUsd).toBe("250.00");
+  });
+
+  it("ws earn update merges WS-owned fields into a matched REST position, preserving REST-only fields", async () => {
+    BackendApi.getEarnPositions.mockResolvedValueOnce({
+      positions: [
+        {
+          protocol: "p1",
+          lpp_address: "l1",
+          currency: "USDC",
+          deposited_nlpn: "100",
+          deposited_lpn: "100",
+          deposited_usd: "250.00",
+          lpp_price: "1.05",
+          current_apy: 5
+        }
+      ],
+      total_deposited_usd: "250.00"
+    });
+
+    const store = useEarnStore();
+    await store.setAddress("nolus1x");
+
+    emitEarn(
+      "nolus1x",
+      [{ protocol: "p1", lpp_address: "l1", deposited_asset: "120", deposited_lpn: "126", rewards: "1" }],
+      "0.00"
+    );
+
+    const pos = store.getPosition("p1");
+    // WS-owned fields updated:
+    expect(pos?.deposited_nlpn).toBe("120");
+    expect(pos?.deposited_lpn).toBe("126");
+    // REST-only fields preserved (not degraded to placeholders):
+    expect(pos?.deposited_usd).toBe("250.00");
+    expect(pos?.current_apy).toBe(5);
+    expect(pos?.currency).toBe("USDC");
+    expect(pos?.lpp_price).toBe("1.05");
+  });
+
+  it("ws earn update drops store positions absent from the WS payload", async () => {
+    BackendApi.getEarnPositions.mockResolvedValueOnce({
+      positions: [
+        {
+          protocol: "p1",
+          lpp_address: "l1",
+          currency: "USDC",
+          deposited_nlpn: "1",
+          deposited_lpn: "1",
+          deposited_usd: "1",
+          lpp_price: "1",
+          current_apy: 1
+        },
+        {
+          protocol: "p2",
+          lpp_address: "l2",
+          currency: "USDC",
+          deposited_nlpn: "2",
+          deposited_lpn: "2",
+          deposited_usd: "2",
+          lpp_price: "1",
+          current_apy: 1
+        }
+      ],
+      total_deposited_usd: "3"
+    });
+
+    const store = useEarnStore();
+    await store.setAddress("nolus1x");
+    expect(store.positions.length).toBe(2);
+
+    // WS reports only p1 — p2 has been withdrawn and must drop (wholesale-replace removal semantics).
+    emitEarn(
+      "nolus1x",
+      [{ protocol: "p1", lpp_address: "l1", deposited_asset: "1", deposited_lpn: "1", rewards: "0" }],
+      "0.00"
+    );
+
+    expect(store.positions.map((p) => p.protocol)).toEqual(["p1"]);
   });
 
   it("ws callback ignores mismatched address", async () => {

--- a/src/common/stores/earn/index.ts
+++ b/src/common/stores/earn/index.ts
@@ -179,20 +179,34 @@ export const useEarnStore = defineStore("earn", () => {
   const { setAddress, cleanup } = useWebSocketLifecycle({
     address,
     subscribe: (addr) =>
-      WebSocketClient.subscribeEarn(addr, (wsAddr, wsPositions, totalUsd) => {
+      // The WS earn total is deliberately ignored: the backend hardcodes
+      // total_deposited_usd="0.00" on every push ("would need prices", websocket.rs),
+      // so the REST-derived totalDepositedUsd is kept until the next full fetch.
+      WebSocketClient.subscribeEarn(addr, (wsAddr, wsPositions) => {
         if (wsAddr !== address.value) return;
 
-        positions.value = wsPositions.map((p) => ({
-          protocol: p.protocol,
-          lpp_address: p.lpp_address,
-          currency: "", // Not provided by WS, will be filled on next full fetch
-          deposited_nlpn: p.deposited_asset,
-          deposited_lpn: p.deposited_lpn,
-          deposited_usd: null,
-          lpp_price: "1.0",
-          current_apy: 0
-        }));
-        totalDepositedUsd.value = totalUsd;
+        // Merge WS-owned fields (deposited_lpn, deposited_asset) into a matched REST
+        // record so its REST-only fields (deposited_usd/current_apy/currency/lpp_price)
+        // survive; an unmatched WS position gets a placeholder until the next fetch.
+        // Positions absent from the payload drop — same wholesale-replace removal
+        // semantics as REST fetchPositions.
+        const existingByKey = new Map(positions.value.map((p) => [`${p.protocol}::${p.lpp_address}`, p]));
+        positions.value = wsPositions.map((p) => {
+          const existing = existingByKey.get(`${p.protocol}::${p.lpp_address}`);
+          if (existing) {
+            return { ...existing, deposited_nlpn: p.deposited_asset, deposited_lpn: p.deposited_lpn };
+          }
+          return {
+            protocol: p.protocol,
+            lpp_address: p.lpp_address,
+            currency: "",
+            deposited_nlpn: p.deposited_asset,
+            deposited_lpn: p.deposited_lpn,
+            deposited_usd: null,
+            lpp_price: "1.0",
+            current_apy: 0
+          };
+        });
         lastUpdated.value = new Date();
       }),
     fetch: fetchPositions,

--- a/src/common/stores/leases/index.test.ts
+++ b/src/common/stores/leases/index.test.ts
@@ -142,6 +142,9 @@ type LeaseRec = {
   interest: { loan_rate: number; margin_rate: number; annual_rate_percent: number };
 
   in_progress?: any;
+  pnl?: { amount: string; percent: string; downpayment: string; pnl_positive: boolean };
+  liquidation_price?: string;
+  opened_at?: string;
 };
 
 const mkLease = (o: Partial<LeaseRec>): LeaseRec => ({
@@ -434,6 +437,75 @@ describe("useLeasesStore", () => {
 
     const lease = store.leases.find((l) => l.address === "l1");
     expect(lease?.amount.amount).toBe("9999");
+  });
+
+  it("ws callback preserves REST pnl when the monitor sends pnl:null (allowlist null-skip)", async () => {
+    const store = useLeasesStore();
+    BackendApi.getLeases.mockResolvedValueOnce([
+      mkLease({
+        address: "l1",
+        status: "opened",
+        pnl: { amount: "42", percent: "5", downpayment: "100", pnl_positive: true }
+      })
+    ]);
+    await store.setOwner("nolus1x");
+
+    // Routine same-status tick: monitor hardcodes pnl:null but advances in_progress.
+    emitLeases({ address: "l1", status: "opened", pnl: null, in_progress: { close: {} } });
+
+    const lease = store.leases.find((l) => l.address === "l1");
+    expect(lease?.pnl).toEqual({ amount: "42", percent: "5", downpayment: "100", pnl_positive: true });
+    expect(lease?.in_progress).toEqual({ close: {} });
+    expect(lease?.status).toBe("opened");
+  });
+
+  it("ws callback preserves amount when the monitor sends amount:null on an opening lease", async () => {
+    const store = useLeasesStore();
+    BackendApi.getLeases.mockResolvedValueOnce([
+      mkLease({ address: "l1", status: "opening", amount: { ticker: "ATOM", amount: "1000000" } })
+    ]);
+    await store.setOwner("nolus1x");
+
+    emitLeases({ address: "l1", status: "opening", amount: null, pnl: null });
+
+    const lease = store.leases.find((l) => l.address === "l1");
+    expect(lease?.amount).toEqual({ ticker: "ATOM", amount: "1000000" });
+    // totalCollateralUsd reads lease.amount.ticker over open leases — a null amount would throw.
+    expect(() => store.totalCollateralUsd).not.toThrow();
+  });
+
+  it("ws callback applies non-null monitor debt and interest values", async () => {
+    const store = useLeasesStore();
+    BackendApi.getLeases.mockResolvedValueOnce([mkLease({ address: "l1", status: "opened" })]);
+    await store.setOwner("nolus1x");
+
+    const newDebt = {
+      ticker: "USDC",
+      principal: "5",
+      overdue_margin: "0",
+      overdue_interest: "0",
+      due_margin: "0",
+      due_interest: "0",
+      total: "5"
+    };
+    const newInterest = { loan_rate: 1, margin_rate: 2, annual_rate_percent: 3 };
+    emitLeases({ address: "l1", status: "opened", debt: newDebt, interest: newInterest, pnl: null });
+
+    const lease = store.leases.find((l) => l.address === "l1");
+    expect(lease?.debt).toEqual(newDebt);
+    expect(lease?.interest).toEqual(newInterest);
+  });
+
+  it("ws callback ignores keys outside the monitor allowlist", async () => {
+    const store = useLeasesStore();
+    BackendApi.getLeases.mockResolvedValueOnce([mkLease({ address: "l1", status: "opened", opened_at: "REST_TIME" })]);
+    await store.setOwner("nolus1x");
+
+    // opened_at is REST/ETL-owned, not a monitor field — a stray WS value must not overwrite it.
+    emitLeases({ address: "l1", status: "opened", opened_at: "WS_TIME", pnl: null });
+
+    const lease = store.leases.find((l) => l.address === "l1");
+    expect(lease?.opened_at).toBe("REST_TIME");
   });
 
   it("ws callback regression guard ignores stale event", async () => {

--- a/src/common/stores/leases/index.ts
+++ b/src/common/stores/leases/index.ts
@@ -42,6 +42,34 @@ const STATUS_ORDER: Record<string, number> = {
   liquidated: 4
 };
 
+/**
+ * Keys the WebSocket lease monitor owns and may write onto an existing record —
+ * exactly the mutable field set of its payload (`start_lease_monitor_task` in
+ * backend/src/handlers/websocket.rs); `address`/`protocol` are identity, not
+ * merged. Contract: a new WS payload field requires an explicit entry here, and
+ * a null/undefined value is never applied — the monitor serializes Rust `None`
+ * as JSON `null` (it hardcodes `pnl: None` on every arm and `amount: None` on
+ * opening/terminal arms), and REST stays authoritative for those. A blanket
+ * spread would clobber the REST-computed pnl/amount with null on a routine tick.
+ */
+const WS_LEASE_MONITOR_KEYS = [
+  "status",
+  "amount",
+  "debt",
+  "interest",
+  "liquidation_price",
+  "pnl",
+  "close_policy",
+  "in_progress"
+] as const satisfies readonly (keyof LeaseInfo)[];
+
+function applyWsMonitorField<K extends keyof LeaseInfo>(target: LeaseInfo, source: Partial<LeaseInfo>, key: K): void {
+  const value = source[key];
+  if (value !== null && value !== undefined) {
+    target[key] = value;
+  }
+}
+
 export const useLeasesStore = defineStore("leases", () => {
   // State
   const leases = ref<LeaseInfo[]>([]);
@@ -311,9 +339,14 @@ export const useLeasesStore = defineStore("leases", () => {
 
         let merged: LeaseInfo;
         if (existing) {
-          // Existing record: WS updates may be partial; merge so ETL-only fields
-          // (not sent over WS) survive. The existing record was already validated.
-          merged = { ...existing, ...wsLease };
+          // Existing record: apply only the monitor-owned keys, and only when the
+          // incoming value is non-null — REST-computed/ETL-only fields survive, and
+          // the monitor's null pnl/amount can no longer overwrite them. The existing
+          // record was already validated. (See WS_LEASE_MONITOR_KEYS.)
+          merged = { ...existing };
+          for (const key of WS_LEASE_MONITOR_KEYS) {
+            applyWsMonitorField(merged, wsLease, key);
+          }
         } else {
           // No prior record: a brand-new lease must arrive as a complete LeaseInfo
           // (the same shape the REST path validates) before it reaches the money

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -110,7 +110,7 @@ export default mergeConfig(
           },
           "src/common/stores/earn/index.ts": {
             lines: 95,
-            branches: 85,
+            branches: 89,
             functions: 95,
             statements: 95
           },
@@ -122,14 +122,14 @@ export default mergeConfig(
           },
           "src/common/stores/leases/index.ts": {
             lines: 80,
-            branches: 80,
+            branches: 86,
             functions: 70,
             statements: 80
           },
           // Large stores — intentionally lower floors; breadth-over-depth.
           "src/common/stores/config/index.ts": {
             lines: 65,
-            branches: 80,
+            branches: 87,
             functions: 35,
             statements: 65
           },


### PR DESCRIPTION
## Summary
Harden the WebSocket→store seams. Closes #272 (leases allowlist merge) and extends it with the results of a repo-wide sweep for the same fragility class, which surfaced — and adversarially confirmed — three live bugs and one degradation, all fixed here. Frontend-only; 3 commits.

## Changes
- **Leases store**: the WS monitor merge is now an explicit allowlist (`WS_LEASE_MONITOR_KEYS`, exactly the monitor's payload field set) applying only non-null values. Fixes two live bugs: the monitor always serializes `pnl: null` (every arm) and `amount: null` (opening/terminal arms), and the old blanket spread let those nulls erase REST-computed values — blanking a position's PnL on a routine tick, and making an opening lease's null `amount` throw in `totalCollateralUsd`. New WS fields now require an explicit allowlist entry instead of silently winning. The status-regression guard and the Zod-validated new-lease branch are unchanged. Known trade-off, documented in code: a legitimate null over WS (e.g. a cleared close policy) is skipped and self-heals on the next REST fetch — the monitor's change detection doesn't track that field, so it never arrives alone.
- **Earn store**: stops consuming the WS `total_deposited_usd` — the backend hardcodes it to `"0.00"` on every push, so any pool event flipped a real Total Deposited to $0.00 until the next REST fetch. WS positions now merge their owned fields into existing records matched by protocol + lpp_address, preserving the REST-only fields (`deposited_usd`, `current_apy`, `currency`, `lpp_price`) that were previously wiped to placeholders on every tick; placeholders remain only for brand-new WS positions.
- **Config store**: `fetchNetworkAssets` commits are guarded by a monotonic request token (returned by the function, checked at commit — success and the watcher's error-branch null alike), fixing a verified race: switch Keplr→Phantom (slow SOLANA fetch)→Keplr, and the late SOLANA response used to commit anyway, rendering SOLANA assets under an OSMOSIS filter until reload. The watcher's pinned behavior contract grows a fifth rule (a superseded in-flight response never commits) with its own tests, including the superseded-failure branch. Store coverage floors ratcheted to the new actuals.

## Verification
- Wrote the failing tests first for all three live bugs and confirmed each red against the pre-fix code (pnl preserved-vs-clobbered, REST total preserved-vs-"0.00", late response rejected-vs-committed), then green after the fixes.
- Ran the full frontend gate: typecheck (vue-tsc), lint, lint:style, format:check, vitest — full suite green including the four pre-existing watcher-contract tests, byte-for-byte unchanged.
- Swept the stores for further instances of the class (blanket merges of partial payloads, dual-writer seams, hydration overwrites, request-cache staleness) and adversarially verified every candidate against the actual backend serializers; the sound seams (prices per-key merge, balances full-replace, request coalescing, wallet-storage hydration, boot ordering) were confirmed sound.
- Ran independent correctness, security, and conventions reviews over the branch; all actionable findings were addressed in-branch (request-token returned by value instead of re-read shared state; superseded-failure branch test; coverage floors; docs). One review suggestion was examined and rejected with evidence: the "toggle back to an already-fetched network shows stale assets" variant is unreachable through the UI because switching wallets forces a disconnect, which refreshes the config store and clears the fetched-network dedup — the reachable variant is exactly the in-flight race the token guard fixes.

## Follow-ups
- Dead WS seams (separate decision): the balances and staking stores subscribe to `balance_update` / `staking_update`, but the backend never produces either in production (`send_balance_update` only under `#[cfg(test)]`; `StakingUpdate` declared, never constructed), and staking also lacks a reconnect refetch — needs a call between wiring real broadcasters and dropping the dead subscriptions.
- Backend: compute the real `total_deposited_usd` for earn pushes server-side (the frontend now ignores the hardcoded `"0.00"`).
- Minor: the non-network `fetchAssets()` path writes the shared assets response without the token guard (not exercised by any wallet flow today).
