### PR TITLE
fix(staking): remove dead WS subscription, add reconnect refetch

### DIFF
--- a/backend/src/handlers/websocket.rs
+++ b/backend/src/handlers/websocket.rs
@@ -5,7 +5,6 @@
 //! - balances: Balance updates for specific addresses
 //! - leases: Lease state changes for a user
 //! - tx_status: Transaction confirmation status
-//! - staking: Staking position updates
 //! - skip_tx: Cross-chain transaction tracking
 //! - earn: Earn position updates for a user
 
@@ -82,11 +81,6 @@ pub enum ServerMessage {
         #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<String>,
     },
-    /// Staking update
-    StakingUpdate {
-        address: String,
-        data: serde_json::Value,
-    },
     /// Skip cross-chain transaction update
     SkipTxUpdate {
         tx_hash: String,
@@ -143,8 +137,6 @@ pub enum Subscription {
     Leases { address: String },
     /// Subscribe to transaction status
     TxStatus { hash: String, chain_id: String },
-    /// Subscribe to staking updates
-    Staking { address: String },
     /// Subscribe to Skip transaction tracking
     SkipTx {
         tx_hash: String,
@@ -197,14 +189,6 @@ impl Subscription {
                     .to_string();
                 Ok(Subscription::TxStatus { hash, chain_id })
             }
-            "staking" => {
-                let address = params
-                    .get("address")
-                    .and_then(|v| v.as_str())
-                    .ok_or("Missing 'address' parameter")?
-                    .to_string();
-                Ok(Subscription::Staking { address })
-            }
             "skip_tx" => {
                 let tx_hash = params
                     .get("tx_hash")
@@ -239,7 +223,6 @@ impl Subscription {
             Subscription::Balances { .. } => "balances",
             Subscription::Leases { .. } => "leases",
             Subscription::TxStatus { .. } => "tx_status",
-            Subscription::Staking { .. } => "staking",
             Subscription::SkipTx { .. } => "skip_tx",
             Subscription::Earn { .. } => "earn",
         }
@@ -1687,10 +1670,10 @@ mod tests {
     // Subscription parsing — additional edge cases
     // ------------------------------------------------------------------
 
-    /// skip_tx and earn topic parsing, plus staking — ensures full coverage
-    /// of the topic dispatch table.
+    /// skip_tx and earn topic parsing — ensures full coverage of the topic
+    /// dispatch table.
     #[test]
-    fn test_subscription_parsing_skip_tx_earn_staking() {
+    fn test_subscription_parsing_skip_tx_earn() {
         let sub = Subscription::from_client_message(
             "skip_tx",
             &serde_json::json!({"tx_hash": "H", "source_chain": "osmosis-1"}),
@@ -1706,20 +1689,11 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(sub, Subscription::Earn { address } if address == "nolus1earn"));
-
-        let sub = Subscription::from_client_message(
-            "staking",
-            &serde_json::json!({"address": "nolus1stake"}),
-        )
-        .unwrap();
-        assert!(matches!(sub, Subscription::Staking { address } if address == "nolus1stake"));
     }
 
     /// Missing specific params for each topic surface `Err` — not panic.
     #[test]
     fn test_subscription_parsing_missing_params_all_topics() {
-        // staking: missing address
-        assert!(Subscription::from_client_message("staking", &serde_json::json!({})).is_err());
         // earn: missing address
         assert!(Subscription::from_client_message("earn", &serde_json::json!({})).is_err());
         // skip_tx: missing tx_hash

--- a/src/common/api/WebSocketClient.ts
+++ b/src/common/api/WebSocketClient.ts
@@ -5,7 +5,7 @@
  * typed event handling for price updates, balance changes, lease updates, etc.
  */
 
-import type { LeaseInfo, BalanceInfo, StakingPositionsResponse } from "./BackendApi";
+import type { LeaseInfo, BalanceInfo } from "./BackendApi";
 
 import { Logger } from "@/common/utils/Logger";
 
@@ -20,7 +20,7 @@ function getWsUrl(): string {
 /**
  * Subscription topics supported by the backend
  */
-export type SubscriptionTopic = "prices" | "balances" | "leases" | "tx_status" | "staking" | "skip_tx" | "earn";
+export type SubscriptionTopic = "prices" | "balances" | "leases" | "tx_status" | "skip_tx" | "earn";
 
 /**
  * Client -> Server messages
@@ -80,12 +80,6 @@ interface TxStatusMessage {
   error?: string;
 }
 
-interface StakingUpdateMessage {
-  type: "staking_update";
-  address: string;
-  data: StakingPositionsResponse;
-}
-
 interface SkipTxUpdateMessage {
   type: "skip_tx_update";
   tx_hash: string;
@@ -118,7 +112,6 @@ type ServerMessage =
   | BalanceUpdateMessage
   | LeaseUpdateMessage
   | TxStatusMessage
-  | StakingUpdateMessage
   | SkipTxUpdateMessage
   | EarnUpdateMessage;
 
@@ -129,7 +122,6 @@ export type PriceCallback = (prices: Record<string, string>) => void;
 export type BalanceCallback = (address: string, balances: BalanceInfo[]) => void;
 export type LeaseCallback = (lease: Partial<LeaseInfo> & Pick<LeaseInfo, "address" | "status">) => void;
 export type TxStatusCallback = (txHash: string, status: "pending" | "success" | "failed", error?: string) => void;
-export type StakingCallback = (address: string, data: StakingPositionsResponse) => void;
 export type SkipTxCallback = (update: {
   tx_hash: string;
   status: "pending" | "success" | "failed";
@@ -374,10 +366,6 @@ class WebSocketClientImpl {
           this.notifySubscribers(`tx_status:${message.tx_hash}`, message.tx_hash, message.status, message.error);
           break;
 
-        case "staking_update":
-          this.notifySubscribers(`staking:${message.address}`, message.address, message.data);
-          break;
-
         case "skip_tx_update":
           this.notifySubscribers(`skip_tx:${message.tx_hash}`, {
             tx_hash: message.tx_hash,
@@ -517,13 +505,6 @@ class WebSocketClientImpl {
    */
   subscribeTxStatus(txHash: string, chainId: string, callback: TxStatusCallback): Unsubscribe {
     return this.subscribe(`tx_status:${txHash}`, "tx_status", callback, { hash: txHash, chain_id: chainId });
-  }
-
-  /**
-   * Subscribe to staking position updates
-   */
-  subscribeStaking(address: string, callback: StakingCallback): Unsubscribe {
-    return this.subscribe(`staking:${address}`, "staking", callback, { address });
   }
 
   /**

--- a/src/common/api/index.ts
+++ b/src/common/api/index.ts
@@ -24,7 +24,6 @@ export type {
   BalanceCallback,
   LeaseCallback,
   TxStatusCallback,
-  StakingCallback,
   SkipTxCallback,
   Unsubscribe,
   ConnectionState,

--- a/src/common/stores/staking/index.test.ts
+++ b/src/common/stores/staking/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
+import { reactive, nextTick } from "vue";
 
 // ThemeManager needs window.matchMedia at module import time.
 vi.hoisted(() => {
@@ -18,26 +19,16 @@ vi.hoisted(() => {
 });
 
 const hoisted = vi.hoisted(() => {
-  const captured: {
-    onStaking: ((addr: string, response: any) => void) | null;
-    unsubscribe: ReturnType<typeof vi.fn>;
-  } = {
-    onStaking: null,
-    unsubscribe: vi.fn()
-  };
-
   const BackendApi = {
     getValidators: vi.fn(),
     getStakingPositions: vi.fn(),
     getStakingParams: vi.fn()
   };
 
-  const subscribeStaking = vi.fn((addr: string, cb: (a: string, resp: any) => void) => {
-    captured.onStaking = cb;
-    return captured.unsubscribe;
-  });
+  // Regression guard: staking must never re-introduce a WS subscription.
+  const subscribeStaking = vi.fn();
 
-  return { captured, BackendApi, subscribeStaking };
+  return { BackendApi, subscribeStaking };
 });
 
 vi.mock("@/common/api", () => ({
@@ -49,36 +40,27 @@ vi.mock("@/common/api", () => ({
 
 // Stub the connection store so useWalletWatcher can read walletAddress/wsReconnectCount
 // without pulling in the real connection store (which imports all other stores).
-const connectionState = {
-  walletAddress: null as string | null,
-  wsReconnectCount: 0
-};
+// Rebuilt per test so a store's watchers only observe its own test's mutations.
+function makeConnectionState() {
+  return reactive({
+    walletAddress: null as string | null,
+    wsReconnectCount: 0
+  });
+}
+let connectionState = makeConnectionState();
 vi.mock("@/common/stores/connection", () => ({
   useConnectionStore: () => connectionState
 }));
 
 import { useStakingStore } from "./index";
 
-const { captured, BackendApi, subscribeStaking } = hoisted;
-
-function emitStaking(addr: string, response: any) {
-  const handler = captured.onStaking;
-  expect(handler).toBeTruthy();
-  (handler as (addr: string, response: any) => void)(addr, response);
-}
+const { BackendApi, subscribeStaking } = hoisted;
 
 describe("useStakingStore", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.resetAllMocks();
-    captured.onStaking = null;
-    captured.unsubscribe = vi.fn();
-    subscribeStaking.mockImplementation((_addr, cb) => {
-      captured.onStaking = cb;
-      return captured.unsubscribe;
-    });
-    connectionState.walletAddress = null;
-    connectionState.wsReconnectCount = 0;
+    connectionState = makeConnectionState();
     setActivePinia(createPinia());
   });
 
@@ -324,42 +306,6 @@ describe("useStakingStore", () => {
     expect(store.hasPositions).toBe(true);
   });
 
-  it("ws callback partially updates state only when address matches", async () => {
-    BackendApi.getStakingPositions.mockResolvedValueOnce({
-      delegations: [],
-      unbonding: [],
-      rewards: [],
-      total_staked: "0",
-      total_rewards: "0"
-    });
-
-    const store = useStakingStore();
-    await store.setAddress("nolus1x");
-
-    expect(captured.onStaking).not.toBeNull();
-
-    // Mismatched address: ignored
-    emitStaking("nolus1OTHER", {
-      delegations: [{ validator_address: "ignored", shares: "0", balance: { denom: "u", amount: "0" } }]
-    });
-    expect(store.delegations).toEqual([]);
-
-    // Null response: ignored (response is falsy)
-    emitStaking("nolus1x", null);
-    expect(store.delegations).toEqual([]);
-
-    // Matching address + partial response: fields only updated where present
-    emitStaking("nolus1x", {
-      delegations: [{ validator_address: "v1", shares: "1", balance: { denom: "u", amount: "5" } }],
-      total_staked: "5"
-      // rewards, unbonding, total_rewards omitted — should remain at defaults
-    });
-    expect(store.delegations.length).toBe(1);
-    expect(store.totalStaked).toBe("5");
-    expect(store.unbonding).toEqual([]);
-    expect(store.rewards).toEqual([]);
-  });
-
   it("initialize fetches validators and params concurrently", async () => {
     BackendApi.getValidators.mockResolvedValueOnce([]);
     BackendApi.getStakingParams.mockResolvedValueOnce({
@@ -375,7 +321,7 @@ describe("useStakingStore", () => {
     expect(BackendApi.getStakingParams).toHaveBeenCalledTimes(1);
   });
 
-  it("cleanup unsubscribes and resets state", async () => {
+  it("cleanup resets state", async () => {
     BackendApi.getStakingPositions.mockResolvedValueOnce({
       delegations: [{ validator_address: "v1", shares: "1", balance: { denom: "u", amount: "1" } }],
       unbonding: [],
@@ -389,9 +335,46 @@ describe("useStakingStore", () => {
     expect(store.delegations.length).toBe(1);
 
     store.cleanup();
-    expect(captured.unsubscribe).toHaveBeenCalledTimes(1);
     expect(store.address).toBeNull();
     expect(store.delegations).toEqual([]);
     expect(store.totalStaked).toBe("0");
+  });
+
+  it("refetches positions on websocket reconnect while a wallet is connected", async () => {
+    BackendApi.getStakingPositions.mockResolvedValue({
+      delegations: [],
+      unbonding: [],
+      rewards: [],
+      total_staked: "0",
+      total_rewards: "0"
+    });
+
+    connectionState.walletAddress = "nolus1x";
+    useStakingStore();
+    await nextTick();
+    expect(BackendApi.getStakingPositions).toHaveBeenCalledTimes(1);
+
+    connectionState.wsReconnectCount++;
+    await nextTick();
+    expect(BackendApi.getStakingPositions).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not register a websocket subscription for staking", async () => {
+    BackendApi.getStakingPositions.mockResolvedValue({
+      delegations: [],
+      unbonding: [],
+      rewards: [],
+      total_staked: "0",
+      total_rewards: "0"
+    });
+
+    connectionState.walletAddress = "nolus1x";
+    useStakingStore();
+    await nextTick();
+
+    connectionState.wsReconnectCount++;
+    await nextTick();
+
+    expect(subscribeStaking).not.toHaveBeenCalled();
   });
 });

--- a/src/common/stores/staking/index.ts
+++ b/src/common/stores/staking/index.ts
@@ -1,15 +1,14 @@
 /**
  * Staking Store - Validators and staking positions from backend
  *
- * Uses WebSocket for real-time updates on staking positions.
- * Replaces direct Cosmos SDK queries.
+ * Positions load over REST: on wallet connect, on WebSocket reconnect, and
+ * after each staking transaction. Replaces direct Cosmos SDK queries.
  */
 
 import { defineStore } from "pinia";
 import { ref, computed } from "vue";
 import {
   BackendApi,
-  WebSocketClient,
   type ValidatorInfo,
   type StakingPosition,
   type StakingPositionsResponse,
@@ -18,7 +17,6 @@ import {
   type StakingParams
 } from "@/common/api";
 import { useWalletWatcher } from "@/common/composables/useWalletWatcher";
-import { useWebSocketLifecycle } from "@/common/composables/useWebSocketLifecycle";
 
 export const useStakingStore = defineStore("staking", () => {
   // State
@@ -138,31 +136,29 @@ export const useStakingStore = defineStore("staking", () => {
     }
   }
 
-  // WebSocket lifecycle: subscribe, fetch, unsubscribe, cleanup
-  const { setAddress, cleanup } = useWebSocketLifecycle({
-    address,
-    subscribe: (addr) =>
-      WebSocketClient.subscribeStaking(addr, (wsAddr, response) => {
-        if (wsAddr === address.value && response) {
-          if (response.delegations) delegations.value = response.delegations;
-          if (response.unbonding) unbonding.value = response.unbonding;
-          if (response.rewards) rewards.value = response.rewards;
-          if (response.total_staked) totalStaked.value = response.total_staked;
-          if (response.total_rewards) totalRewards.value = response.total_rewards;
-          lastUpdated.value = new Date();
-        }
-      }),
-    fetch: fetchPositions,
-    resetState: () => {
-      delegations.value = [];
-      unbonding.value = [];
-      rewards.value = [];
-      totalStaked.value = "0";
-      totalRewards.value = "0";
-      lastUpdated.value = null;
-      error.value = null;
+  function resetPositions(): void {
+    delegations.value = [];
+    unbonding.value = [];
+    rewards.value = [];
+    totalStaked.value = "0";
+    totalRewards.value = "0";
+    lastUpdated.value = null;
+    error.value = null;
+  }
+
+  async function setAddress(newAddress: string | null): Promise<void> {
+    address.value = newAddress;
+    resetPositions();
+
+    if (newAddress) {
+      await fetchPositions();
     }
-  });
+  }
+
+  function cleanup(): void {
+    address.value = null;
+    resetPositions();
+  }
 
   /**
    * Initialize the store
@@ -171,8 +167,8 @@ export const useStakingStore = defineStore("staking", () => {
     await Promise.all([fetchValidators(), fetchParams()]);
   }
 
-  // Self-register: watch wallet address changes from connectionStore.
-  useWalletWatcher(setAddress, cleanup);
+  // Self-register: watch wallet address changes; refetch on WS reconnect.
+  useWalletWatcher(setAddress, cleanup, fetchPositions);
 
   return {
     // State


### PR DESCRIPTION
## Summary
Remove the dead staking WebSocket seam on both sides and add the missing reconnect refetch. The backend declared `ServerMessage::StakingUpdate` but never constructed it, so the store's subscription never received an event — and staking was the only per-user store without a reconnect refetch, leaving positions stale after a WS drop until page re-init. Positions now load over REST on connect, reconnect, and after each staking transaction. Closes #274.

## Changes
- Staking store: WS subscription/callback removed; `setAddress`/`cleanup` restructured to fetch-only; `fetchPositions` passed as the reconnect callback to `useWalletWatcher` (mirroring balances/leases/earn); docstring rewritten to the actual refresh model.
- `WebSocketClient.ts`: `subscribeStaking`, `StakingUpdateMessage`/`StakingCallback`, the `staking_update` dispatch case, and the `staking` topic removed; dangling api-index re-export dropped.
- Backend: `ServerMessage::StakingUpdate`, `Subscription::Staking`, its parse and `topic_name` arms, the module-doc line, and the staking parse assertions removed. Unknown-topic handling is unchanged: a stale client still subscribing to `staking` gets an `INVALID_SUBSCRIPTION` error message and the connection stays open.
- Post-tx refetch was verified already present in all four staking flows (delegate/undelegate/redelegate/claim each refetch positions and balances after broadcast) — intentionally untouched.

## Verification
- Wrote the reconnect test first and confirmed it failed against the 2-arg store (`expected "spy" to be called 2 times, but got 1`), then green after the fix; added a regression guard asserting no WS subscription is registered for staking.
- Ran the full frontend gate: vue-tsc typecheck, eslint, lint:style, format:check, vitest with coverage (1040 tests), build — all green; staking store at 100% line coverage.
- Ran the full backend gate: cargo fmt --check, clippy -D warnings, style-check.sh, build, cargo test (485 passed) — green; OpenAPI snapshot byte-identical (WS types are not in the REST schema).
- Ran independent correctness, security, and conventions reviews over the branch diff: the 12-item correctness checklist passed on every item; security review returned CLEAR (the change only narrows the WS surface; stale-client compatibility confirmed against the unknown-topic error path); conventions review passed. One informational note carried over: the WS message dispatch switch has no default arm — pre-existing behavior, unchanged here.
- Checked rollout safety in both directions: new backend + old frontend degrades to a logged error only; old backend + new frontend leaves the staking arm unused.