### PR TITLE
test(e2e): m1 t1 read-only ui smoke and post-deploy wiring

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -134,6 +134,44 @@ jobs:
             exit 1
           REMOTE
 
+      - name: Post-deploy verification (t0+t1)
+        id: e2e
+        continue-on-error: true
+        env:
+          E2E_BASE_URL: https://${{ inputs.base_domain }}
+          E2E_WS_URL: wss://${{ inputs.base_domain }}/ws
+          E2E_HOST_RESOLVER: ${{ inputs.base_domain }}=${{ vars.DEPLOY_HOST }}
+          E2E_READONLY_ADDRESS: ${{ vars.E2E_READONLY_ADDRESS }}
+          BASE_DOMAIN: ${{ inputs.base_domain }}
+        run: |
+          set -uo pipefail
+          cd e2e || exit 1
+          npm ci
+          npx playwright install chromium
+          t0_rc=0
+          npm run t0 || t0_rc=$?
+          t1_rc=0
+          npm run t1 || t1_rc=$?
+          if [ "$t0_rc" -ne 0 ] || [ "$t1_rc" -ne 0 ]; then
+            failed=""
+            [ "$t0_rc" -ne 0 ] && failed="t0"
+            [ "$t1_rc" -ne 0 ] && failed="${failed:+$failed }t1"
+            echo "::error::post-deploy verification failed ($failed); e2e artifacts uploaded as e2e-${BASE_DOMAIN}"
+            exit 1
+          fi
+
+      - name: Upload e2e artifacts
+        if: always() && steps.e2e.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-${{ inputs.base_domain }}
+          path: |
+            e2e/results/
+            e2e/playwright-report/
+            e2e/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Rollback on failure
         if: failure()
         run: |

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 results/
 coverage/
+playwright-report/
+test-results/
 .env
 .env.*

--- a/e2e/.prettierignore
+++ b/e2e/.prettierignore
@@ -1,5 +1,7 @@
 node_modules/
 results/
 coverage/
+playwright-report/
+test-results/
 dist/
 package-lock.json

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,8 +9,8 @@ It is a separate npm package (its own `package.json` and lockfile) so the repo-r
 
 ## Tiers
 
-The suite is organized into tiers of increasing fidelity. This package currently
-ships **T0** only.
+The suite is organized into tiers of increasing fidelity. This package ships **T0**
+(API/WS cross-checks) and **T1** (a read-only browser smoke).
 
 | Tier | Scope                                                               | Wallet | Browser |
 | ---- | ------------------------------------------------------------------- | ------ | ------- |
@@ -56,13 +56,14 @@ never binary floats.
 
 ### Scripts
 
-| Script                            | Purpose                               |
-| --------------------------------- | ------------------------------------- |
-| `npm run t0`                      | Run the T0 suite.                     |
-| `npm run typecheck`               | `tsc --noEmit`.                       |
-| `npm run lint`                    | ESLint (type-checked), zero warnings. |
-| `npm run format` / `format:check` | Prettier.                             |
-| `npm test`                        | Vitest unit tests.                    |
+| Script                            | Purpose                                |
+| --------------------------------- | -------------------------------------- |
+| `npm run t0`                      | Run the T0 suite.                      |
+| `npm run t1`                      | Run the T1 browser smoke (Playwright). |
+| `npm run typecheck`               | `tsc --noEmit`.                        |
+| `npm run lint`                    | ESLint (type-checked), zero warnings.  |
+| `npm run format` / `format:check` | Prettier.                              |
+| `npm test`                        | Vitest unit tests.                     |
 
 ## The T0 checks
 
@@ -135,8 +136,90 @@ The run prints one JSON document to stdout and writes the same document to
 **Exit code:** `1` if any check has status `fail`, otherwise `0`. A `skip` never fails
 the run. The `E2E_HOST_RESOLVER` value is never present anywhere in the output.
 
+## The T1 browser smoke
+
+T1 drives a real headless Chromium against the live origin and asserts that every
+wallet-less route renders and behaves, and that a handful of rendered numbers match the
+API they come from. It never connects a wallet.
+
+```bash
+cd e2e
+E2E_BASE_URL=https://app-dev.nolus.io npm run t1
+```
+
+### Projects
+
+Three projects run every spec, so each assertion is checked at all three surfaces:
+
+| Project         | Viewport   | Theme | Extra assertion        |
+| --------------- | ---------- | ----- | ---------------------- |
+| `desktop-light` | 1440 x 900 | light |                        |
+| `desktop-dark`  | 1440 x 900 | dark  | `html.dark` is present |
+| `mobile`        | 390 x 844  | light |                        |
+
+Theme (`theme_data`) and language (`language` = `en`) are seeded into `localStorage`
+before the SPA boots. The viewport is fixed per project because the app reads its mobile
+breakpoint once at component setup.
+
+### What the route smoke asserts
+
+For each of the eight wallet-less routes (`/`, `/assets`, `/earn`, `/positions`,
+`/stake`, `/activities`, `/vote`, `/stats`) the smoke loads the page, waits for the app
+shell to become interactive, then holds a short window and asserts a per-route budget:
+
+- zero `console.error` and zero uncaught page errors,
+- zero failed same-origin requests (responses with status `>= 400`, plus request
+  failures other than aborts); third-party origins are reported, not budgeted,
+- exactly one WebSocket to a URL ending `/ws` opens, receives a
+  `{"type":"subscribed","topic":"prices"}` acknowledgement, and stays open through the
+  observation window.
+
+Console warnings are recorded as test annotations without failing the run.
+
+### The math-to-UI bridge
+
+`bridge.spec.ts` proves that rendered numbers equal the numbers the backend serves:
+
+- `/stats` overview: TVL, Tx Volume and Realized PnL (the three figures visible at every
+  viewport) are each compared against `GET /api/etl/batch/stats-overview`
+  (`tvl.total_value_locked`, `tx_volume.total_tx_value`, `realized_pnl_stats.amount`).
+  The rendered value is read from the AnimateNumber `aria-label`, the expected value is
+  formatted with the same compact-currency options the app uses, and the API value is
+  re-fetched on each attempt so a live price tick does not flake the assertion. A
+  within-one-percent tolerance on the parsed compact string is the documented fallback.
+- `/assets` zero-state: the wallet-less assets table total renders the formatted zero
+  value (`$0.00`), a real formatting-path check.
+
+The API reads inside the bridge go through the package's own undici client with the host
+resolver, because a browser API request context does not honor the Chromium host-resolver
+rules.
+
+### Post-deploy behavior
+
+The deploy workflow runs t0 and t1 after the health probe as a single non-blocking step
+(`continue-on-error`). A failure is loud (a workflow error annotation naming which tier
+failed) but never fails the deploy or triggers rollback. On failure the `results/`,
+`playwright-report/` and `test-results/` directories are uploaded as an artifact for
+triage.
+
+### T1 environment variables
+
+| Variable            | Required | Meaning                                                                                                                                                  |
+| ------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `E2E_BASE_URL`      | yes      | HTTPS origin of the SPA/API. A missing value fails config load loudly before any browser launches.                                                       |
+| `E2E_HOST_RESOLVER` | no       | Optional `host=target` connect overrides, reused from T0. Drives both the browser resolver rules and the bridge's API client. Its value is never echoed. |
+
+T1 does not use `E2E_READONLY_ADDRESS`; it is wallet-less.
+
 ## Known coverage gaps
 
+- The funded-wallet Dashboard and Assets wallet totals are **not** bridged. There is no
+  wallet-less path to load balances for a chosen address (seeding `localStorage` is inert;
+  the balances store only fetches after a real extension connect), so that bridge belongs
+  to the T2 scripted-wallet tier. Today the T1 bridge binds the wallet-independent `/stats`
+  figures and the `/assets` zero-state total.
+- Every new route must gain a T1 route-smoke entry in `routes.spec.ts`. A route added
+  without one is a silent gap, not a passing test.
 - `ws-rest-parity` may report `skip` on a quiet address: the backend only pushes a
   `balance_update` when a live on-chain transfer touches the subscribed address. A
   deterministic trigger arrives with the T2 wallet tier. Until then the wire-shape

--- a/e2e/eslint.config.js
+++ b/e2e/eslint.config.js
@@ -3,7 +3,7 @@ import tseslint from "typescript-eslint";
 import prettier from "eslint-config-prettier";
 
 export default tseslint.config(
-  { ignores: ["node_modules", "results", "dist", "coverage"] },
+  { ignores: ["node_modules", "results", "dist", "coverage", "playwright-report", "test-results"] },
   js.configs.recommended,
   ...tseslint.configs.strictTypeChecked,
   {
@@ -23,7 +23,7 @@ export default tseslint.config(
     }
   },
   {
-    files: ["**/*.test.ts"],
+    files: ["**/*.test.ts", "**/*.spec.ts"],
     rules: {
       "max-lines-per-function": "off"
     }

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
+        "@playwright/test": "1.61.1",
         "@types/node": "26.1.1",
         "@types/ws": "8.18.1",
         "@vitest/coverage-v8": "4.1.10",
@@ -813,6 +814,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2684,6 +2701,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "t0": "tsx src/t0.ts",
+    "t1": "playwright test --config playwright.config.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
+    "@playwright/test": "1.61.1",
     "@types/node": "26.1.1",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "4.1.10",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig } from "@playwright/test";
+import { parseT1Config } from "./src/config.js";
+import { buildHostResolverRules } from "./src/resolver.js";
+import type { T1Options } from "./src/t1/support.js";
+
+const parsed = parseT1Config(process.env);
+if (!parsed.ok) {
+  throw new Error(`E2E T1 configuration error:\n  - ${parsed.errors.join("\n  - ")}`);
+}
+
+const { baseUrl, hostOverrides } = parsed.config;
+const resolverRules = buildHostResolverRules(hostOverrides);
+const launchArgs = resolverRules.length > 0 ? [`--host-resolver-rules=${resolverRules}`] : [];
+const isCI = Boolean(process.env.CI);
+
+export default defineConfig<T1Options>({
+  testDir: "src/t1",
+  fullyParallel: true,
+  forbidOnly: isCI,
+  workers: 2,
+  timeout: 60000,
+  retries: isCI ? 1 : 0,
+  reporter: [
+    ["list"],
+    ["html", { open: "never", outputFolder: "playwright-report" }],
+    ["json", { outputFile: "results/t1.json" }]
+  ],
+  use: {
+    baseURL: baseUrl,
+    headless: true,
+    browserName: "chromium",
+    screenshot: "only-on-failure",
+    trace: isCI ? "on-first-retry" : "off",
+    launchOptions: { args: launchArgs }
+  },
+  projects: [
+    {
+      name: "desktop-light",
+      use: { viewport: { width: 1440, height: 900 }, themeData: "light" }
+    },
+    {
+      name: "desktop-dark",
+      use: { viewport: { width: 1440, height: 900 }, themeData: "dark" }
+    },
+    {
+      name: "mobile",
+      use: { viewport: { width: 390, height: 844 }, themeData: "light" }
+    }
+  ]
+});

--- a/e2e/src/config.test.ts
+++ b/e2e/src/config.test.ts
@@ -5,7 +5,8 @@ import {
   DEFAULT_WS_PUSH_TIMEOUT_MS,
   deriveWsUrl,
   isValidNolusAddress,
-  parseConfig
+  parseConfig,
+  parseT1Config
 } from "./config.js";
 
 const VALID_ADDRESS = "nolus10hvz04hh92xzct5hxnpsn5h2fp3p4amm28vhvp";
@@ -153,5 +154,44 @@ describe("parseConfig", () => {
       throw new Error("expected failure");
     }
     expect(result.errors).toEqual(["E2E_RATE_MIN_PERCENT (90) must not exceed E2E_RATE_MAX_PERCENT (10)"]);
+  });
+});
+
+describe("parseT1Config", () => {
+  it("accepts only E2E_BASE_URL and does not require an address", () => {
+    const result = parseT1Config({ E2E_BASE_URL: VALID_BASE });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected success");
+    }
+    expect(result.config.baseUrl).toBe(VALID_BASE);
+    expect(result.config.hostOverrides.size).toBe(0);
+  });
+
+  it("reuses the host-resolver pairs", () => {
+    const result = parseT1Config({ E2E_BASE_URL: VALID_BASE, E2E_HOST_RESOLVER: "app-dev.nolus.io=198.51.100.7" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected success");
+    }
+    expect(result.config.hostOverrides.get("app-dev.nolus.io")).toBe("198.51.100.7");
+  });
+
+  it("fails hard with a descriptive error when E2E_BASE_URL is missing", () => {
+    const result = parseT1Config({});
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected failure");
+    }
+    expect(result.errors).toEqual(["E2E_BASE_URL is required (https origin of the SPA/API)"]);
+  });
+
+  it("prefixes a malformed host-resolver pair", () => {
+    const result = parseT1Config({ E2E_BASE_URL: VALID_BASE, E2E_HOST_RESOLVER: "nodelimiter" });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected failure");
+    }
+    expect(result.errors).toEqual([`E2E_HOST_RESOLVER: pair 1 is missing "=" (expected host=target)`]);
   });
 });

--- a/e2e/src/config.ts
+++ b/e2e/src/config.ts
@@ -213,3 +213,31 @@ export function parseConfig(env: Record<string, string | undefined>): ConfigResu
     }
   };
 }
+
+export interface T1Config {
+  baseUrl: string;
+  hostOverrides: Map<string, string>;
+}
+
+export type T1ConfigResult = { ok: true; config: T1Config } | { ok: false; errors: string[] };
+
+/**
+ * The T1 (browser smoke) subset: only E2E_BASE_URL is required and the optional
+ * E2E_HOST_RESOLVER pairs are reused. It shares the exact field parsers with the
+ * full T0 config so the two never drift.
+ */
+export function parseT1Config(env: Record<string, string | undefined>): T1ConfigResult {
+  const errors: string[] = [];
+
+  const base = parseBaseUrlField(env, errors);
+  const resolver = parseHostResolver(env.E2E_HOST_RESOLVER);
+  for (const message of resolver.errors) {
+    errors.push(`E2E_HOST_RESOLVER: ${message}`);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, config: { baseUrl: base.baseUrl, hostOverrides: resolver.overrides } };
+}

--- a/e2e/src/resolver.test.ts
+++ b/e2e/src/resolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseHostResolver } from "./resolver.js";
+import { buildHostResolverRules, parseHostResolver } from "./resolver.js";
 
 describe("parseHostResolver", () => {
   it("returns no overrides for an undefined value", () => {
@@ -37,5 +37,27 @@ describe("parseHostResolver", () => {
     const result = parseHostResolver("=198.51.100.7");
     expect(result.overrides.size).toBe(0);
     expect(result.errors).toEqual(["pair 1 has an empty host"]);
+  });
+});
+
+describe("buildHostResolverRules", () => {
+  it("returns an empty string for no overrides", () => {
+    expect(buildHostResolverRules(new Map())).toBe("");
+  });
+
+  it("renders a single MAP rule", () => {
+    expect(buildHostResolverRules(new Map([["app-dev.nolus.io", "198.51.100.7"]]))).toBe(
+      "MAP app-dev.nolus.io 198.51.100.7"
+    );
+  });
+
+  it("joins multiple MAP rules with a comma", () => {
+    const rules = buildHostResolverRules(
+      new Map([
+        ["a.example", "198.51.100.1"],
+        ["b.example", "198.51.100.2"]
+      ])
+    );
+    expect(rules).toBe("MAP a.example 198.51.100.1, MAP b.example 198.51.100.2");
   });
 });

--- a/e2e/src/resolver.ts
+++ b/e2e/src/resolver.ts
@@ -47,6 +47,10 @@ export function createLookup(overrides: Map<string, string>): LookupFunction {
   };
 }
 
+export function buildHostResolverRules(overrides: Map<string, string>): string {
+  return [...overrides].map(([host, target]) => `MAP ${host} ${target}`).join(", ");
+}
+
 export function createUndiciConnector(overrides: Map<string, string>): buildConnector.connector {
   const base = buildConnector({});
   return (options, callback) => {

--- a/e2e/src/t1/bridge.spec.ts
+++ b/e2e/src/t1/bridge.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from "./support.js";
+import type { Locator, Page } from "@playwright/test";
+import { Agent } from "undici";
+import type { Dispatcher } from "undici";
+import { getJson } from "../http.js";
+import { parseT1Config } from "../config.js";
+import { createUndiciConnector } from "../resolver.js";
+
+const APP_SHELL_TIMEOUT = 20000;
+const STABLE_TIMEOUT = 15000;
+const BRIDGE_TIMEOUT = 30000;
+const TOLERANCE = 0.01;
+const OVERVIEW_PATH = "/api/etl/batch/stats-overview";
+
+// Mirrors src/common/utils/NumberFormatUtils.compactFormatOptions. The rendered
+// AnimateNumber exposes the formatted number (no currency symbol) via aria-label;
+// the "$" is a separate static prefix asserted independently.
+const compactUsd = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  compactDisplay: "short",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+});
+
+const MULTIPLIERS: Record<string, number> = { "": 1, K: 1e3, M: 1e6, B: 1e9, T: 1e12 };
+
+let dispatcher: Dispatcher | undefined;
+let origin: string;
+let labels: { tvl: string; txVolume: string; realizedPnl: string; assetsTitle: string };
+
+function readString(root: unknown, ...path: string[]): string | undefined {
+  let cur: unknown = root;
+  for (const key of path) {
+    if (typeof cur !== "object" || cur === null || !(key in cur)) return undefined;
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return typeof cur === "string" ? cur : undefined;
+}
+
+function mustString(root: unknown, ...path: string[]): string {
+  const value = readString(root, ...path);
+  if (value === undefined) throw new Error(`missing string at ${path.join(".")}`);
+  return value;
+}
+
+function expectedCompact(raw: string): string {
+  return compactUsd.format(Math.abs(Number(raw)));
+}
+
+function parseCompact(rendered: string): number | null {
+  const match = /^([0-9][0-9,]*(?:\.[0-9]+)?)([KMBT]?)$/.exec(rendered.trim());
+  if (match === null) return null;
+  const digits = match[1];
+  if (digits === undefined) return null;
+  const mult = MULTIPLIERS[match[2] ?? ""] ?? 1;
+  return Number(digits.replace(/,/g, "")) * mult;
+}
+
+function figureContainer(page: Page, label: string): Locator {
+  return page.locator("div.label", { hasText: label }).locator("xpath=..").locator("div.items-center.gap-2").first();
+}
+
+async function readStableAria(container: Locator): Promise<string> {
+  const holder = container.locator("[aria-label]").first();
+  let previous = "";
+  await expect
+    .poll(
+      async () => {
+        const current = ((await holder.getAttribute("aria-label")) ?? "").replace(/\s+/g, "");
+        const stable = current.length > 0 && current === previous;
+        previous = current;
+        return stable;
+      },
+      { message: "the AnimateNumber aria-label should stabilize across two reads", timeout: STABLE_TIMEOUT }
+    )
+    .toBe(true);
+  return previous;
+}
+
+async function compareFigure(container: Locator, apiPath: readonly string[]): Promise<string> {
+  const raw = readString(await getJson(`${origin}${OVERVIEW_PATH}`, dispatcher), ...apiPath);
+  if (raw === undefined) return `api-missing:${apiPath.join(".")}`;
+  const expected = expectedCompact(raw);
+  const rendered = await readStableAria(container);
+  if (rendered === expected) return "match-exact";
+  const renderedNum = parseCompact(rendered);
+  const actual = Math.abs(Number(raw));
+  if (renderedNum !== null && actual !== 0 && Math.abs(renderedNum - actual) / actual <= TOLERANCE) {
+    return "match-tolerance";
+  }
+  return `mismatch rendered=${rendered} expected=${expected}`;
+}
+
+async function bridgeFigure(page: Page, label: string, apiPath: readonly string[]): Promise<void> {
+  const container = figureContainer(page, label);
+  await expect(container, `figure "${label}" should be visible`).toBeVisible({ timeout: APP_SHELL_TIMEOUT });
+  await expect(container, `figure "${label}" should carry the "$" currency prefix`).toContainText("$");
+  await expect
+    .poll(() => compareFigure(container, apiPath), {
+      message: `stats bridge for "${label}"`,
+      timeout: BRIDGE_TIMEOUT,
+      intervals: [500, 1000, 1000, 2000]
+    })
+    .toMatch(/^match/);
+}
+
+async function waitForAppShell(page: Page): Promise<void> {
+  await page.locator("#app button").first().waitFor({ state: "visible", timeout: APP_SHELL_TIMEOUT });
+}
+
+test.beforeAll(async () => {
+  const parsed = parseT1Config(process.env);
+  if (!parsed.ok) throw new Error(`T1 config error: ${parsed.errors.join("; ")}`);
+  origin = parsed.config.baseUrl.replace(/\/$/, "");
+  dispatcher =
+    parsed.config.hostOverrides.size > 0
+      ? new Agent({ connect: createUndiciConnector(parsed.config.hostOverrides) })
+      : undefined;
+  const locale = await getJson(`${origin}/api/locales/en`, dispatcher);
+  labels = {
+    tvl: mustString(locale, "message", "tvl"),
+    txVolume: mustString(locale, "message", "tx-volume"),
+    realizedPnl: mustString(locale, "message", "realized-pnl"),
+    assetsTitle: mustString(locale, "message", "assets-title")
+  };
+});
+
+test.afterAll(async () => {
+  if (dispatcher !== undefined) await dispatcher.close();
+});
+
+test("stats overview figures bridge math to the rendered values", async ({ page, budget }) => {
+  budget.route = "/stats";
+  await page.goto("/stats", { waitUntil: "domcontentloaded" });
+  await waitForAppShell(page);
+  await bridgeFigure(page, labels.tvl, ["tvl", "total_value_locked"]);
+  await bridgeFigure(page, labels.txVolume, ["tx_volume", "total_tx_value"]);
+  await bridgeFigure(page, labels.realizedPnl, ["realized_pnl_stats", "amount"]);
+});
+
+test("assets wallet-less total renders the formatted zero value", async ({ page, budget }) => {
+  budget.route = "/assets";
+  await page.goto("/assets", { waitUntil: "domcontentloaded" });
+  await waitForAppShell(page);
+  const container = figureContainer(page, labels.assetsTitle);
+  await expect(container, "assets total should be visible").toBeVisible({ timeout: APP_SHELL_TIMEOUT });
+  await expect(container, 'assets total should carry the "$" currency prefix').toContainText("$");
+  expect(await readStableAria(container)).toBe("0.00");
+});

--- a/e2e/src/t1/routes.spec.ts
+++ b/e2e/src/t1/routes.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "./support.js";
+import type { WsState } from "./support.js";
+import type { Page } from "@playwright/test";
+
+// Every route boots wallet-less; the catch-all redirects unknown paths to "/".
+const ROUTES = ["/", "/assets", "/earn", "/positions", "/stake", "/activities", "/vote", "/stats"] as const;
+
+const APP_SHELL_TIMEOUT = 20000;
+const WS_ACK_TIMEOUT = 15000;
+const WS_OBSERVE_MS = 1500;
+
+async function waitForAppShell(page: Page): Promise<void> {
+  // The header renders interactive controls only after the language guard resolves
+  // and the SPA mounts, so the first visible button is a stable "interactive" signal
+  // across every route and viewport without waiting on networkidle.
+  await page.locator("#app button").first().waitFor({ state: "visible", timeout: APP_SHELL_TIMEOUT });
+}
+
+function wsObservationStatus(ws: WsState): "closed" | "open-stable" | "waiting" {
+  if (ws.closed) return "closed";
+  if (Date.now() - ws.openedAt >= WS_OBSERVE_MS) return "open-stable";
+  return "waiting";
+}
+
+async function assertWsHealthy(ws: WsState): Promise<void> {
+  await expect
+    .poll(() => ws.sawWsUrl, { message: "a WebSocket to a URL ending /ws should open", timeout: WS_ACK_TIMEOUT })
+    .toBe(true);
+  await expect
+    .poll(() => ws.ackReceived, {
+      message: "WS should receive a prices 'subscribed' ack frame",
+      timeout: WS_ACK_TIMEOUT
+    })
+    .toBe(true);
+  await expect
+    .poll(() => wsObservationStatus(ws), {
+      message: "the /ws WebSocket should stay open through the observation window",
+      timeout: WS_OBSERVE_MS + 3000
+    })
+    .toBe("open-stable");
+}
+
+for (const route of ROUTES) {
+  test(`route ${route} boots wallet-less and clean`, async ({ page, budget }, testInfo) => {
+    budget.route = route;
+    await page.goto(route, { waitUntil: "domcontentloaded" });
+    await waitForAppShell(page);
+    if (testInfo.project.name === "desktop-dark") {
+      await expect(page.locator("html")).toHaveClass(/(^|\s)dark(\s|$)/);
+    }
+    await assertWsHealthy(budget.ws);
+  });
+}

--- a/e2e/src/t1/support.ts
+++ b/e2e/src/t1/support.ts
@@ -1,0 +1,136 @@
+import { test as base, expect } from "@playwright/test";
+import type { Page, TestInfo } from "@playwright/test";
+
+export interface T1Options {
+  themeData: "light" | "dark" | "sync";
+}
+
+export interface WsState {
+  sawWsUrl: boolean;
+  openedAt: number;
+  ackReceived: boolean;
+  closed: boolean;
+  frames: number;
+}
+
+export interface BudgetState {
+  route: string;
+  consoleErrors: string[];
+  consoleWarnings: string[];
+  pageErrors: string[];
+  failedRequests: string[];
+  ws: WsState;
+}
+
+export interface T1Fixtures {
+  budget: BudgetState;
+}
+
+const ABORTED = "net::ERR_ABORTED";
+
+function createBudgetState(): BudgetState {
+  return {
+    route: "",
+    consoleErrors: [],
+    consoleWarnings: [],
+    pageErrors: [],
+    failedRequests: [],
+    ws: { sawWsUrl: false, openedAt: 0, ackReceived: false, closed: false, frames: 0 }
+  };
+}
+
+// Seed theme + locale into localStorage before the SPA boots. A string init script
+// avoids referencing browser globals in the Node-typed test source; the values are a
+// controlled enum, JSON-quoted for safety.
+function seedScript(theme: string): string {
+  return `try { localStorage.setItem('theme_data', ${JSON.stringify(theme)}); localStorage.setItem('language', 'en'); } catch (e) { void e; }`;
+}
+
+function isSameOrigin(url: string, originHost: string): boolean {
+  try {
+    return new URL(url).host === originHost;
+  } catch {
+    return false;
+  }
+}
+
+function isPricesAck(payload: string | Buffer): boolean {
+  const text = typeof payload === "string" ? payload : payload.toString("utf8");
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return false;
+    const frame = parsed as Record<string, unknown>;
+    return frame.type === "subscribed" && frame.topic === "prices";
+  } catch {
+    return false;
+  }
+}
+
+function attachWsListener(page: Page, ws: WsState): void {
+  page.on("websocket", (socket) => {
+    if (!socket.url().endsWith("/ws")) return;
+    ws.sawWsUrl = true;
+    ws.openedAt = Date.now();
+    socket.on("framereceived", (frame) => {
+      if (isPricesAck(frame.payload)) {
+        ws.ackReceived = true;
+        ws.frames += 1;
+      }
+    });
+    socket.on("close", () => {
+      ws.closed = true;
+    });
+  });
+}
+
+function attachCollectors(page: Page, state: BudgetState, originHost: string): void {
+  page.on("console", (msg) => {
+    if (msg.type() === "error") state.consoleErrors.push(msg.text());
+    else if (msg.type() === "warning") state.consoleWarnings.push(msg.text());
+  });
+  page.on("pageerror", (err) => state.pageErrors.push(err.message));
+  page.on("requestfailed", (req) => {
+    const reason = req.failure()?.errorText ?? "unknown";
+    if (reason !== ABORTED && isSameOrigin(req.url(), originHost)) {
+      state.failedRequests.push(`${req.url()} (${reason})`);
+    }
+  });
+  page.on("response", (resp) => {
+    if (resp.status() >= 400 && isSameOrigin(resp.url(), originHost)) {
+      state.failedRequests.push(`${resp.url()} (HTTP ${resp.status()})`);
+    }
+  });
+  attachWsListener(page, state.ws);
+}
+
+function assertBudgetClean(state: BudgetState, testInfo: TestInfo): void {
+  const route = state.route || "(unset)";
+  if (state.consoleWarnings.length > 0) {
+    testInfo.annotations.push({
+      type: "console-warning",
+      description: `${route}: ${state.consoleWarnings.join(" | ")}`
+    });
+  }
+  expect(state.consoleErrors, `console errors on ${route}: ${state.consoleErrors.join(" | ")}`).toEqual([]);
+  expect(state.pageErrors, `page errors on ${route}: ${state.pageErrors.join(" | ")}`).toEqual([]);
+  expect(state.failedRequests, `failed same-origin requests on ${route}: ${state.failedRequests.join(" | ")}`).toEqual(
+    []
+  );
+}
+
+export const test = base.extend<T1Options & T1Fixtures>({
+  themeData: ["light", { option: true }],
+  budget: async ({ page, themeData }, use, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL;
+    if (baseURL === undefined) {
+      throw new Error("T1 project is missing baseURL (E2E_BASE_URL)");
+    }
+    await page.addInitScript(seedScript(themeData));
+    const state = createBudgetState();
+    attachCollectors(page, state, new URL(baseURL).host);
+    await use(state);
+    assertBudgetClean(state, testInfo);
+  }
+});
+
+export { expect };

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -18,5 +18,5 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "vitest.config.ts"]
+  "include": ["src/**/*.ts", "vitest.config.ts", "playwright.config.ts"]
 }

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/t0.ts", "src/http.ts", "src/ws.ts"],
+      exclude: ["src/**/*.test.ts", "src/t0.ts", "src/http.ts", "src/ws.ts", "src/t1/**"],
       reporter: ["text", "json-summary"],
       // Ratchet floors pinned just under measured actuals. The pure modules
       // (config/decimal/report/validate) sit at 97-100%; the global is pulled down by


### PR DESCRIPTION
## Summary
Adds tier T1 of the real-env QA suite: a headless Playwright smoke that boots every route on the deployed origin under a zero-error budget, bridges rendered numbers to API values, and wires T0+T1 as a non-blocking post-deploy step of the shared deploy workflow.

Closes #280. Stacked on #301; retargets to `main` once it merges.

## Changes
- Playwright 1.61 (pinned) added to the e2e package; three projects: desktop light, desktop dark, mobile 390x844 (theme and locale seeded before boot)
- Route smoke for `/`, `/assets`, `/earn`, `/positions`, `/stake`, `/activities`, `/vote`, `/stats`: zero console errors, zero page errors, zero failed same-origin requests; the app's WebSocket must connect and ack the prices subscription (asserted structurally on the WS frames, not log text)
- Math-to-UI bridge: rendered `/stats` TVL, transaction volume and realized PnL vs `GET /api/etl/batch/stats-overview` after the app's compact currency formatting, plus the `/assets` zero-state total. The issue's dashboard/assets wallet totals cannot load without a wallet extension (there is no wallet-less balance path; storage seeding is inert), so the funded-wallet bridge is a documented README gap owned by the T2 tier (#281)
- deploy.yaml: post-deploy verification step after the health probe; `continue-on-error` so the deploy result never depends on it, loud `::error::` annotation and Playwright artifact upload on failure; origin, resolver mapping and read-only address all derive from the existing `base_domain` input and repository variables (no host literal added)
- README: T1 section and updated coverage gaps (every new route must gain a smoke entry; silent gaps are disallowed)

## Verification
- Ran the package gate: typecheck, format check, lint at zero warnings, vitest (91 tests, coverage floors met)
- Ran T1 against staging: 30/30 across the three projects in ~30s; every route boots clean wallet-less, the WS connects and acks prices on all of them; 18 benign console warnings collected as report-only annotations
- Proved the budgets bite: an injected console error fails its route naming the message; a simulated wrong rendered value fails the bridge with rendered-vs-API values in the output
- Verified the workflow edit: YAML parses, the run block is shellcheck-clean, upload-artifact is pinned to the verified v4.6.2 commit SHA, and an e2e failure cannot trigger the rollback path
- Completed independent review passes (general quality, security, project conventions); the security pass suggested routing `base_domain` through the step env instead of interpolating into the shell, which was applied

Suite impact: adds the T1 route x theme x viewport smoke layer; dashboard/assets funded totals tracked as an explicit gap for #281.

## Follow-ups
- Ops: create repository variable `E2E_READONLY_ADDRESS` (a funded nolus1 address, ideally holding an open lease) before the step's first run; the first runner execution downloads the pinned chromium build if not cached
- App: benign `Invalid keyframe value for property opacity: ,1` warning from the route transition on `/stats`, `/assets`, `/earn`, `/stake`; candidate cleanup
- The revenue and buyback stats figures are desktop-only and not bridged (documented in the README)
