### PR TITLE
feat(backend): balance monitor broadcaster for balances subscription

### DIFF
--- a/backend/src/chain_events.rs
+++ b/backend/src/chain_events.rs
@@ -7,6 +7,7 @@
 //! On disconnect: reconnects with exponential backoff (1s → 30s max).
 //! No timer fallback — data goes stale visibly via `Cached<T>.age_secs()`.
 
+use std::collections::HashSet;
 use std::time::Duration;
 
 use futures::{SinkExt, StreamExt};
@@ -27,6 +28,12 @@ const BLOCK_SILENCE_TIMEOUT: Duration = Duration::from_secs(60);
 /// How often the watchdog ticks to re-evaluate block silence.
 const WATCHDOG_INTERVAL: Duration = Duration::from_secs(10);
 
+/// Nolus fee-collector module account. Every fee-paying tx emits a `transfer`
+/// event crediting this account, so an unfiltered transfer branch would fire on
+/// ~100% of chain txs and flood the channel. Verified live against
+/// `/cosmos/auth/v1beta1/module_accounts/fee_collector`.
+const FEE_COLLECTOR_ADDRESS: &str = "nolus17xpfvakm2amg962yls6f84z3kell8c5lxfnlfc";
+
 /// Pure predicate for the block-silence watchdog — kept outside
 /// `connect_and_listen` so it's trivially unit-testable.
 fn block_silence_exceeded(elapsed: Duration) -> bool {
@@ -45,6 +52,15 @@ pub struct ContractExecEvent {
     pub tx_hash: String,
 }
 
+/// Bank-transfer event extracted from CometBFT Tx events.
+///
+/// One event per tx, carrying the deduped set of all non-fee-collector transfer
+/// participants (recipients and senders) across every `transfer` event in the tx.
+#[derive(Debug, Clone)]
+pub struct BankTransferEvent {
+    pub addresses: Vec<String>,
+}
+
 /// Broadcast channels for dispatching chain events to consumers.
 ///
 /// Uses `tokio::sync::broadcast` so multiple receivers can subscribe independently.
@@ -56,6 +72,9 @@ pub struct EventChannels {
     pub new_block: broadcast::Sender<u64>,
     /// Fires on each wasm contract execution within a transaction.
     pub contract_exec: broadcast::Sender<ContractExecEvent>,
+    /// Fires once per tx that moved bank funds for one or more non-fee-collector
+    /// addresses.
+    pub bank_transfer: broadcast::Sender<BankTransferEvent>,
 }
 
 impl Default for EventChannels {
@@ -68,9 +87,13 @@ impl EventChannels {
     pub fn new() -> Self {
         let (new_block, _) = broadcast::channel(64);
         let (contract_exec, _) = broadcast::channel(256);
+        // Transfer events outnumber wasm events even after fee filtering; per-tx
+        // dedup keeps the message rate ≈ tx rate, with headroom for burst blocks.
+        let (bank_transfer, _) = broadcast::channel(1024);
         Self {
             new_block,
             contract_exec,
+            bank_transfer,
         }
     }
 }
@@ -317,40 +340,67 @@ impl ChainEventClient {
             None => return,
         };
 
+        // Deduped set of all non-fee-collector transfer participants across every
+        // `transfer` event in this tx — dispatched as ONE BankTransferEvent below.
+        let mut transfer_addresses: HashSet<String> = HashSet::new();
+
         for event in events {
-            if event["type"].as_str() != Some("wasm") {
-                continue;
-            }
+            let event_type = event["type"].as_str();
 
-            let attrs = match event["attributes"].as_array() {
-                Some(a) => a,
-                None => continue,
-            };
+            if event_type == Some("wasm") {
+                let attrs = match event["attributes"].as_array() {
+                    Some(a) => a,
+                    None => continue,
+                };
 
-            let mut contract_address = String::new();
-            let mut action = None;
+                let mut contract_address = String::new();
+                let mut action = None;
 
-            for attr in attrs {
-                match attr["key"].as_str() {
-                    Some("contract_address") | Some("_contract_address") => {
+                for attr in attrs {
+                    match attr["key"].as_str() {
+                        Some("contract_address") | Some("_contract_address") => {
+                            if let Some(v) = attr["value"].as_str() {
+                                contract_address = v.to_string();
+                            }
+                        }
+                        Some("action") => {
+                            action = attr["value"].as_str().map(|s| s.to_string());
+                        }
+                        _ => {}
+                    }
+                }
+
+                if !contract_address.is_empty() {
+                    let _ = self.channels.contract_exec.send(ContractExecEvent {
+                        contract_address,
+                        action,
+                        tx_hash: tx_hash.clone(),
+                    });
+                }
+            } else if event_type == Some("transfer") {
+                let attrs = match event["attributes"].as_array() {
+                    Some(a) => a,
+                    None => continue,
+                };
+
+                // A single transfer event can carry repeated recipient/sender/amount
+                // triples (MsgMultiSend) — iterate every attribute, not just the first pair.
+                for attr in attrs {
+                    if let Some("recipient" | "sender") = attr["key"].as_str() {
                         if let Some(v) = attr["value"].as_str() {
-                            contract_address = v.to_string();
+                            if !v.is_empty() && v != FEE_COLLECTOR_ADDRESS {
+                                transfer_addresses.insert(v.to_string());
+                            }
                         }
                     }
-                    Some("action") => {
-                        action = attr["value"].as_str().map(|s| s.to_string());
-                    }
-                    _ => {}
                 }
             }
+        }
 
-            if !contract_address.is_empty() {
-                let _ = self.channels.contract_exec.send(ContractExecEvent {
-                    contract_address,
-                    action,
-                    tx_hash: tx_hash.clone(),
-                });
-            }
+        if !transfer_addresses.is_empty() {
+            let _ = self.channels.bank_transfer.send(BankTransferEvent {
+                addresses: transfer_addresses.into_iter().collect(),
+            });
         }
     }
 }
@@ -798,6 +848,147 @@ mod tests {
         }"#;
 
         client.handle_message(msg);
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// A single transfer event carrying repeated recipient/sender triples
+    /// (MsgMultiSend) yields ONE BankTransferEvent with every participant deduped.
+    #[test]
+    fn test_transfer_event_collects_all_recipients_deduped() {
+        let channels = EventChannels::new();
+        let mut rx = channels.bank_transfer.subscribe();
+        let client = ChainEventClient {
+            ws_url: "wss://test/websocket".to_string(),
+            channels,
+        };
+
+        let msg = r#"{
+            "result": {
+                "query": "tm.event='Tx'",
+                "events": { "tx.hash": ["HASH"] },
+                "data": { "value": { "TxResult": { "result": { "events": [{
+                    "type": "transfer",
+                    "attributes": [
+                        { "key": "recipient", "value": "nolus1a" },
+                        { "key": "sender", "value": "nolus1b" },
+                        { "key": "amount", "value": "100unls" },
+                        { "key": "recipient", "value": "nolus1c" },
+                        { "key": "sender", "value": "nolus1b" },
+                        { "key": "amount", "value": "200unls" }
+                    ]
+                }] } } } }
+            }
+        }"#;
+        client.handle_message(msg);
+
+        let event = rx.try_recv().unwrap();
+        let mut addresses = event.addresses.clone();
+        addresses.sort();
+        assert_eq!(addresses, vec!["nolus1a", "nolus1b", "nolus1c"]);
+        // Exactly one event dispatched for the tx.
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// The fee-collector recipient is filtered out of the participant set; a real
+    /// counterparty in the same transfer still survives.
+    #[test]
+    fn test_transfer_event_filters_fee_collector() {
+        let channels = EventChannels::new();
+        let mut rx = channels.bank_transfer.subscribe();
+        let client = ChainEventClient {
+            ws_url: "wss://test/websocket".to_string(),
+            channels,
+        };
+
+        let msg = r#"{
+            "result": {
+                "query": "tm.event='Tx'",
+                "events": { "tx.hash": ["HASH"] },
+                "data": { "value": { "TxResult": { "result": { "events": [{
+                    "type": "transfer",
+                    "attributes": [
+                        { "key": "recipient", "value": "nolus17xpfvakm2amg962yls6f84z3kell8c5lxfnlfc" },
+                        { "key": "sender", "value": "nolus1payer" },
+                        { "key": "amount", "value": "5unls" }
+                    ]
+                }] } } } }
+            }
+        }"#;
+        client.handle_message(msg);
+
+        let event = rx.try_recv().unwrap();
+        assert_eq!(event.addresses, vec!["nolus1payer".to_string()]);
+        // Guard: the fixture's filtered recipient must match the production constant.
+        assert_eq!(
+            FEE_COLLECTOR_ADDRESS,
+            "nolus17xpfvakm2amg962yls6f84z3kell8c5lxfnlfc"
+        );
+    }
+
+    /// Several transfer events within one tx collapse into a single deduped
+    /// BankTransferEvent.
+    #[test]
+    fn test_multiple_transfer_events_dedup_into_one() {
+        let channels = EventChannels::new();
+        let mut rx = channels.bank_transfer.subscribe();
+        let client = ChainEventClient {
+            ws_url: "wss://test/websocket".to_string(),
+            channels,
+        };
+
+        let msg = r#"{
+            "result": {
+                "query": "tm.event='Tx'",
+                "events": { "tx.hash": ["HASH"] },
+                "data": { "value": { "TxResult": { "result": { "events": [
+                    {"type":"transfer","attributes":[
+                        {"key":"recipient","value":"nolus1a"},
+                        {"key":"sender","value":"nolus1b"}
+                    ]},
+                    {"type":"transfer","attributes":[
+                        {"key":"recipient","value":"nolus1a"},
+                        {"key":"sender","value":"nolus1c"}
+                    ]}
+                ] } } } }
+            }
+        }"#;
+        client.handle_message(msg);
+
+        let event = rx.try_recv().unwrap();
+        let mut addresses = event.addresses.clone();
+        addresses.sort();
+        assert_eq!(addresses, vec!["nolus1a", "nolus1b", "nolus1c"]);
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// A tx whose only transfer participants are the fee collector dispatches
+    /// nothing — the whole surviving set is empty.
+    #[test]
+    fn test_fee_collector_only_transfers_dispatch_nothing() {
+        let channels = EventChannels::new();
+        let mut rx = channels.bank_transfer.subscribe();
+        let client = ChainEventClient {
+            ws_url: "wss://test/websocket".to_string(),
+            channels,
+        };
+
+        let msg = r#"{
+            "result": {
+                "query": "tm.event='Tx'",
+                "events": { "tx.hash": ["HASH"] },
+                "data": { "value": { "TxResult": { "result": { "events": [
+                    {"type":"transfer","attributes":[
+                        {"key":"recipient","value":"nolus17xpfvakm2amg962yls6f84z3kell8c5lxfnlfc"},
+                        {"key":"sender","value":"nolus17xpfvakm2amg962yls6f84z3kell8c5lxfnlfc"}
+                    ]},
+                    {"type":"transfer","attributes":[
+                        {"key":"recipient","value":"nolus17xpfvakm2amg962yls6f84z3kell8c5lxfnlfc"}
+                    ]}
+                ] } } } }
+            }
+        }"#;
+        client.handle_message(msg);
+
         assert!(rx.try_recv().is_err());
     }
 }

--- a/backend/src/external/chain.rs
+++ b/backend/src/external/chain.rs
@@ -315,7 +315,12 @@ impl ChainClient {
 
     /// Query all bank balances for an address
     pub async fn get_all_balances(&self, address: &str) -> Result<Vec<BankBalance>, AppError> {
-        let url = format!("{}/cosmos/bank/v1beta1/balances/{}", self.rest_url, address);
+        // Valid bech32 is unaffected; prevents path-steering if any caller ever passes an unvalidated string.
+        let encoded_address = urlencoding::encode(address);
+        let url = format!(
+            "{}/cosmos/bank/v1beta1/balances/{}",
+            self.rest_url, encoded_address
+        );
 
         let response = self.chain_get(&url).await?;
 

--- a/backend/src/handlers/currencies.rs
+++ b/backend/src/handlers/currencies.rs
@@ -84,12 +84,15 @@ pub struct BalanceInfo {
 
 /// Why balance computation could not produce a payload.
 ///
-/// Lets the balance monitor skip a cold-cache tick silently while the REST
-/// handler surfaces the wrapped 503/chain error verbatim.
+/// Lets the balance monitor skip such a tick silently while the REST handler
+/// surfaces the wrapped error verbatim.
 pub enum BalancesError {
     /// A required cache (filter context, currencies, or prices) is not yet warm.
     /// Carries the 503 the REST handler returns unchanged.
     Unavailable(AppError),
+    /// The address failed validation. Carries the 400 the REST handler returns
+    /// unchanged.
+    Validation(AppError),
     /// The chain balance query (or another downstream call) failed.
     Chain(AppError),
 }
@@ -210,7 +213,9 @@ pub async fn get_balances(
 
     match compute_balances(&state, &query.address).await {
         Ok(response) => Ok(Json(response)),
-        Err(BalancesError::Unavailable(e) | BalancesError::Chain(e)) => Err(e),
+        Err(
+            BalancesError::Unavailable(e) | BalancesError::Validation(e) | BalancesError::Chain(e),
+        ) => Err(e),
     }
 }
 
@@ -224,7 +229,7 @@ pub async fn compute_balances(
     address: &str,
 ) -> Result<BalancesResponse, BalancesError> {
     if !crate::validation::is_valid_nolus_address(address) {
-        return Err(BalancesError::Unavailable(AppError::Validation {
+        return Err(BalancesError::Validation(AppError::Validation {
             message: "Invalid Nolus address format".to_string(),
             field: Some("address".to_string()),
             details: None,
@@ -378,12 +383,12 @@ mod tests {
             .await
             .unwrap_err();
         match err {
-            super::BalancesError::Unavailable(crate::error::AppError::Validation {
+            super::BalancesError::Validation(crate::error::AppError::Validation {
                 field, ..
             }) => {
                 assert_eq!(field, Some("address".to_string()));
             }
-            _ => panic!("expected Unavailable(Validation) for an invalid address"),
+            _ => panic!("expected Validation for an invalid address"),
         }
     }
 }

--- a/backend/src/handlers/currencies.rs
+++ b/backend/src/handlers/currencies.rs
@@ -72,7 +72,7 @@ pub struct BalancesResponse {
     pub total_value_usd: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct BalanceInfo {
     pub key: String,
     pub symbol: String,
@@ -80,6 +80,18 @@ pub struct BalanceInfo {
     pub amount: String,
     pub amount_usd: String,
     pub decimal_digits: u8,
+}
+
+/// Why balance computation could not produce a payload.
+///
+/// Lets the balance monitor skip a cold-cache tick silently while the REST
+/// handler surfaces the wrapped 503/chain error verbatim.
+pub enum BalancesError {
+    /// A required cache (filter context, currencies, or prices) is not yet warm.
+    /// Carries the 503 the REST handler returns unchanged.
+    Unavailable(AppError),
+    /// The chain balance query (or another downstream call) failed.
+    Chain(AppError),
 }
 
 /// List all currencies
@@ -196,21 +208,44 @@ pub async fn get_balances(
         });
     }
 
-    // Read filter context from cache
+    match compute_balances(&state, &query.address).await {
+        Ok(response) => Ok(Json(response)),
+        Err(BalancesError::Unavailable(e) | BalancesError::Chain(e)) => Err(e),
+    }
+}
+
+/// Compute visible balances and their aggregate USD value for an address.
+///
+/// Shared by the REST balances handler and the WebSocket balance monitor. Cold
+/// caches surface as `BalancesError::Unavailable` (503 for REST, skip for the
+/// monitor); chain failures surface as `BalancesError::Chain`.
+pub async fn compute_balances(
+    state: &AppState,
+    address: &str,
+) -> Result<BalancesResponse, BalancesError> {
     let filter_ctx = state
         .data_cache
         .filter_context
-        .load_or_unavailable("Filter context")?;
+        .load_or_unavailable("Filter context")
+        .map_err(BalancesError::Unavailable)?;
 
-    // Read currencies and prices from cache, fetch balances from chain
     let currencies_response = state
         .data_cache
         .currencies
-        .load_or_unavailable("Currencies")?;
+        .load_or_unavailable("Currencies")
+        .map_err(BalancesError::Unavailable)?;
 
-    let prices_response = state.data_cache.prices.load_or_unavailable("Prices")?;
+    let prices_response = state
+        .data_cache
+        .prices
+        .load_or_unavailable("Prices")
+        .map_err(BalancesError::Unavailable)?;
 
-    let bank_balances = state.chain_client.get_all_balances(&query.address).await?;
+    let bank_balances = state
+        .chain_client
+        .get_all_balances(address)
+        .await
+        .map_err(BalancesError::Chain)?;
     let prices = &prices_response.prices;
 
     let mut balances = Vec::new();
@@ -260,10 +295,10 @@ pub async fn get_balances(
         // Note: Unknown denoms are now excluded (gated by default)
     }
 
-    Ok(Json(BalancesResponse {
+    Ok(BalancesResponse {
         balances,
         total_value_usd: total_usd.to_string(),
-    }))
+    })
 }
 
 /// Calculate price with LPN base and decimal adjustment

--- a/backend/src/handlers/currencies.rs
+++ b/backend/src/handlers/currencies.rs
@@ -223,6 +223,14 @@ pub async fn compute_balances(
     state: &AppState,
     address: &str,
 ) -> Result<BalancesResponse, BalancesError> {
+    if !crate::validation::is_valid_nolus_address(address) {
+        return Err(BalancesError::Unavailable(AppError::Validation {
+            message: "Invalid Nolus address format".to_string(),
+            field: Some("address".to_string()),
+            details: None,
+        }));
+    }
+
     let filter_ctx = state
         .data_cache
         .filter_context
@@ -359,5 +367,23 @@ mod tests {
 
         // Zero amount should return "0"
         assert_eq!(calculate_price_with_decimals("100", "0", "1.0", 8, 6), "0");
+    }
+
+    /// An invalid address is rejected before any cache or chain access, as the
+    /// 400-mapped `Validation` error the REST balances handler already returns.
+    #[tokio::test]
+    async fn test_compute_balances_rejects_invalid_address() {
+        let state = crate::test_utils::test_app_state().await;
+        let err = super::compute_balances(&state, "not-a-valid-address")
+            .await
+            .unwrap_err();
+        match err {
+            super::BalancesError::Unavailable(crate::error::AppError::Validation {
+                field, ..
+            }) => {
+                assert_eq!(field, Some("address".to_string()));
+            }
+            _ => panic!("expected Unavailable(Validation) for an invalid address"),
+        }
     }
 }

--- a/backend/src/handlers/websocket.rs
+++ b/backend/src/handlers/websocket.rs
@@ -26,6 +26,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
+use crate::handlers::currencies;
 use crate::AppState;
 
 // ============================================================================
@@ -69,7 +70,8 @@ pub enum ServerMessage {
     BalanceUpdate {
         chain: String,
         address: String,
-        balances: Vec<BalanceInfo>,
+        balances: Vec<currencies::BalanceInfo>,
+        total_value_usd: String,
         timestamp: String,
     },
     /// Lease update
@@ -115,12 +117,6 @@ pub enum TxStatusValue {
     Pending,
     Success,
     Failed,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BalanceInfo {
-    pub denom: String,
-    pub amount: String,
 }
 
 // ============================================================================
@@ -298,6 +294,10 @@ pub struct WebSocketManager {
     skip_tx_states: DashMap<String, CachedSkipTxState>,
     /// Cached earn states for change detection (address -> state)
     earn_states: DashMap<String, CachedEarnState>,
+    /// Cached on-chain balances for change detection (address -> sorted (denom, amount) pairs).
+    /// Deliberately excludes USD-derived fields: amount_usd wiggles with price
+    /// refreshes, so comparing it would produce spurious pushes.
+    balance_states: DashMap<String, Vec<(String, String)>>,
     /// Reverse index: lease contract address -> owner address (for targeted event handling)
     lease_address_to_owner: DashMap<String, String>,
     /// Known LPP contract addresses (for filtering earn-relevant contract events)
@@ -313,6 +313,7 @@ impl WebSocketManager {
             lease_states: DashMap::new(),
             skip_tx_states: DashMap::new(),
             earn_states: DashMap::new(),
+            balance_states: DashMap::new(),
             lease_address_to_owner: DashMap::new(),
             lpp_contract_addresses: DashSet::new(),
         }
@@ -355,11 +356,18 @@ impl WebSocketManager {
     }
 
     /// Send balance update to relevant subscribers
-    pub fn send_balance_update(&self, chain: &str, address: &str, balances: Vec<BalanceInfo>) {
+    pub fn send_balance_update(
+        &self,
+        chain: &str,
+        address: &str,
+        balances: Vec<currencies::BalanceInfo>,
+        total_value_usd: String,
+    ) {
         let msg = Arc::new(ServerMessage::BalanceUpdate {
             chain: chain.to_string(),
             address: address.to_string(),
             balances,
+            total_value_usd,
             timestamp: chrono::Utc::now().to_rfc3339(),
         });
 
@@ -473,6 +481,15 @@ impl WebSocketManager {
                         ) =>
                     {
                         self.clear_earn_cache(address);
+                    }
+                    Subscription::Balances { addresses } => {
+                        for address in addresses {
+                            if !self.has_other_subscriber(|s| {
+                                matches!(s, Subscription::Balances { addresses: a } if a.contains(address))
+                            }) {
+                                self.clear_balance_cache(address);
+                            }
+                        }
                     }
                     Subscription::SkipTx { tx_hash, .. }
                         if !self.has_other_subscriber(|s| {
@@ -725,6 +742,56 @@ impl WebSocketManager {
                 }
             }
         }
+    }
+
+    // =========================================================================
+    // Balance Tracking
+    // =========================================================================
+
+    /// Get all unique addresses that have balance subscriptions.
+    pub fn get_subscribed_balance_addresses(&self) -> Vec<String> {
+        let mut addresses = HashSet::new();
+        for entry in self.connections.iter() {
+            for sub in &entry.value().subscriptions {
+                if let Subscription::Balances { addresses: subs } = sub {
+                    for a in subs {
+                        addresses.insert(a.clone());
+                    }
+                }
+            }
+        }
+        addresses.into_iter().collect()
+    }
+
+    /// Update cached on-chain balances and return true if the (denom, amount)
+    /// set changed. USD-derived fields are intentionally ignored: the same
+    /// holdings under different prices must NOT report a change.
+    pub fn update_balance_state(
+        &self,
+        address: &str,
+        balances: &[currencies::BalanceInfo],
+    ) -> bool {
+        let mut new_state: Vec<(String, String)> = balances
+            .iter()
+            .map(|b| (b.denom.clone(), b.amount.clone()))
+            .collect();
+        new_state.sort();
+
+        let changed = match self.balance_states.get(address) {
+            Some(old) => *old != new_state,
+            None => true,
+        };
+
+        if changed {
+            self.balance_states.insert(address.to_string(), new_state);
+        }
+
+        changed
+    }
+
+    /// Clear balance cache for an address (when they unsubscribe).
+    pub fn clear_balance_cache(&self, address: &str) {
+        self.balance_states.remove(address);
     }
 
     // =========================================================================
@@ -1586,6 +1653,156 @@ async fn check_earn_positions(state: &AppState, address: &str) -> Result<(), Str
     Ok(())
 }
 
+// ============================================================================
+// Balance Monitoring Task
+// ============================================================================
+
+/// Concurrency cap for the balance monitor's per-address chain fan-out — the
+/// house refresh-fan-out bound, kept off the shared chain-query semaphore.
+const BALANCE_MONITOR_FANOUT_CAP: usize = 8;
+
+/// Outcome of evaluating one address in a balance-monitor flush.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BalanceFlushOutcome {
+    Pushed,
+    Unchanged,
+    SkippedUnavailable,
+}
+
+/// Change-detect a freshly computed balance payload and push it to subscribers
+/// only if the on-chain holdings changed. Kept synchronous and independent of the
+/// chain client so the skip-on-unavailable branch is unit-testable in isolation.
+fn process_balance_compute(
+    manager: &WebSocketManager,
+    address: &str,
+    computed: Result<currencies::BalancesResponse, currencies::BalancesError>,
+) -> BalanceFlushOutcome {
+    match computed {
+        Ok(response) => {
+            if manager.update_balance_state(address, &response.balances) {
+                manager.send_balance_update(
+                    "nolus",
+                    address,
+                    response.balances,
+                    response.total_value_usd,
+                );
+                BalanceFlushOutcome::Pushed
+            } else {
+                BalanceFlushOutcome::Unchanged
+            }
+        }
+        // Push exactly what REST would serve; never a payload REST would have 503'd.
+        Err(currencies::BalancesError::Unavailable(_)) => BalanceFlushOutcome::SkippedUnavailable,
+        Err(currencies::BalancesError::Chain(e)) => {
+            debug!("Balance monitor chain query failed for {}: {}", address, e);
+            BalanceFlushOutcome::SkippedUnavailable
+        }
+    }
+}
+
+/// Start background task for balance monitoring, triggered by bank-transfer events.
+///
+/// Accumulates each tx's transfer participants, debounces, intersects with
+/// subscribed balance addresses, re-queries via the shared REST compute, and
+/// pushes on change. No periodic sweep — REST covers in-app actions.
+pub async fn start_balance_monitor_task(
+    state: Arc<AppState>,
+    mut bank_transfer_rx: tokio::sync::broadcast::Receiver<crate::chain_events::BankTransferEvent>,
+) {
+    tokio::spawn(async move {
+        loop {
+            let mut candidate_addresses: HashSet<String> = HashSet::new();
+            let mut do_full_recheck = false;
+
+            // Block until the first transfer event (or a lag signal).
+            match bank_transfer_rx.recv().await {
+                Ok(event) => candidate_addresses.extend(event.addresses),
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(
+                        "Balance monitor lagged {} events, re-checking all subscribed balance addresses",
+                        n
+                    );
+                    do_full_recheck = true;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    error!("Bank transfer channel closed, balance monitor stopping");
+                    return;
+                }
+            }
+
+            if !do_full_recheck {
+                // Balances tolerate 10s staleness; REST covers in-app actions.
+                let debounce = tokio::time::sleep(Duration::from_secs(10));
+                tokio::pin!(debounce);
+                loop {
+                    tokio::select! {
+                        _ = &mut debounce => break,
+                        result = bank_transfer_rx.recv() => {
+                            match result {
+                                Ok(event) => {
+                                    candidate_addresses.extend(event.addresses);
+                                    continue;
+                                }
+                                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                                    do_full_recheck = true;
+                                    break;
+                                }
+                                Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+                            }
+                        }
+                    }
+                }
+            }
+
+            let subscribed = state.ws_manager.get_subscribed_balance_addresses();
+            let addresses_to_check: Vec<String> = if do_full_recheck {
+                subscribed
+            } else {
+                let subscribed_set: HashSet<String> = subscribed.into_iter().collect();
+                candidate_addresses
+                    .into_iter()
+                    .filter(|a| subscribed_set.contains(a))
+                    .collect()
+            };
+
+            if addresses_to_check.is_empty() {
+                continue;
+            }
+
+            let pending = addresses_to_check.len();
+            let outcomes: Vec<BalanceFlushOutcome> = futures::stream::iter(addresses_to_check)
+                .map(|address| {
+                    let state = state.clone();
+                    async move {
+                        let computed = currencies::compute_balances(&state, &address).await;
+                        process_balance_compute(&state.ws_manager, &address, computed)
+                    }
+                })
+                .buffer_unordered(BALANCE_MONITOR_FANOUT_CAP)
+                .collect()
+                .await;
+
+            let pushed = outcomes
+                .iter()
+                .filter(|&&o| o == BalanceFlushOutcome::Pushed)
+                .count();
+            let unchanged = outcomes
+                .iter()
+                .filter(|&&o| o == BalanceFlushOutcome::Unchanged)
+                .count();
+            let unavailable = outcomes
+                .iter()
+                .filter(|&&o| o == BalanceFlushOutcome::SkippedUnavailable)
+                .count();
+
+            info!(
+                "Balance monitor flush: pending={} pushed={} unchanged={} unavailable={}",
+                pending, pushed, unchanged, unavailable
+            );
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1811,6 +2028,18 @@ mod tests {
         rx
     }
 
+    /// Build a `currencies::BalanceInfo` fixture for balance-monitor tests.
+    fn sample_balance(denom: &str, amount: &str, amount_usd: &str) -> currencies::BalanceInfo {
+        currencies::BalanceInfo {
+            key: format!("{denom}@NOLUS"),
+            symbol: denom.to_uppercase(),
+            denom: denom.to_string(),
+            amount: amount.to_string(),
+            amount_usd: amount_usd.to_string(),
+            decimal_digits: 6,
+        }
+    }
+
     #[tokio::test]
     async fn test_manager_add_and_remove_connection() {
         let m = WebSocketManager::new(5);
@@ -1930,15 +2159,23 @@ mod tests {
         m.send_balance_update(
             "nolus",
             "nolus1alice",
-            vec![BalanceInfo {
-                denom: "unls".to_string(),
-                amount: "100".to_string(),
-            }],
+            vec![sample_balance("unls", "100", "15")],
+            "0.15".to_string(),
         );
 
         let msg = rx_alice.try_recv().unwrap();
         match &*msg {
-            ServerMessage::BalanceUpdate { address, .. } => assert_eq!(address, "nolus1alice"),
+            ServerMessage::BalanceUpdate {
+                address,
+                balances,
+                total_value_usd,
+                ..
+            } => {
+                assert_eq!(address, "nolus1alice");
+                assert_eq!(balances.len(), 1);
+                assert_eq!(balances[0].denom, "unls");
+                assert_eq!(total_value_usd, "0.15");
+            }
             _ => panic!("expected BalanceUpdate"),
         }
         assert!(rx_bob.try_recv().is_err());
@@ -2276,6 +2513,212 @@ mod tests {
         let mut changed = st.clone();
         changed.positions[0].rewards = "6".to_string();
         assert!(m.update_earn_state("alice", changed));
+    }
+
+    // ------------------------------------------------------------------
+    // Balance monitoring
+    // ------------------------------------------------------------------
+
+    /// get_subscribed_balance_addresses flattens per-subscription address Vecs
+    /// and dedups across connections.
+    #[tokio::test]
+    async fn test_get_subscribed_balance_addresses_dedupes() {
+        let m = WebSocketManager::new(16);
+        let _r1 = register_conn(&m, "c1");
+        let _r2 = register_conn(&m, "c2");
+
+        m.add_subscription(
+            "c1",
+            Subscription::Balances {
+                addresses: vec!["shared".to_string(), "a".to_string()],
+            },
+        )
+        .unwrap();
+        m.add_subscription(
+            "c2",
+            Subscription::Balances {
+                addresses: vec!["shared".to_string(), "b".to_string()],
+            },
+        )
+        .unwrap();
+
+        let mut got = m.get_subscribed_balance_addresses();
+        got.sort();
+        assert_eq!(
+            got,
+            vec!["a".to_string(), "b".to_string(), "shared".to_string()]
+        );
+    }
+
+    /// update_balance_state keys change detection on (denom, amount) ONLY — the
+    /// same holdings under a different price must NOT report a change.
+    #[tokio::test]
+    async fn test_update_balance_state_change_detection() {
+        let m = WebSocketManager::new(16);
+
+        // First insert → change.
+        assert!(m.update_balance_state("alice", &[sample_balance("unls", "100", "15")]));
+        // Identical → no change.
+        assert!(!m.update_balance_state("alice", &[sample_balance("unls", "100", "15")]));
+        // Same (denom, amount), different USD → still no change.
+        assert!(!m.update_balance_state("alice", &[sample_balance("unls", "100", "999")]));
+        // Amount changed → change.
+        assert!(m.update_balance_state("alice", &[sample_balance("unls", "101", "15")]));
+        // Order-independent: reordering the same set is not a change.
+        assert!(m.update_balance_state(
+            "alice",
+            &[
+                sample_balance("unls", "101", "15"),
+                sample_balance("uusdc", "5", "5"),
+            ],
+        ));
+        assert!(!m.update_balance_state(
+            "alice",
+            &[
+                sample_balance("uusdc", "5", "5"),
+                sample_balance("unls", "101", "15"),
+            ],
+        ));
+    }
+
+    /// process_balance_compute pushes only on a real (denom, amount) change and
+    /// reports Unchanged when only the USD value moved.
+    #[tokio::test]
+    async fn test_process_balance_compute_pushes_on_change_only() {
+        let m = WebSocketManager::new(16);
+        let mut rx = register_conn(&m, "c1");
+        m.add_subscription(
+            "c1",
+            Subscription::Balances {
+                addresses: vec!["nolus1a".to_string()],
+            },
+        )
+        .unwrap();
+
+        let response = currencies::BalancesResponse {
+            balances: vec![sample_balance("unls", "100", "15")],
+            total_value_usd: "15".to_string(),
+        };
+        assert_eq!(
+            process_balance_compute(&m, "nolus1a", Ok(response)),
+            BalanceFlushOutcome::Pushed
+        );
+        let msg = rx.try_recv().unwrap();
+        match &*msg {
+            ServerMessage::BalanceUpdate {
+                address,
+                total_value_usd,
+                ..
+            } => {
+                assert_eq!(address, "nolus1a");
+                assert_eq!(total_value_usd, "15");
+            }
+            _ => panic!("expected BalanceUpdate"),
+        }
+
+        // Same (denom, amount), only USD moved → Unchanged, no second push.
+        let response_reprice = currencies::BalancesResponse {
+            balances: vec![sample_balance("unls", "100", "999")],
+            total_value_usd: "999".to_string(),
+        };
+        assert_eq!(
+            process_balance_compute(&m, "nolus1a", Ok(response_reprice)),
+            BalanceFlushOutcome::Unchanged
+        );
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// A cold-cache compute result skips the push entirely and leaves the cache
+    /// untouched — exercisable without a live chain client.
+    #[tokio::test]
+    async fn test_process_balance_compute_skips_on_unavailable() {
+        let m = WebSocketManager::new(16);
+        let mut rx = register_conn(&m, "c1");
+        m.add_subscription(
+            "c1",
+            Subscription::Balances {
+                addresses: vec!["nolus1a".to_string()],
+            },
+        )
+        .unwrap();
+
+        let unavailable = Err(currencies::BalancesError::Unavailable(
+            crate::error::AppError::ServiceUnavailable {
+                message: "Prices not yet available".to_string(),
+            },
+        ));
+        assert_eq!(
+            process_balance_compute(&m, "nolus1a", unavailable),
+            BalanceFlushOutcome::SkippedUnavailable
+        );
+        // Nothing pushed to the subscriber.
+        assert!(rx.try_recv().is_err());
+        // Cache untouched: a subsequent first real compute still registers a change.
+        assert!(m.update_balance_state("nolus1a", &[sample_balance("unls", "1", "0")]));
+    }
+
+    /// A chain failure also skips the push and leaves the cache untouched.
+    #[tokio::test]
+    async fn test_process_balance_compute_skips_on_chain_error() {
+        let m = WebSocketManager::new(16);
+        let mut rx = register_conn(&m, "c1");
+        m.add_subscription(
+            "c1",
+            Subscription::Balances {
+                addresses: vec!["nolus1a".to_string()],
+            },
+        )
+        .unwrap();
+
+        let chain_err = Err(currencies::BalancesError::Chain(
+            crate::error::AppError::ChainRpc {
+                chain: "nolus".to_string(),
+                message: "HTTP 502".to_string(),
+            },
+        ));
+        assert_eq!(
+            process_balance_compute(&m, "nolus1a", chain_err),
+            BalanceFlushOutcome::SkippedUnavailable
+        );
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// Balance cache is cleared when the last subscriber for an address
+    /// disconnects, mirroring the earn/lease cleanup.
+    #[tokio::test]
+    async fn test_remove_connection_cleans_up_balance_cache() {
+        let m = WebSocketManager::new(16);
+        let _rx = register_conn(&m, "c1");
+        m.add_subscription(
+            "c1",
+            Subscription::Balances {
+                addresses: vec!["nolus1a".to_string()],
+            },
+        )
+        .unwrap();
+        m.update_balance_state("nolus1a", &[sample_balance("unls", "1", "0")]);
+        assert!(m.balance_states.get("nolus1a").is_some());
+
+        m.remove_connection("c1");
+        assert!(m.balance_states.get("nolus1a").is_none());
+    }
+
+    /// When another connection still subscribes the same address, its balance
+    /// cache survives one subscriber disconnecting.
+    #[tokio::test]
+    async fn test_remove_connection_preserves_balance_cache_with_other_subscriber() {
+        let m = WebSocketManager::new(16);
+        let _rx1 = register_conn(&m, "c1");
+        let _rx2 = register_conn(&m, "c2");
+        let sub = Subscription::Balances {
+            addresses: vec!["nolus1a".to_string()],
+        };
+        m.add_subscription("c1", sub.clone()).unwrap();
+        m.add_subscription("c2", sub).unwrap();
+        m.update_balance_state("nolus1a", &[sample_balance("unls", "1", "0")]);
+
+        m.remove_connection("c1");
+        assert!(m.balance_states.get("nolus1a").is_some());
     }
 
     /// `remove_connection` cleans up the skip_tx state cache when no other

--- a/backend/src/handlers/websocket.rs
+++ b/backend/src/handlers/websocket.rs
@@ -147,7 +147,10 @@ impl Subscription {
         match topic {
             "prices" => Ok(Subscription::Prices),
             "balance" | "balances" => {
-                let addresses = params
+                // Frontend sends exactly one; the cap bounds monitor fan-out per subscription.
+                const MAX_ADDRESSES_PER_BALANCE_SUBSCRIPTION: usize = 16;
+
+                let addresses: Vec<String> = params
                     .get("addresses")
                     .and_then(|v| v.as_array())
                     .map(|arr| {
@@ -162,6 +165,25 @@ impl Subscription {
                             .map(|s| vec![s.to_string()])
                     })
                     .ok_or("Missing 'addresses' or 'address' parameter")?;
+
+                if addresses.is_empty() {
+                    return Err("Balance subscription requires at least one address".to_string());
+                }
+                if addresses.len() > MAX_ADDRESSES_PER_BALANCE_SUBSCRIPTION {
+                    return Err(format!(
+                        "Balance subscription exceeds the maximum of {} addresses",
+                        MAX_ADDRESSES_PER_BALANCE_SUBSCRIPTION
+                    ));
+                }
+                if !addresses
+                    .iter()
+                    .all(|a| crate::validation::is_valid_nolus_address(a))
+                {
+                    return Err(
+                        "Balance subscription contains an invalid Nolus address".to_string()
+                    );
+                }
+
                 Ok(Subscription::Balances { addresses })
             }
             "lease" | "leases" => {
@@ -1661,6 +1683,19 @@ async fn check_earn_positions(state: &AppState, address: &str) -> Result<(), Str
 /// house refresh-fan-out bound, kept off the shared chain-query semaphore.
 const BALANCE_MONITOR_FANOUT_CAP: usize = 8;
 
+/// Minimum gap between Lagged-driven full rechecks, so a burst of lag signals
+/// cannot translate into back-to-back full fan-outs over every subscriber.
+const LAG_RECHECK_MIN_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Whether a Lagged signal may trigger a full recheck, given when the last one
+/// ran. `None` means none has run yet, so a full recheck is always allowed.
+fn lag_recheck_allowed(last_full_recheck: Option<Instant>, now: Instant) -> bool {
+    match last_full_recheck {
+        Some(prev) => now.duration_since(prev) >= LAG_RECHECK_MIN_INTERVAL,
+        None => true,
+    }
+}
+
 /// Outcome of evaluating one address in a balance-monitor flush.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BalanceFlushOutcome {
@@ -1700,29 +1735,41 @@ fn process_balance_compute(
     }
 }
 
-/// Start background task for balance monitoring, triggered by bank-transfer events.
+/// Background task that pushes balance updates to subscribed connections.
 ///
-/// Accumulates each tx's transfer participants, debounces, intersects with
-/// subscribed balance addresses, re-queries via the shared REST compute, and
-/// pushes on change. No periodic sweep — REST covers in-app actions.
+/// Guarantees a subscribed address receives a full REST-shaped balance payload
+/// whenever its on-chain holdings change, and nothing when the address is
+/// unchanged or the underlying caches are cold — the monitor only ever emits
+/// what the REST balances endpoint would serve, never a payload REST would 503.
 pub async fn start_balance_monitor_task(
     state: Arc<AppState>,
     mut bank_transfer_rx: tokio::sync::broadcast::Receiver<crate::chain_events::BankTransferEvent>,
 ) {
     tokio::spawn(async move {
+        let mut last_full_recheck: Option<Instant> = None;
+
         loop {
             let mut candidate_addresses: HashSet<String> = HashSet::new();
             let mut do_full_recheck = false;
 
-            // Block until the first transfer event (or a lag signal).
             match bank_transfer_rx.recv().await {
                 Ok(event) => candidate_addresses.extend(event.addresses),
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(
-                        "Balance monitor lagged {} events, re-checking all subscribed balance addresses",
-                        n
-                    );
-                    do_full_recheck = true;
+                    let now = Instant::now();
+                    if lag_recheck_allowed(last_full_recheck, now) {
+                        warn!(
+                            "Balance monitor lagged {} events, re-checking all subscribed balance addresses",
+                            n
+                        );
+                        do_full_recheck = true;
+                        last_full_recheck = Some(now);
+                    } else {
+                        warn!(
+                            "Balance monitor lagged {} events within {}s of the last full recheck; suppressed, processing pending addresses only",
+                            n,
+                            LAG_RECHECK_MIN_INTERVAL.as_secs()
+                        );
+                    }
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                     error!("Bank transfer channel closed, balance monitor stopping");
@@ -1743,8 +1790,18 @@ pub async fn start_balance_monitor_task(
                                     candidate_addresses.extend(event.addresses);
                                     continue;
                                 }
-                                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                                    do_full_recheck = true;
+                                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                                    let now = Instant::now();
+                                    if lag_recheck_allowed(last_full_recheck, now) {
+                                        do_full_recheck = true;
+                                        last_full_recheck = Some(now);
+                                    } else {
+                                        warn!(
+                                            "Balance monitor lagged {} events during debounce within {}s of the last full recheck; suppressed",
+                                            n,
+                                            LAG_RECHECK_MIN_INTERVAL.as_secs()
+                                        );
+                                    }
                                     break;
                                 }
                                 Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
@@ -1818,7 +1875,10 @@ mod tests {
         // Balances with array
         let sub = Subscription::from_client_message(
             "balances",
-            &serde_json::json!({"addresses": ["nolus1abc", "nolus1def"]}),
+            &serde_json::json!({"addresses": [
+                "nolus17xpfvakm2amg962yls6f84z3kell8c5lxfnlfc",
+                "nolus1qg5ega6dykkxc307y25pecuufrjkxkaggkkxh7nad0vhyhtuhw3sqaa3c5"
+            ]}),
         )
         .unwrap();
         assert!(matches!(sub, Subscription::Balances { addresses } if addresses.len() == 2));
@@ -1826,7 +1886,7 @@ mod tests {
         // Balance with single address
         let sub = Subscription::from_client_message(
             "balance",
-            &serde_json::json!({"address": "nolus1abc"}),
+            &serde_json::json!({"address": "nolus17xpfvakm2amg962yls6f84z3kell8c5lxfnlfc"}),
         )
         .unwrap();
         assert!(matches!(sub, Subscription::Balances { addresses } if addresses.len() == 1));
@@ -1859,6 +1919,51 @@ mod tests {
         assert!(Subscription::from_client_message("balances", &serde_json::json!({})).is_err());
         assert!(Subscription::from_client_message("leases", &serde_json::json!({})).is_err());
         assert!(Subscription::from_client_message("tx_status", &serde_json::json!({})).is_err());
+    }
+
+    /// Balance subscription parse arm caps and validates its address list:
+    /// a single valid address is accepted; empty, oversized, and invalid lists
+    /// are rejected before a subscription is ever created.
+    #[test]
+    fn test_balance_subscription_validation() {
+        let valid = "nolus17xpfvakm2amg962yls6f84z3kell8c5lxfnlfc";
+
+        let sub =
+            Subscription::from_client_message("balance", &serde_json::json!({ "address": valid }))
+                .unwrap();
+        assert!(matches!(sub, Subscription::Balances { addresses } if addresses.len() == 1));
+
+        assert!(Subscription::from_client_message(
+            "balances",
+            &serde_json::json!({ "addresses": [] })
+        )
+        .is_err());
+
+        let oversized = vec![valid; 17];
+        assert!(Subscription::from_client_message(
+            "balances",
+            &serde_json::json!({ "addresses": oversized })
+        )
+        .is_err());
+
+        assert!(Subscription::from_client_message(
+            "balances",
+            &serde_json::json!({ "addresses": ["not-a-valid-address"] })
+        )
+        .is_err());
+    }
+
+    /// The lag-backoff gate allows the first full recheck, suppresses a second
+    /// within the window, and re-allows once the window has elapsed.
+    #[test]
+    fn test_lag_recheck_allowed_backoff() {
+        let now = Instant::now();
+        assert!(lag_recheck_allowed(None, now));
+        assert!(!lag_recheck_allowed(Some(now), now));
+        assert!(lag_recheck_allowed(
+            Some(now),
+            now + LAG_RECHECK_MIN_INTERVAL
+        ));
     }
 
     #[test]

--- a/backend/src/handlers/websocket.rs
+++ b/backend/src/handlers/websocket.rs
@@ -1728,6 +1728,8 @@ fn process_balance_compute(
         }
         // Push exactly what REST would serve; never a payload REST would have 503'd.
         Err(currencies::BalancesError::Unavailable(_)) => BalanceFlushOutcome::SkippedUnavailable,
+        // Belt-and-braces: monitor addresses are validated at subscribe time, so this is unreachable here; skip like Unavailable.
+        Err(currencies::BalancesError::Validation(_)) => BalanceFlushOutcome::SkippedUnavailable,
         Err(currencies::BalancesError::Chain(e)) => {
             debug!("Balance monitor chain query failed for {}: {}", address, e);
             BalanceFlushOutcome::SkippedUnavailable
@@ -1762,7 +1764,6 @@ pub async fn start_balance_monitor_task(
                             n
                         );
                         do_full_recheck = true;
-                        last_full_recheck = Some(now);
                     } else {
                         warn!(
                             "Balance monitor lagged {} events within {}s of the last full recheck; suppressed, processing pending addresses only",
@@ -1794,7 +1795,6 @@ pub async fn start_balance_monitor_task(
                                     let now = Instant::now();
                                     if lag_recheck_allowed(last_full_recheck, now) {
                                         do_full_recheck = true;
-                                        last_full_recheck = Some(now);
                                     } else {
                                         warn!(
                                             "Balance monitor lagged {} events during debounce within {}s of the last full recheck; suppressed",
@@ -1838,6 +1838,10 @@ pub async fn start_balance_monitor_task(
                 .buffer_unordered(BALANCE_MONITOR_FANOUT_CAP)
                 .collect()
                 .await;
+
+            if do_full_recheck {
+                last_full_recheck = Some(Instant::now());
+            }
 
             let pushed = outcomes
                 .iter()
@@ -2783,6 +2787,34 @@ mod tests {
         ));
         assert_eq!(
             process_balance_compute(&m, "nolus1a", chain_err),
+            BalanceFlushOutcome::SkippedUnavailable
+        );
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// A validation error also skips the push, mirroring the belt-and-braces
+    /// arm for monitor input that is already validated at subscribe time.
+    #[tokio::test]
+    async fn test_process_balance_compute_skips_on_validation() {
+        let m = WebSocketManager::new(16);
+        let mut rx = register_conn(&m, "c1");
+        m.add_subscription(
+            "c1",
+            Subscription::Balances {
+                addresses: vec!["nolus1a".to_string()],
+            },
+        )
+        .unwrap();
+
+        let validation = Err(currencies::BalancesError::Validation(
+            crate::error::AppError::Validation {
+                message: "Invalid Nolus address format".to_string(),
+                field: Some("address".to_string()),
+                details: None,
+            },
+        ));
+        assert_eq!(
+            process_balance_compute(&m, "nolus1a", validation),
             BalanceFlushOutcome::SkippedUnavailable
         );
         assert!(rx.try_recv().is_err());

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -219,6 +219,11 @@ async fn main() -> anyhow::Result<()> {
         event_channels.contract_exec.subscribe(),
     )
     .await;
+    handlers::websocket::start_balance_monitor_task(
+        state.clone(),
+        event_channels.bank_transfer.subscribe(),
+    )
+    .await;
     handlers::websocket::start_stale_connection_reaper(state.clone()).await;
 
     // Build router

--- a/backend/src/validation.rs
+++ b/backend/src/validation.rs
@@ -20,6 +20,15 @@ pub fn validate_bech32_address(address: &str, field_name: &str) -> Result<(), Ap
     Ok(())
 }
 
+/// Returns `true` only for a valid bech32 address on the `nolus` HRP.
+///
+/// A valid address decodes cleanly and reports the `nolus` human-readable part,
+/// so this rejects empty strings, uppercase, whitespace, and `/ ? # %` by
+/// construction — a caller may then interpolate the result into an LCD path.
+pub fn is_valid_nolus_address(address: &str) -> bool {
+    matches!(bech32::decode(address), Ok((hrp, _)) if hrp.as_str() == "nolus")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -63,5 +72,30 @@ mod tests {
             }
             _ => panic!("Expected Validation error"),
         }
+    }
+
+    #[test]
+    fn test_is_valid_nolus_address_accepts_mainnet() {
+        assert!(is_valid_nolus_address(
+            "nolus17xpfvakm2amg962yls6f84z3kell8c5lxfnlfc"
+        ));
+    }
+
+    /// Path-traversal, query, fragment, percent, uppercase, whitespace, empty,
+    /// and over-length inputs must all fail — none may reach an LCD path.
+    #[test]
+    fn test_is_valid_nolus_address_rejects_hostile_inputs() {
+        let mainnet = "nolus17xpfvakm2amg962yls6f84z3kell8c5lxfnlfc";
+        assert!(!is_valid_nolus_address(&format!("{mainnet}/../../foo")));
+        assert!(!is_valid_nolus_address(&format!("{mainnet}?x=1")));
+        assert!(!is_valid_nolus_address(&format!("{mainnet}#frag")));
+        assert!(!is_valid_nolus_address("nolus1%2e%2e"));
+        assert!(!is_valid_nolus_address(&mainnet.to_uppercase()));
+        assert!(!is_valid_nolus_address("nolus1 abc"));
+        assert!(!is_valid_nolus_address(""));
+        assert!(!is_valid_nolus_address(&format!(
+            "nolus1{}",
+            "q".repeat(120)
+        )));
     }
 }

--- a/src/common/api/WebSocketClient.test.ts
+++ b/src/common/api/WebSocketClient.test.ts
@@ -233,13 +233,17 @@ describe("WebSocketClientImpl", () => {
       const callback = vi.fn();
       client.subscribeBalances("addr1", callback);
 
+      const balances = [
+        { key: "NLS@NOLUS", symbol: "NLS", denom: "unls", amount: "1000000", amount_usd: "150000", decimal_digits: 6 }
+      ];
       mockWs.simulateMessage({
         type: "balance_update",
         address: "addr1",
-        balances: { unls: "1000000" }
+        balances,
+        total_value_usd: "150000"
       });
 
-      expect(callback).toHaveBeenCalledWith("addr1", { unls: "1000000" });
+      expect(callback).toHaveBeenCalledWith("addr1", balances, "150000");
     });
 
     it("should handle lease updates", () => {

--- a/src/common/api/WebSocketClient.ts
+++ b/src/common/api/WebSocketClient.ts
@@ -66,6 +66,7 @@ interface BalanceUpdateMessage {
   type: "balance_update";
   address: string;
   balances: BalanceInfo[];
+  total_value_usd: string;
 }
 
 interface LeaseUpdateMessage {
@@ -119,7 +120,7 @@ type ServerMessage =
  * Callback types for each subscription
  */
 export type PriceCallback = (prices: Record<string, string>) => void;
-export type BalanceCallback = (address: string, balances: BalanceInfo[]) => void;
+export type BalanceCallback = (address: string, balances: BalanceInfo[], totalValueUsd: string) => void;
 export type LeaseCallback = (lease: Partial<LeaseInfo> & Pick<LeaseInfo, "address" | "status">) => void;
 export type TxStatusCallback = (txHash: string, status: "pending" | "success" | "failed", error?: string) => void;
 export type SkipTxCallback = (update: {
@@ -355,7 +356,12 @@ class WebSocketClientImpl {
           break;
 
         case "balance_update":
-          this.notifySubscribers(`balances:${message.address}`, message.address, message.balances);
+          this.notifySubscribers(
+            `balances:${message.address}`,
+            message.address,
+            message.balances,
+            message.total_value_usd
+          );
           break;
 
         case "lease_update":

--- a/src/common/stores/balances/index.test.ts
+++ b/src/common/stores/balances/index.test.ts
@@ -18,14 +18,14 @@ vi.hoisted(() => {
 
 const hoisted = vi.hoisted(() => {
   const captured: {
-    onBalances: ((addr: string, balances: any) => void) | null;
+    onBalances: ((addr: string, balances: any, totalValueUsd: string) => void) | null;
     unsubscribe: ReturnType<typeof vi.fn>;
   } = { onBalances: null, unsubscribe: vi.fn() };
 
   const BackendApi = {
     getBalances: vi.fn()
   };
-  const subscribeBalances = vi.fn((_addr: string, cb: (addr: string, balances: any) => void) => {
+  const subscribeBalances = vi.fn((_addr: string, cb: (addr: string, balances: any, totalValueUsd: string) => void) => {
     captured.onBalances = cb;
     return captured.unsubscribe;
   });
@@ -66,10 +66,10 @@ import { useBalancesStore } from "./index";
 
 const { captured, BackendApi, subscribeBalances } = hoisted;
 
-function emitBalances(addr: string, balances: any) {
+function emitBalances(addr: string, balances: any, totalValueUsd = "0") {
   const handler = captured.onBalances;
   expect(handler).toBeTruthy();
-  (handler as (addr: string, balances: any) => void)(addr, balances);
+  (handler as (addr: string, balances: any, totalValueUsd: string) => void)(addr, balances, totalValueUsd);
 }
 
 type BalanceRec = {
@@ -308,6 +308,19 @@ describe("useBalancesStore", () => {
     const updated = store.balances[0];
     if (updated === undefined) throw new Error("expected one balance entry after the ws update");
     expect(updated.amount).toBe("5");
+  });
+
+  it("ws push updates balances AND totalValueUsd", async () => {
+    BackendApi.getBalances.mockResolvedValueOnce({
+      balances: [],
+      total_value_usd: "0"
+    });
+    const store = useBalancesStore();
+    await store.setAddress("nolus1x");
+
+    emitBalances("nolus1x", [mkBalance({ amount: "5" })], "50");
+    expect(store.balances.length).toBe(1);
+    expect(store.totalValueUsd).toBe("50");
   });
 
   it("ws callback ignores mismatched address", async () => {

--- a/src/common/stores/balances/index.ts
+++ b/src/common/stores/balances/index.ts
@@ -193,9 +193,10 @@ export const useBalancesStore = defineStore("balances", () => {
   const { setAddress, cleanup } = useWebSocketLifecycle({
     address,
     subscribe: (addr) =>
-      WebSocketClient.subscribeBalances(addr, (wsAddr, newBalances) => {
+      WebSocketClient.subscribeBalances(addr, (wsAddr, newBalances, newTotalValueUsd) => {
         if (wsAddr === address.value && Array.isArray(newBalances)) {
           balances.value = newBalances;
+          totalValueUsd.value = newTotalValueUsd;
           lastUpdated.value = new Date();
         }
       }),


### PR DESCRIPTION
## Summary
Make the existing `balances:<addr>` WebSocket subscription real: a backend monitor now broadcasts `balance_update` when an on-chain bank transfer touches a subscribed address, so external deposits (IBC transfers, exchange withdrawals, another wallet) appear in the UI live instead of waiting for a reconnect or manual refresh. Closes #275.

## Changes
- `chain_events.rs`: the Tx event handler gains a `transfer` branch feeding a new `bank_transfer` broadcast channel. It iterates every recipient/sender attribute in every transfer event (MsgMultiSend-safe), filters out the fee-collector module account (`nolus17xpfvakm2amg962yls6f84z3kell8c5lxfnlfc` — verified live; every fee-paying tx emits a transfer to it, so unfiltered this branch would fire on ~100% of chain txs), and dedups the survivors into one event per tx.
- `currencies.rs`: the `/api/currencies/balances` computation is extracted into `compute_balances`, shared by the REST handler (behavior unchanged, same 400/503 semantics via typed `BalancesError` variants) and the monitor — WS payloads are computed by the same code as REST responses, so they cannot drift.
- `websocket.rs`: `BalanceUpdate` now carries the full 6-field REST `BalanceInfo` shape plus `total_value_usd` (the old 2-field WS struct is deleted — wiring the monitor onto it would have silently wiped USD fields on every push). New monitor task: 10s debounce, per-address change detection on the on-chain `(denom, amount)` pairs only (price wiggles don't trigger pushes), chain queries capped at 8 concurrent, push skipped entirely whenever REST would have returned an error (never a $0/partial payload from cold caches), no periodic polling. Cache cleanup mirrors the lease/earn monitors on both the disconnect and explicit-unsubscribe paths.
- Hardening (from the security review rounds): balance subscriptions now cap at 16 addresses and bech32-validate each one at subscribe time (the monitor turns subscribed addresses into chain queries — unbounded unvalidated input allowed fan-out amplification and LCD path steering); `compute_balances` re-validates as a shared chokepoint; the LCD path segment is percent-encoded; lag-driven full rechecks back off with a 30s window measured from recheck end.
- Frontend: `BalanceUpdateMessage`/`BalanceCallback` carry `total_value_usd` and the balances store sets it inside the existing address + array guards — balances and the total travel in one payload and are replaced together, so they cannot diverge (this also fixes the WebMCP `get_balances` tool reading a stale total).

## Verification
- Wrote the frontend seam tests first and confirmed both red (store total assertion `expected '0' to be '50'`; callback arity), then green.
- Backend tests: 502 passed — including transfer-parse fixtures (multi-recipient dedup, fee-collector filtered, fee-collector-only tx dispatches nothing), subscription cap/validation (16 accepted / 17 rejected / hostile inputs rejected), change-detection invariance under repricing, push/skip decision seams, cache cleanup with and without a second subscriber, and lag-backoff boundary cases.
- Ran the full frontend gate (vue-tsc, eslint, lint:style, format:check, vitest coverage — 1041 tests, build) and the full backend gate (fmt, clippy -D warnings, style-check, build, test) — all green.
- OpenAPI snapshot byte-identical: the REST refactor preserves the schema; WS types are not in the REST spec.
- Ran independent correctness, security, and conventions reviews over the branch through three rounds: round 1 flagged the unbounded-subscription amplification (HIGH) and validation-bypass/URL-encoding gap (MEDIUM); round 2 flagged an error-variant doc drift; both fix commits are in this branch and the final round passed all three reviews with no open findings.
- Rebased onto main after #276 merged; the rebased tree hash is byte-identical to the reviewed and gated tree.

## Follow-ups
- Manual staging smoke after this merges and auto-deploys: send an external transfer to a subscribed wallet and confirm the balance appears live within the debounce window — required before any prod tag.
- Accepted as-is for parity with the existing monitors (surfaced during review, deliberately not changed here): orphan cache entry on disconnect-during-flight (self-heals), fire-and-forget task spawn, unvalidated single-address lease/earn subscriptions (bounded), a possible `NolusAddress` newtype at the chain-client boundary.