### PR TITLE
test(e2e): m2 scripted keplr-surface wallet provider

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -260,6 +260,10 @@ the future T3 transactional tier.
 | `E2E_WALLET_MNEMONIC`   | yes      | BIP-39 mnemonic (12/15/18/21/24 lowercase words) for the primary scripted account. Validated for shape only; **never echoed anywhere**, including error output and results. |
 | `E2E_WALLET_MNEMONIC_2` | no       | Optional second mnemonic for the two-identity spec. When unset it falls back to a fixed, publicly-known, unfunded CosmJS test vector used connect-only.                     |
 
+The stub exposes a signing binding that any JavaScript running in the page can call,
+so `E2E_WALLET_MNEMONIC` must only ever hold a dedicated, disposable e2e test wallet —
+never a personal or production key.
+
 ## Known coverage gaps
 
 - The funded-wallet Dashboard and Assets wallet totals are **not** bridged. T2 now scripts

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,7 +10,8 @@ It is a separate npm package (its own `package.json` and lockfile) so the repo-r
 ## Tiers
 
 The suite is organized into tiers of increasing fidelity. This package ships **T0**
-(API/WS cross-checks) and **T1** (a read-only browser smoke).
+(API/WS cross-checks), **T1** (a read-only browser smoke), and **T2** (scripted-wallet
+flows: connect, offline signing, disconnect).
 
 | Tier | Scope                                                               | Wallet | Browser |
 | ---- | ------------------------------------------------------------------- | ------ | ------- |
@@ -60,6 +61,7 @@ never binary floats.
 | --------------------------------- | -------------------------------------- |
 | `npm run t0`                      | Run the T0 suite.                      |
 | `npm run t1`                      | Run the T1 browser smoke (Playwright). |
+| `npm run t2`                      | Run the T2 scripted-wallet flows.      |
 | `npm run typecheck`               | `tsc --noEmit`.                        |
 | `npm run lint`                    | ESLint (type-checked), zero warnings.  |
 | `npm run format` / `format:check` | Prettier.                              |
@@ -211,13 +213,61 @@ triage.
 
 T1 does not use `E2E_READONLY_ADDRESS`; it is wallet-less.
 
+## The T2 scripted-wallet flows
+
+T2 drives the app's **real** Keplr connect flow against the live origin, but with no
+browser extension: a scripted `window.keplr` provider is injected before the SPA boots.
+The provider implements exactly the four methods the app calls (`enable`,
+`experimentalSuggestChain`, `getOfflineSignerOnlyAmino`, `getOfflineSignerAuto`) and
+proxies signing to a CosmJS wallet running in Node. **The mnemonic never enters the
+browser** — only a derived address, a base64 public key, and per-call amino
+signatures cross the page boundary.
+
+```bash
+cd e2e
+E2E_BASE_URL=https://app-dev.nolus.io \
+E2E_WALLET_MNEMONIC="<throwaway 12/24-word mnemonic>" \
+npm run t2
+```
+
+The `t2` project runs on a desktop viewport with the light theme. Connect needs no
+funds, so any freshly generated mnemonic works; the funded account is only required for
+the future T3 transactional tier.
+
+### What T2 asserts
+
+- **Connect** — opens the app, clicks the real Connect → Keplr controls, and asserts the
+  app reaches the connected state: `localStorage.wallet_connect_mechanism === "extension"`
+  and the header renders the derived `nolus1…` address. It also pins that
+  `window.keplr.isKeplr === undefined` (the #155 regression class: real Keplr's Cosmos
+  provider exposes no such marker, so the app must not branch on one).
+- **Offline signing** — signs a representative bank-send amino doc through the stub and
+  verifies in Node that the returned secp256k1 signature is cryptographically valid over
+  `sha256(serializeSignDoc(doc))`, with no popup and no signing network request.
+- **Disconnect** — drives the disconnect UI and asserts the wallet storage keys are
+  cleared and the app returns to the disconnected state.
+- **Two identities** — connects the fallback second identity and asserts its derived
+  address differs from the primary's.
+- **Secret hygiene** — asserts no three-word mnemonic window appears in the collected
+  console output, the connected page content, or the injected init-script source.
+
+### T2 environment variables
+
+| Variable                | Required | Meaning                                                                                                                                                                     |
+| ----------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `E2E_BASE_URL`          | yes      | HTTPS origin of the SPA/API. Fails config load loudly before any browser launches.                                                                                          |
+| `E2E_HOST_RESOLVER`     | no       | Optional `host=target` connect overrides, reused from T0/T1. Its value is never echoed.                                                                                     |
+| `E2E_WALLET_MNEMONIC`   | yes      | BIP-39 mnemonic (12/15/18/21/24 lowercase words) for the primary scripted account. Validated for shape only; **never echoed anywhere**, including error output and results. |
+| `E2E_WALLET_MNEMONIC_2` | no       | Optional second mnemonic for the two-identity spec. When unset it falls back to a fixed, publicly-known, unfunded CosmJS test vector used connect-only.                     |
+
 ## Known coverage gaps
 
-- The funded-wallet Dashboard and Assets wallet totals are **not** bridged. There is no
-  wallet-less path to load balances for a chosen address (seeding `localStorage` is inert;
-  the balances store only fetches after a real extension connect), so that bridge belongs
-  to the T2 scripted-wallet tier. Today the T1 bridge binds the wallet-independent `/stats`
-  figures and the `/assets` zero-state total.
+- The funded-wallet Dashboard and Assets wallet totals are **not** bridged. T2 now scripts
+  a real Keplr connect (so the balances store does fetch for the connected address), but
+  the T2 accounts are deliberately unfunded — connect needs no funds. Bridging the rendered
+  Dashboard/Assets totals against `/api/balances` for a funded account is tracked in **#282**.
+  Today the T1 bridge binds the wallet-independent `/stats` figures and the `/assets`
+  zero-state total.
 - Every new route must gain a T1 route-smoke entry in `routes.spec.ts`. A route added
   without one is a silent gap, not a passing test.
 - `ws-rest-parity` may report `skip` on a quiet address: the backend only pushes a

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,6 +8,9 @@
       "name": "nolus-webapp-e2e",
       "version": "0.1.0",
       "dependencies": {
+        "@cosmjs/amino": "0.38.1",
+        "@cosmjs/crypto": "0.38.1",
+        "@cosmjs/encoding": "0.38.1",
         "undici": "8.7.0",
         "ws": "8.21.1"
       },
@@ -88,6 +91,57 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@cosmjs/amino": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.38.1.tgz",
+      "integrity": "sha512-WaThDpq2JwUyKuazq08Xa+FHzQ3jh1HcYnGL4xsyfqFwOlAvnl0EDvSSz9WSwz1oopIxFE9Qtf3OUKOlxBZbYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.38.1",
+        "@cosmjs/encoding": "^0.38.1",
+        "@cosmjs/math": "^0.38.1",
+        "@cosmjs/utils": "^0.38.1"
+      }
+    },
+    "node_modules/@cosmjs/crypto": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.38.1.tgz",
+      "integrity": "sha512-r1KQCjKAdMga2aZ/nkgULRF4fisPZMF6ErucVsMmkASBgDl0k9/vD9K9fHUdGClMv0oOYEfwOT/UTBR7K2OuYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.38.1",
+        "@cosmjs/math": "^0.38.1",
+        "@cosmjs/utils": "^0.38.1",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.2",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip39": "^1.6.0",
+        "hash-wasm": "^4.12.0"
+      }
+    },
+    "node_modules/@cosmjs/encoding": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.38.1.tgz",
+      "integrity": "sha512-i5jGgJhiXs7boePGA48xzYxnCbf3MS5nT/R2HvnvSQyVAG2A99NyL96lBgmz6etOJSGOiwVrB8uh1Qp5bq6WKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scure/base": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "readonly-date-esm": "^2.0.0"
+      }
+    },
+    "node_modules/@cosmjs/math": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.38.1.tgz",
+      "integrity": "sha512-MBk7p6kPNULi0TusD8O3xoBskFIkRzOtpmnea3sXbTVnguX7epNPVDITXM4tlsg8kAQrEOEIA0g5zAJxzH3Ikw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@cosmjs/utils": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.38.1.tgz",
+      "integrity": "sha512-ccQ5in6IvsQ+o/SstUdQH1jCJ2+MkJPZK7A/EYwMAFcjV8vzOgJ97LVy6AT24nwdi0/iVa2nbAG+fitUEsgLcA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
@@ -806,6 +860,45 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.139.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
@@ -1095,6 +1188,37 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1619,6 +1743,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
@@ -2079,6 +2223,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hash-wasm": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -2814,6 +2964,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/readonly-date-esm": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/readonly-date-esm/-/readonly-date-esm-2.0.0.tgz",
+      "integrity": "sha512-adlyzz144ofU22kjnnRIN0HPPqIbc5IZvMmMuVtEgMY4mKgNyKqOVb4Fa2GUzE2By4TEPOYoGqDoKRyqmeEuPQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/rolldown": {
       "version": "1.1.5",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "t0": "tsx src/t0.ts",
-    "t1": "playwright test --config playwright.config.ts",
+    "t1": "playwright test --config playwright.config.ts --project=desktop-light --project=desktop-dark --project=mobile",
+    "t2": "playwright test --config playwright.config.ts --project=t2",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",
@@ -19,6 +20,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@cosmjs/amino": "0.38.1",
+    "@cosmjs/crypto": "0.38.1",
+    "@cosmjs/encoding": "0.38.1",
     "undici": "8.7.0",
     "ws": "8.21.1"
   },

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "@playwright/test";
 import { parseT1Config } from "./src/config.js";
 import { buildHostResolverRules } from "./src/resolver.js";
-import type { T1Options } from "./src/t1/support.js";
+import type { T2Options } from "./src/t2/support.js";
 
 const parsed = parseT1Config(process.env);
 if (!parsed.ok) {
@@ -13,8 +13,8 @@ const resolverRules = buildHostResolverRules(hostOverrides);
 const launchArgs = resolverRules.length > 0 ? [`--host-resolver-rules=${resolverRules}`] : [];
 const isCI = Boolean(process.env.CI);
 
-export default defineConfig<T1Options>({
-  testDir: "src/t1",
+export default defineConfig<T2Options>({
+  testMatch: "**/*.spec.ts",
   fullyParallel: true,
   forbidOnly: isCI,
   workers: 2,
@@ -36,15 +36,23 @@ export default defineConfig<T1Options>({
   projects: [
     {
       name: "desktop-light",
+      testDir: "src/t1",
       use: { viewport: { width: 1440, height: 900 }, themeData: "light" }
     },
     {
       name: "desktop-dark",
+      testDir: "src/t1",
       use: { viewport: { width: 1440, height: 900 }, themeData: "dark" }
     },
     {
       name: "mobile",
+      testDir: "src/t1",
       use: { viewport: { width: 390, height: 844 }, themeData: "light" }
+    },
+    {
+      name: "t2",
+      testDir: "src/t2",
+      use: { viewport: { width: 1440, height: 900 }, themeData: "light" }
     }
   ]
 });

--- a/e2e/src/config.test.ts
+++ b/e2e/src/config.test.ts
@@ -6,8 +6,14 @@ import {
   deriveWsUrl,
   isValidNolusAddress,
   parseConfig,
-  parseT1Config
+  parseT1Config,
+  parseT2Config,
+  PUBLIC_FALLBACK_MNEMONIC
 } from "./config.js";
+
+// The canonical public all-zeros BIP-39 vector, used only to exercise the parser's
+// happy path — never a realistic secret.
+const VALID_MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
 const VALID_ADDRESS = "nolus10hvz04hh92xzct5hxnpsn5h2fp3p4amm28vhvp";
 const VALID_BASE = "https://app-dev.nolus.io";
@@ -193,5 +199,54 @@ describe("parseT1Config", () => {
       throw new Error("expected failure");
     }
     expect(result.errors).toEqual([`E2E_HOST_RESOLVER: pair 1 is missing "=" (expected host=target)`]);
+  });
+});
+
+describe("parseT2Config", () => {
+  it("accepts a primary mnemonic and falls back to the public vector for the secondary", () => {
+    const result = parseT2Config({ E2E_WALLET_MNEMONIC: VALID_MNEMONIC });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected success");
+    }
+    expect(result.config.primaryMnemonic).toBe(VALID_MNEMONIC);
+    expect(result.config.secondaryMnemonic).toBe(PUBLIC_FALLBACK_MNEMONIC);
+  });
+
+  it("uses an explicit secondary mnemonic when provided", () => {
+    const result = parseT2Config({
+      E2E_WALLET_MNEMONIC: VALID_MNEMONIC,
+      E2E_WALLET_MNEMONIC_2: PUBLIC_FALLBACK_MNEMONIC
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected success");
+    }
+    expect(result.config.secondaryMnemonic).toBe(PUBLIC_FALLBACK_MNEMONIC);
+  });
+
+  it("requires E2E_WALLET_MNEMONIC and names only the variable", () => {
+    const result = parseT2Config({});
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected failure");
+    }
+    expect(result.errors).toEqual([
+      "E2E_WALLET_MNEMONIC is required (a BIP-39 mnemonic of 12/15/18/21/24 lowercase words)"
+    ]);
+  });
+
+  it("rejects a malformed mnemonic without echoing its value", () => {
+    const badValue = "Two Words";
+    const result = parseT2Config({ E2E_WALLET_MNEMONIC: badValue });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected failure");
+    }
+    expect(result.errors).toEqual(["E2E_WALLET_MNEMONIC must be a BIP-39 mnemonic of 12/15/18/21/24 lowercase words"]);
+    for (const message of result.errors) {
+      expect(message).not.toContain("Two");
+      expect(message).not.toContain("Words");
+    }
   });
 });

--- a/e2e/src/config.ts
+++ b/e2e/src/config.ts
@@ -241,3 +241,87 @@ export function parseT1Config(env: Record<string, string | undefined>): T1Config
 
   return { ok: true, config: { baseUrl: base.baseUrl, hostOverrides: resolver.overrides } };
 }
+
+const MNEMONIC_WORD_COUNTS = new Set([12, 15, 18, 21, 24]);
+const MNEMONIC_WORD = /^[a-z]+$/;
+
+/**
+ * A deliberately public, unfunded BIP-39 test vector (the standard CosmJS docs
+ * mnemonic). It holds no assets on any chain and is used connect-only as the fallback
+ * second identity when E2E_WALLET_MNEMONIC_2 is unset. Never point real funds at it.
+ */
+export const PUBLIC_FALLBACK_MNEMONIC = "enlist hip relief stomach skate base shallow young switch frequent cry park";
+
+export interface T2Config {
+  primaryMnemonic: string;
+  secondaryMnemonic: string;
+}
+
+export type T2ConfigResult = { ok: true; config: T2Config } | { ok: false; errors: string[] };
+
+/**
+ * A plausible BIP-39 mnemonic is 12/15/18/21/24 lowercase words. This is a shape gate,
+ * not a checksum: it is enough to reject an obviously wrong value while — critically —
+ * never needing to echo the value to report the failure.
+ */
+function isPlausibleMnemonic(value: string): boolean {
+  const words = value.trim().split(/\s+/);
+  if (!MNEMONIC_WORD_COUNTS.has(words.length)) {
+    return false;
+  }
+  return words.every((word) => MNEMONIC_WORD.test(word));
+}
+
+interface MnemonicFieldSpec {
+  raw: string | undefined;
+  name: string;
+  required: boolean;
+  fallback: string;
+}
+
+function parseMnemonicField(spec: MnemonicFieldSpec, errors: string[]): string {
+  const trimmed = spec.raw?.trim();
+  if (!trimmed) {
+    if (spec.required) {
+      errors.push(`${spec.name} is required (a BIP-39 mnemonic of 12/15/18/21/24 lowercase words)`);
+      return "";
+    }
+    return spec.fallback;
+  }
+  if (!isPlausibleMnemonic(trimmed)) {
+    errors.push(`${spec.name} must be a BIP-39 mnemonic of 12/15/18/21/24 lowercase words`);
+    return spec.fallback;
+  }
+  return trimmed;
+}
+
+/**
+ * The T2 (scripted-wallet) subset. E2E_WALLET_MNEMONIC is required; E2E_WALLET_MNEMONIC_2
+ * is optional and falls back to the public unfunded test vector so the two-identity spec
+ * always has a distinct second account. Error messages name the offending variable only
+ * and never echo any part of a mnemonic — the same posture the file holds for
+ * E2E_HOST_RESOLVER.
+ */
+export function parseT2Config(env: Record<string, string | undefined>): T2ConfigResult {
+  const errors: string[] = [];
+
+  const primaryMnemonic = parseMnemonicField(
+    { raw: env.E2E_WALLET_MNEMONIC, name: "E2E_WALLET_MNEMONIC", required: true, fallback: "" },
+    errors
+  );
+  const secondaryMnemonic = parseMnemonicField(
+    {
+      raw: env.E2E_WALLET_MNEMONIC_2,
+      name: "E2E_WALLET_MNEMONIC_2",
+      required: false,
+      fallback: PUBLIC_FALLBACK_MNEMONIC
+    },
+    errors
+  );
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, config: { primaryMnemonic, secondaryMnemonic } };
+}

--- a/e2e/src/signer.test.ts
+++ b/e2e/src/signer.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { StdSignDoc } from "@cosmjs/amino";
+import { fromBase64, toBase64 } from "@cosmjs/encoding";
+import { createWalletIdentity, verifyAminoSignature } from "./signer.js";
+
+// A deliberately public, unfunded CosmJS test vector. The nolus1 address below was
+// produced once by running the derivation and pinned here as the known-good expectation.
+const TEST_MNEMONIC = "enlist hip relief stomach skate base shallow young switch frequent cry park";
+const EXPECTED_ADDRESS = "nolus14qemq0vw6y3gc3u3e0aty2e764u4gs5l0p8z0c";
+
+const SIGN_DOC: StdSignDoc = {
+  chain_id: "nolus-1",
+  account_number: "7",
+  sequence: "3",
+  fee: { amount: [{ denom: "unls", amount: "500" }], gas: "200000" },
+  msgs: [
+    {
+      type: "cosmos-sdk/MsgSend",
+      value: {
+        from_address: EXPECTED_ADDRESS,
+        to_address: EXPECTED_ADDRESS,
+        amount: [{ denom: "unls", amount: "1000" }]
+      }
+    }
+  ],
+  memo: "unit"
+};
+
+describe("createWalletIdentity", () => {
+  it("derives the pinned nolus1 address for the test vector", async () => {
+    const identity = await createWalletIdentity(TEST_MNEMONIC);
+    expect(identity.address).toBe(EXPECTED_ADDRESS);
+  });
+
+  it("returns a JSON-safe account payload with a 33-byte secp256k1 pubkey", async () => {
+    const identity = await createWalletIdentity(TEST_MNEMONIC);
+    const account = await identity.getAccounts();
+    expect(account.address).toBe(EXPECTED_ADDRESS);
+    expect(account.algo).toBe("secp256k1");
+    expect(account.pubkey).toBe(identity.pubkeyBase64);
+    expect(fromBase64(account.pubkey)).toHaveLength(33);
+  });
+
+  it("signs a byte-exact amino doc that verifies cryptographically", async () => {
+    const identity = await createWalletIdentity(TEST_MNEMONIC);
+    const response = await identity.signAmino(identity.address, SIGN_DOC);
+    expect(response.signed).toEqual(SIGN_DOC);
+    expect(response.signature.pub_key.value).toBe(identity.pubkeyBase64);
+    expect(verifyAminoSignature(response)).toBe(true);
+  });
+
+  it("rejects a tampered signature", async () => {
+    const identity = await createWalletIdentity(TEST_MNEMONIC);
+    const response = await identity.signAmino(identity.address, SIGN_DOC);
+    const bytes = fromBase64(response.signature.signature);
+    bytes[0] = bytes[0] === undefined ? 0 : bytes[0] ^ 0xff;
+    const tampered = {
+      ...response,
+      signature: { ...response.signature, signature: toBase64(bytes) }
+    };
+    expect(verifyAminoSignature(tampered)).toBe(false);
+  });
+
+  it("never serializes the mnemonic", async () => {
+    const identity = await createWalletIdentity(TEST_MNEMONIC);
+    const serialized = JSON.stringify(identity);
+    expect(Object.keys(JSON.parse(serialized) as object).sort()).toEqual(["address", "pubkeyBase64"]);
+    expect(serialized).not.toContain(TEST_MNEMONIC);
+  });
+});

--- a/e2e/src/signer.ts
+++ b/e2e/src/signer.ts
@@ -1,0 +1,100 @@
+import { createRequire } from "node:module";
+import type { AccountData, AminoSignResponse, StdSignDoc } from "@cosmjs/amino";
+
+// Minimal typed views over the cosmjs surface this module uses. See the createRequire
+// note below for why the modules are loaded, not imported; casting the loaded value to a
+// hand-declared interface keeps every call fully typed without an `import()` annotation.
+type SignatureHandle = object;
+
+interface OfflineWallet {
+  getAccounts(): Promise<readonly AccountData[]>;
+  signAmino(signerAddress: string, signDoc: StdSignDoc): Promise<AminoSignResponse>;
+}
+
+interface AminoLib {
+  Secp256k1HdWallet: { fromMnemonic(mnemonic: string, options: { prefix: string }): Promise<OfflineWallet> };
+  serializeSignDoc(signDoc: StdSignDoc): Uint8Array;
+}
+
+interface CryptoLib {
+  sha256(data: Uint8Array): Uint8Array;
+  Secp256k1Signature: { fromFixedLength(data: Uint8Array): SignatureHandle };
+  Secp256k1: { verifySignature(signature: SignatureHandle, messageHash: Uint8Array, pubkey: Uint8Array): boolean };
+}
+
+interface EncodingLib {
+  toBase64(data: Uint8Array): string;
+  fromBase64(encoded: string): Uint8Array;
+}
+
+// Playwright (pinned 1.61) installs a require-hook that cannot interop cosmjs's CJS
+// build with the ESM-only `@scure/base` it depends on, so a static `import` of any
+// cosmjs package aborts the T2 browser run at collection time. A native `createRequire`
+// sidesteps that hook and loads the real modules; the same path works under vitest, so
+// this file stays usable by both runners without a second code path.
+const loadModule = createRequire(import.meta.url);
+const aminoLib = loadModule("@cosmjs/amino") as AminoLib;
+const cryptoLib = loadModule("@cosmjs/crypto") as CryptoLib;
+const encodingLib = loadModule("@cosmjs/encoding") as EncodingLib;
+
+const NOLUS_PREFIX = "nolus";
+
+/**
+ * JSON-safe account shape handed to the in-page stub. A `Uint8Array` cannot survive a
+ * Playwright `exposeFunction` boundary, so the public key crosses as base64; the stub
+ * decodes it back to bytes in the browser before returning it to the app.
+ */
+export interface AccountPayload {
+  address: string;
+  pubkey: string;
+  algo: string;
+}
+
+/**
+ * A wallet identity usable by the scripted Keplr stub. The mnemonic is deliberately
+ * not a member of this type: it is captured only inside the closure returned by
+ * `createWalletIdentity`, never stored as a property, so neither `JSON.stringify` nor a
+ * page-side binding can ever serialize it out of Node.
+ */
+export interface WalletIdentity {
+  readonly address: string;
+  readonly pubkeyBase64: string;
+  getAccounts(): Promise<AccountPayload>;
+  signAmino(signerAddress: string, signDoc: StdSignDoc): Promise<AminoSignResponse>;
+}
+
+export async function createWalletIdentity(mnemonic: string): Promise<WalletIdentity> {
+  const wallet = await aminoLib.Secp256k1HdWallet.fromMnemonic(mnemonic, { prefix: NOLUS_PREFIX });
+  const accounts = await wallet.getAccounts();
+  const account = accounts[0];
+  if (account === undefined) {
+    throw new Error("derived wallet exposed no account");
+  }
+  const address = account.address;
+  const pubkeyBase64 = encodingLib.toBase64(account.pubkey);
+  const algo = account.algo;
+
+  return {
+    address,
+    pubkeyBase64,
+    getAccounts(): Promise<AccountPayload> {
+      return Promise.resolve({ address, pubkey: pubkeyBase64, algo });
+    },
+    signAmino(signerAddress: string, signDoc: StdSignDoc): Promise<AminoSignResponse> {
+      return wallet.signAmino(signerAddress, signDoc);
+    }
+  };
+}
+
+/**
+ * Verifies a secp256k1 amino signature the way CosmJS's `SigningStargateClient` does:
+ * over `sha256(serializeSignDoc(signed))` against the embedded public key. This is the
+ * outermost cryptographic seam of the stub — a passing verification proves the signature
+ * a real transaction would carry is valid, not merely that a validator accepted a shape.
+ */
+export function verifyAminoSignature(response: AminoSignResponse): boolean {
+  const messageHash = cryptoLib.sha256(aminoLib.serializeSignDoc(response.signed));
+  const signature = cryptoLib.Secp256k1Signature.fromFixedLength(encodingLib.fromBase64(response.signature.signature));
+  const pubkey = encodingLib.fromBase64(String(response.signature.pub_key.value));
+  return cryptoLib.Secp256k1.verifySignature(signature, messageHash, pubkey);
+}

--- a/e2e/src/t2/connect.spec.ts
+++ b/e2e/src/t2/connect.spec.ts
@@ -3,6 +3,11 @@ import type { Page, Request } from "@playwright/test";
 import type { AminoSignResponse, StdSignDoc } from "@cosmjs/amino";
 import { Agent } from "undici";
 import type { Dispatcher } from "undici";
+import { parseT1Config, parseT2Config } from "../config.js";
+import { createUndiciConnector } from "../resolver.js";
+import { getJson } from "../http.js";
+import { createWalletIdentity, verifyAminoSignature } from "../signer.js";
+import { buildKeplrInitScript, buildSignAminoScript, isKeplrExpression, lastChainIdExpression } from "./keplr.js";
 
 interface WalletLabels {
   connect: string;
@@ -10,11 +15,10 @@ interface WalletLabels {
   disconnect: string;
 }
 
-import { parseT1Config, parseT2Config } from "../config.js";
-import { createUndiciConnector } from "../resolver.js";
-import { getJson } from "../http.js";
-import { createWalletIdentity, verifyAminoSignature } from "../signer.js";
-import { buildKeplrInitScript, buildSignAminoScript, isKeplrExpression, lastChainIdExpression } from "./keplr.js";
+interface AddressTruncation {
+  front: number;
+  back: number;
+}
 
 const APP_SHELL_TIMEOUT = 20000;
 const CONNECT_TIMEOUT = 30000;
@@ -55,7 +59,7 @@ test.afterAll(async () => {
   if (dispatcher !== undefined) await dispatcher.close();
 });
 
-function truncateAddress(address: string, front: number, back: number): string {
+function truncateAddress(address: string, { front, back }: AddressTruncation): string {
   return `${address.substring(0, front)}...${address.substring(address.length - back)}`;
 }
 
@@ -69,7 +73,7 @@ async function connectKeplr(page: Page): Promise<void> {
 }
 
 async function assertConnected(page: Page, address: string): Promise<void> {
-  const shortName = truncateAddress(address, 8, 4);
+  const shortName = truncateAddress(address, { front: 8, back: 4 });
   await expect(page.getByRole("button", { name: shortName, exact: true })).toBeVisible({ timeout: CONNECT_TIMEOUT });
   const mechanism = await page.evaluate<string | null>(`localStorage.getItem(${JSON.stringify(MECHANISM_KEY)})`);
   expect(mechanism).toBe(EXTENSION_MECHANISM);
@@ -136,6 +140,9 @@ test.describe("scripted keplr connect", () => {
     page.on("popup", () => (popupOpened = true));
     const signRequests: string[] = [];
     const onRequest = (req: Request): void => {
+      // Only non-GET same-origin traffic is relevant: a broadcast/sign call would be a
+      // POST, whereas GETs here are unrelated background polling (prices/balances).
+      if (req.method() === "GET") return;
       const url = new URL(req.url());
       if (url.host === apiHost && url.pathname.startsWith("/api/")) signRequests.push(url.pathname);
     };
@@ -149,7 +156,7 @@ test.describe("scripted keplr connect", () => {
     expect(response.signature.pub_key.value).toBe(wallet.pubkeyBase64);
     expect(verifyAminoSignature(response)).toBe(true);
     expect(popupOpened, "signing must not open a popup").toBe(false);
-    expect(signRequests, "signing must not trigger a same-origin API request").toEqual([]);
+    expect(signRequests, "signing must not trigger a non-GET same-origin API request").toEqual([]);
   });
 
   test("disconnects through the UI and clears wallet storage", async ({ page, budget, wallet }) => {
@@ -159,7 +166,9 @@ test.describe("scripted keplr connect", () => {
     await connectKeplr(page);
     await assertConnected(page, wallet.address);
 
-    await page.getByRole("button", { name: truncateAddress(wallet.address, 8, 4), exact: true }).click();
+    await page
+      .getByRole("button", { name: truncateAddress(wallet.address, { front: 8, back: 4 }), exact: true })
+      .click();
     const accountCard = page.locator("div.bg-neutral-bg-1").filter({ hasText: NETWORK_LABEL });
     await accountCard.getByRole("button").last().click();
     await page.getByRole("button", { name: labels.disconnect, exact: true }).click();
@@ -212,8 +221,8 @@ test.describe("secondary identity", () => {
     await waitForAppShell(page);
     await connectKeplr(page);
     await assertConnected(page, wallet.address);
-    await expect(page.getByRole("button", { name: truncateAddress(primary.address, 8, 4), exact: true })).toHaveCount(
-      0
-    );
+    await expect(
+      page.getByRole("button", { name: truncateAddress(primary.address, { front: 8, back: 4 }), exact: true })
+    ).toHaveCount(0);
   });
 });

--- a/e2e/src/t2/connect.spec.ts
+++ b/e2e/src/t2/connect.spec.ts
@@ -1,0 +1,219 @@
+import { test, expect } from "./support.js";
+import type { Page, Request } from "@playwright/test";
+import type { AminoSignResponse, StdSignDoc } from "@cosmjs/amino";
+import { Agent } from "undici";
+import type { Dispatcher } from "undici";
+
+interface WalletLabels {
+  connect: string;
+  keplr: string;
+  disconnect: string;
+}
+
+import { parseT1Config, parseT2Config } from "../config.js";
+import { createUndiciConnector } from "../resolver.js";
+import { getJson } from "../http.js";
+import { createWalletIdentity, verifyAminoSignature } from "../signer.js";
+import { buildKeplrInitScript, buildSignAminoScript, isKeplrExpression, lastChainIdExpression } from "./keplr.js";
+
+const APP_SHELL_TIMEOUT = 20000;
+const CONNECT_TIMEOUT = 30000;
+const MECHANISM_KEY = "wallet_connect_mechanism";
+const PUBKEY_KEY = "wallet_pubkey";
+const EXTENSION_MECHANISM = "extension";
+const NETWORK_LABEL = "Nolus";
+
+let labels: WalletLabels;
+let dispatcher: Dispatcher | undefined;
+
+function readMessage(locale: unknown, key: string): string {
+  if (typeof locale !== "object" || locale === null) throw new Error("locale payload is not an object");
+  const message = (locale as Record<string, unknown>).message;
+  if (typeof message !== "object" || message === null) throw new Error("locale payload has no message map");
+  const value = (message as Record<string, unknown>)[key];
+  if (typeof value !== "string") throw new Error(`locale message "${key}" is missing`);
+  return value;
+}
+
+test.beforeAll(async () => {
+  const parsed = parseT1Config(process.env);
+  if (!parsed.ok) throw new Error(`E2E T2 config error: ${parsed.errors.join("; ")}`);
+  const origin = parsed.config.baseUrl.replace(/\/$/, "");
+  dispatcher =
+    parsed.config.hostOverrides.size > 0
+      ? new Agent({ connect: createUndiciConnector(parsed.config.hostOverrides) })
+      : undefined;
+  const locale = await getJson(`${origin}/api/locales/en`, dispatcher);
+  labels = {
+    connect: readMessage(locale, "connect-wallet"),
+    keplr: readMessage(locale, "keplr"),
+    disconnect: readMessage(locale, "disconnect")
+  };
+});
+
+test.afterAll(async () => {
+  if (dispatcher !== undefined) await dispatcher.close();
+});
+
+function truncateAddress(address: string, front: number, back: number): string {
+  return `${address.substring(0, front)}...${address.substring(address.length - back)}`;
+}
+
+async function waitForAppShell(page: Page): Promise<void> {
+  await page.locator("#app button").first().waitFor({ state: "visible", timeout: APP_SHELL_TIMEOUT });
+}
+
+async function connectKeplr(page: Page): Promise<void> {
+  await page.getByRole("button", { name: labels.connect, exact: true }).click();
+  await page.getByRole("button", { name: labels.keplr, exact: true }).click();
+}
+
+async function assertConnected(page: Page, address: string): Promise<void> {
+  const shortName = truncateAddress(address, 8, 4);
+  await expect(page.getByRole("button", { name: shortName, exact: true })).toBeVisible({ timeout: CONNECT_TIMEOUT });
+  const mechanism = await page.evaluate<string | null>(`localStorage.getItem(${JSON.stringify(MECHANISM_KEY)})`);
+  expect(mechanism).toBe(EXTENSION_MECHANISM);
+}
+
+function bankSendDoc(chainId: string, address: string): StdSignDoc {
+  return {
+    chain_id: chainId,
+    account_number: "12",
+    sequence: "0",
+    fee: { amount: [{ denom: "unls", amount: "500" }], gas: "200000" },
+    msgs: [
+      {
+        type: "cosmos-sdk/MsgSend",
+        value: { from_address: address, to_address: address, amount: [{ denom: "unls", amount: "1000" }] }
+      }
+    ],
+    memo: "e2e-keplr-stub"
+  };
+}
+
+function threeWordWindows(mnemonic: string): string[] {
+  const words = mnemonic.trim().split(/\s+/);
+  const windows: string[] = [];
+  for (let i = 0; i + 3 <= words.length; i++) {
+    windows.push(words.slice(i, i + 3).join(" "));
+  }
+  return windows;
+}
+
+test.describe("scripted keplr connect", () => {
+  test("connects through the real UI without an identity marker", async ({ page, budget, wallet }) => {
+    budget.route = "/";
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await waitForAppShell(page);
+
+    const marker = await page.evaluate<unknown>(isKeplrExpression);
+    expect(marker, "the stub must not expose an isKeplr identity marker (#155)").toBeUndefined();
+
+    await connectKeplr(page);
+    await assertConnected(page, wallet.address);
+  });
+
+  test("signs an amino doc locally with a valid secp256k1 signature", async ({ page, budget, wallet }, testInfo) => {
+    budget.route = "/";
+    const baseURL = testInfo.project.use.baseURL;
+    if (baseURL === undefined) throw new Error("T2 project is missing baseURL");
+    const apiHost = new URL(baseURL).host;
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await waitForAppShell(page);
+    const balancesSettled = page.waitForResponse((resp) => resp.url().includes("/api/balances"), {
+      timeout: CONNECT_TIMEOUT
+    });
+    await connectKeplr(page);
+    await assertConnected(page, wallet.address);
+    await balancesSettled;
+
+    const chainId = await page.evaluate<string>(lastChainIdExpression);
+    expect(chainId.length).toBeGreaterThan(0);
+    const signDoc = bankSendDoc(chainId, wallet.address);
+
+    let popupOpened = false;
+    page.on("popup", () => (popupOpened = true));
+    const signRequests: string[] = [];
+    const onRequest = (req: Request): void => {
+      const url = new URL(req.url());
+      if (url.host === apiHost && url.pathname.startsWith("/api/")) signRequests.push(url.pathname);
+    };
+    page.on("request", onRequest);
+
+    const response = await page.evaluate<AminoSignResponse>(buildSignAminoScript(wallet.address, signDoc));
+
+    page.off("request", onRequest);
+
+    expect(response.signed).toEqual(signDoc);
+    expect(response.signature.pub_key.value).toBe(wallet.pubkeyBase64);
+    expect(verifyAminoSignature(response)).toBe(true);
+    expect(popupOpened, "signing must not open a popup").toBe(false);
+    expect(signRequests, "signing must not trigger a same-origin API request").toEqual([]);
+  });
+
+  test("disconnects through the UI and clears wallet storage", async ({ page, budget, wallet }) => {
+    budget.route = "/";
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await waitForAppShell(page);
+    await connectKeplr(page);
+    await assertConnected(page, wallet.address);
+
+    await page.getByRole("button", { name: truncateAddress(wallet.address, 8, 4), exact: true }).click();
+    const accountCard = page.locator("div.bg-neutral-bg-1").filter({ hasText: NETWORK_LABEL });
+    await accountCard.getByRole("button").last().click();
+    await page.getByRole("button", { name: labels.disconnect, exact: true }).click();
+
+    await expect(page.getByRole("button", { name: labels.connect, exact: true })).toBeVisible({
+      timeout: CONNECT_TIMEOUT
+    });
+    const mechanism = await page.evaluate<string | null>(`localStorage.getItem(${JSON.stringify(MECHANISM_KEY)})`);
+    const pubkey = await page.evaluate<string | null>(`localStorage.getItem(${JSON.stringify(PUBKEY_KEY)})`);
+    expect(mechanism).toBeNull();
+    expect(pubkey).toBeNull();
+  });
+
+  test("leaks no mnemonic fragment into the page, console, or init script", async ({ page, budget, wallet }) => {
+    budget.route = "/";
+    const consoleLines: string[] = [];
+    page.on("console", (msg) => consoleLines.push(msg.text()));
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await waitForAppShell(page);
+    await connectKeplr(page);
+    await assertConnected(page, wallet.address);
+
+    const parsed = parseT2Config(process.env);
+    if (!parsed.ok) throw new Error("T2 config unexpectedly invalid inside spec");
+    const windows = threeWordWindows(parsed.config.primaryMnemonic);
+    const pageContent = await page.content();
+    const initScript = buildKeplrInitScript();
+
+    const inConsole = windows.some((w) => consoleLines.join("\n").includes(w));
+    const inPage = windows.some((w) => pageContent.includes(w));
+    const inScript = windows.some((w) => initScript.includes(w));
+    expect(inConsole, "a 3-word mnemonic window appeared in console output").toBe(false);
+    expect(inPage, "a 3-word mnemonic window appeared in page content").toBe(false);
+    expect(inScript, "a 3-word mnemonic window appeared in the init-script source").toBe(false);
+  });
+});
+
+test.describe("secondary identity", () => {
+  test.use({ walletIdentity: "secondary" });
+
+  test("connects the distinct fallback identity", async ({ page, budget, wallet }) => {
+    budget.route = "/";
+    const parsed = parseT2Config(process.env);
+    if (!parsed.ok) throw new Error("T2 config unexpectedly invalid inside spec");
+    const primary = await createWalletIdentity(parsed.config.primaryMnemonic);
+    expect(wallet.address).not.toBe(primary.address);
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await waitForAppShell(page);
+    await connectKeplr(page);
+    await assertConnected(page, wallet.address);
+    await expect(page.getByRole("button", { name: truncateAddress(primary.address, 8, 4), exact: true })).toHaveCount(
+      0
+    );
+  });
+});

--- a/e2e/src/t2/keplr.test.ts
+++ b/e2e/src/t2/keplr.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { StdSignDoc } from "@cosmjs/amino";
 import { PUBLIC_FALLBACK_MNEMONIC } from "../config.js";
-import { buildKeplrInitScript } from "./keplr.js";
+import { buildKeplrInitScript, buildSignAminoScript } from "./keplr.js";
 
 describe("buildKeplrInitScript", () => {
   const script = buildKeplrInitScript();
@@ -23,6 +24,38 @@ describe("buildKeplrInitScript", () => {
 
   it("takes no arguments, so it can never receive or embed a secret", () => {
     expect(buildKeplrInitScript).toHaveLength(0);
+    expect(script).not.toContain(PUBLIC_FALLBACK_MNEMONIC);
+    for (const word of PUBLIC_FALLBACK_MNEMONIC.split(" ")) {
+      expect(script).not.toContain(` ${word} `);
+    }
+  });
+});
+
+describe("buildSignAminoScript", () => {
+  const SIGNER = "nolus1testaddressplaceholderxxxxxxxxxxxxxxxx";
+  const SIGN_DOC: StdSignDoc = {
+    chain_id: "nolus-probe-1",
+    account_number: "1",
+    sequence: "0",
+    fee: { amount: [{ denom: "unls", amount: "500" }], gas: "200000" },
+    msgs: [{ type: "cosmos-sdk/MsgSend", value: { from_address: SIGNER, to_address: SIGNER, amount: [] } }],
+    memo: "probe-memo"
+  };
+  const script = buildSignAminoScript(SIGNER, SIGN_DOC);
+
+  it("drives the amino getter and the signAmino method", () => {
+    expect(script).toContain("getOfflineSignerOnlyAmino");
+    expect(script).toContain("signAmino");
+  });
+
+  it("passes the signer address and sign doc through verbatim", () => {
+    expect(script).toContain(JSON.stringify(SIGNER));
+    expect(script).toContain(SIGN_DOC.chain_id);
+    expect(script).toContain(SIGN_DOC.memo);
+    expect(script).toContain(JSON.stringify(SIGN_DOC));
+  });
+
+  it("receives only an address and a doc, so it embeds no secret", () => {
     expect(script).not.toContain(PUBLIC_FALLBACK_MNEMONIC);
     for (const word of PUBLIC_FALLBACK_MNEMONIC.split(" ")) {
       expect(script).not.toContain(` ${word} `);

--- a/e2e/src/t2/keplr.test.ts
+++ b/e2e/src/t2/keplr.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { PUBLIC_FALLBACK_MNEMONIC } from "../config.js";
+import { buildKeplrInitScript } from "./keplr.js";
+
+describe("buildKeplrInitScript", () => {
+  const script = buildKeplrInitScript();
+
+  it("defines exactly the four methods the app calls", () => {
+    for (const method of ["enable", "experimentalSuggestChain", "getOfflineSignerOnlyAmino", "getOfflineSignerAuto"]) {
+      expect(script).toContain(`${method}:`);
+    }
+  });
+
+  it("omits every method the app never calls", () => {
+    for (const absent of ["getKey", "signArbitrary", "defaultOptions", "signDirect", "enigmaEncrypt"]) {
+      expect(script).not.toContain(absent);
+    }
+  });
+
+  it("exposes no isKeplr identity marker (the #155 pin)", () => {
+    expect(script).not.toContain("isKeplr");
+  });
+
+  it("takes no arguments, so it can never receive or embed a secret", () => {
+    expect(buildKeplrInitScript).toHaveLength(0);
+    expect(script).not.toContain(PUBLIC_FALLBACK_MNEMONIC);
+    for (const word of PUBLIC_FALLBACK_MNEMONIC.split(" ")) {
+      expect(script).not.toContain(` ${word} `);
+    }
+  });
+});

--- a/e2e/src/t2/keplr.ts
+++ b/e2e/src/t2/keplr.ts
@@ -1,0 +1,97 @@
+import type { Page } from "@playwright/test";
+import type { AminoSignResponse, StdSignDoc } from "@cosmjs/amino";
+
+import type { AccountPayload, WalletIdentity } from "../signer.js";
+
+/**
+ * A scripted `window.keplr` provider that lets Playwright drive the app's real Keplr
+ * connect flow without a browser extension. It implements EXACTLY the four methods the
+ * app calls and nothing else — `getKey`, `signArbitrary`, `defaultOptions` and friends
+ * have zero call sites in `src/` and are deliberately omitted so drift stays visible.
+ *
+ * App call sites (verified against main @ 9394cceb):
+ *   - `enable(chainId)`
+ *       src/common/stores/wallet/actions/connectKeplrLike.ts:46
+ *       src/networks/cosm/WalletFactory.ts:89
+ *   - `experimentalSuggestChain(chainInfo)`
+ *       src/common/stores/wallet/actions/connectKeplrLike.ts:24 (presence), :34 (call)
+ *       src/networks/cosm/WalletFactory.ts:71 (presence), :83 (call)
+ *   - `getOfflineSignerOnlyAmino(chainId, options)`  (Path A — connect button)
+ *       src/common/stores/wallet/actions/connectKeplrLike.ts:22 (presence), :48-49 (call)
+ *   - `getOfflineSignerAuto(chainId)`  (Path B — cross-chain external wallet)
+ *       src/networks/cosm/WalletFactory.ts:69 (presence), :92 (call)
+ *
+ * The signer object returned by the two getters intentionally omits `signDirect`:
+ * CosmJS's `isOfflineDirectSigner` is literally `signer.signDirect !== undefined`
+ * (@cosmjs/proto-signing signer.js), so defining it at all would route signing down the
+ * direct branch instead of the amino `signAmino` branch the app relies on.
+ */
+
+const GET_ACCOUNTS_BINDING = "__e2eWalletGetAccounts";
+const SIGN_AMINO_BINDING = "__e2eWalletSignAmino";
+const LAST_CHAIN_ID_VAR = "__e2eLastChainId";
+
+/**
+ * Browser-context source for the stub. This package's tsconfig omits the "DOM" lib, so
+ * every line here is authored as a string (never referencing browser globals in typed
+ * code) exactly like the `seedScript` pattern in `src/t1/support.ts`. The builder takes
+ * no arguments — in particular it never receives the mnemonic — so the init-script
+ * source can never carry a secret.
+ */
+export function buildKeplrInitScript(): string {
+  return `(() => {
+  const decodePubkey = (base64) => {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) { bytes[i] = binary.charCodeAt(i); }
+    return bytes;
+  };
+  const makeAminoSigner = () => ({
+    getAccounts: async () => {
+      const account = await window.${GET_ACCOUNTS_BINDING}();
+      return [{ address: account.address, pubkey: decodePubkey(account.pubkey), algo: account.algo }];
+    },
+    signAmino: (signerAddress, signDoc) => window.${SIGN_AMINO_BINDING}(signerAddress, signDoc)
+  });
+  window.keplr = {
+    enable: (chainId) => { window.${LAST_CHAIN_ID_VAR} = chainId; return Promise.resolve(); },
+    experimentalSuggestChain: () => Promise.resolve(),
+    getOfflineSignerOnlyAmino: () => makeAminoSigner(),
+    getOfflineSignerAuto: () => Promise.resolve(makeAminoSigner())
+  };
+})();`;
+}
+
+/**
+ * Registers the Node-side signing bindings and injects the in-page `window.keplr` before
+ * the SPA boots. The mnemonic never crosses into the page: `getAccounts` hands back a
+ * base64 public key and `signAmino` proxies a JSON-safe `StdSignDoc`/`AminoSignResponse`
+ * pair, both of which survive the `exposeFunction` boundary untouched.
+ */
+export async function installKeplrStub(page: Page, identity: WalletIdentity): Promise<void> {
+  await page.exposeFunction(GET_ACCOUNTS_BINDING, (): Promise<AccountPayload> => identity.getAccounts());
+  await page.exposeFunction(
+    SIGN_AMINO_BINDING,
+    (signerAddress: string, signDoc: StdSignDoc): Promise<AminoSignResponse> =>
+      identity.signAmino(signerAddress, signDoc)
+  );
+  await page.addInitScript(buildKeplrInitScript());
+}
+
+/** Browser expression reading the chain id the app last passed to `enable`. */
+export const lastChainIdExpression = `window.${LAST_CHAIN_ID_VAR}`;
+
+/** Browser expression reading the stub's identity marker (must be `undefined`, the #155 pin). */
+export const isKeplrExpression = `window.keplr.isKeplr`;
+
+/**
+ * Browser-context source that drives one amino signature through the stub's Path-A
+ * getter, mirroring how CosmJS calls the signer: `getOfflineSignerOnlyAmino` synchronously,
+ * then `signAmino`. Authored as a string for the same no-DOM-lib reason as the init script.
+ */
+export function buildSignAminoScript(signerAddress: string, signDoc: StdSignDoc): string {
+  return `(async () => {
+  const signer = window.keplr.getOfflineSignerOnlyAmino(window.${LAST_CHAIN_ID_VAR});
+  return signer.signAmino(${JSON.stringify(signerAddress)}, ${JSON.stringify(signDoc)});
+})()`;
+}

--- a/e2e/src/t2/support.ts
+++ b/e2e/src/t2/support.ts
@@ -1,0 +1,45 @@
+import { test as t1Test, expect } from "../t1/support.js";
+import type { T1Options } from "../t1/support.js";
+import { parseT2Config } from "../config.js";
+import { createWalletIdentity } from "../signer.js";
+import type { WalletIdentity } from "../signer.js";
+import { installKeplrStub } from "./keplr.js";
+
+export type WalletSelection = "primary" | "secondary";
+
+export interface T2Options extends T1Options {
+  walletIdentity: WalletSelection;
+}
+
+export interface T2Fixtures {
+  wallet: WalletIdentity;
+}
+
+function selectMnemonic(selection: WalletSelection): string {
+  const parsed = parseT2Config(process.env);
+  if (!parsed.ok) {
+    throw new Error(`E2E T2 configuration error:\n  - ${parsed.errors.join("\n  - ")}`);
+  }
+  return selection === "secondary" ? parsed.config.secondaryMnemonic : parsed.config.primaryMnemonic;
+}
+
+/**
+ * T2 reuses the T1 `budget` fixture verbatim — the same console/pageerror/failed-request
+ * and `/ws` collectors and the same clean-budget assertion. A wallet-connected page fetches
+ * its balances once on connect (a same-origin `200`) and opens a `balances` WS subscription
+ * on the existing `/ws` socket; neither trips the T1 budget, so no relaxation is needed.
+ *
+ * The `wallet` fixture derives the selected identity in Node and installs the scripted
+ * `window.keplr` before the SPA boots. `walletIdentity` is a fixture option so a spec can
+ * switch to the secondary account with `test.use({ walletIdentity: "secondary" })`.
+ */
+export const test = t1Test.extend<T2Options & T2Fixtures>({
+  walletIdentity: ["primary", { option: true }],
+  wallet: async ({ page, walletIdentity }, use) => {
+    const identity = await createWalletIdentity(selectMnemonic(walletIdentity));
+    await installKeplrStub(page, identity);
+    await use(identity);
+  }
+});
+
+export { expect };

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -7,18 +7,18 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/t0.ts", "src/http.ts", "src/ws.ts", "src/t1/**"],
+      exclude: ["src/**/*.test.ts", "src/t0.ts", "src/http.ts", "src/ws.ts", "src/t1/**", "src/t2/**"],
       reporter: ["text", "json-summary"],
       // Ratchet floors pinned just under measured actuals. The pure modules
-      // (config/decimal/report/validate) sit at 97-100%; the global is pulled down by
-      // the network runners in the check files and resolver's connector, which have no
+      // (config/decimal/report/validate/signer) sit at 93-100%; the global is pulled down
+      // by the network runners in the check files and resolver's connector, which have no
       // unit tests. Floors track actuals while this branch evolves; once merged, the
       // shipped baseline is one-way: raise as coverage improves, never lower.
       thresholds: {
-        statements: 79,
-        branches: 78,
-        functions: 73,
-        lines: 79
+        statements: 82,
+        branches: 79,
+        functions: 77,
+        lines: 81
       }
     }
   }


### PR DESCRIPTION
Closes #281. Part of #278.

## Summary
Add a scripted `window.keplr` provider to the e2e package so the wallet-connected tiers (T2+) can drive the real Keplr connect flow against staging without a browser extension. Signing is Node-side: the mnemonic never enters the page context.

## Changes
- `e2e/src/signer.ts`: wallet identity over `@cosmjs/amino@0.38.1` (version-aligned with the app's pin); the mnemonic is captured in a closure and is not reachable as a property. Loaded via `createRequire` because Playwright 1.61's loader cannot import CosmJS's CJS build (ESM-only `@scure/base` dependency).
- `e2e/src/t2/keplr.ts`: `window.keplr` injected as a page init script with exactly the four methods the app calls — `enable`, `experimentalSuggestChain`, `getOfflineSignerOnlyAmino` (synchronous, matching the unawaited call in `connectKeplrLike.ts`), `getOfflineSignerAuto` — enumerated with call-site anchors in the doc header. The returned amino signer deliberately omits `signDirect` (CosmJS detects direct signing by property presence) and the stub carries no `isKeplr` marker (the #155 regression class); page-side signing proxies to Node over exposed bindings, pubkey crosses as base64.
- `e2e/src/t2/connect.spec.ts` + `support.ts`: five specs — connect (asserts no identity marker first), offline signing (secp256k1 signature verified cryptographically in Node; no popup, no non-GET API request), disconnect, second identity, secret hygiene — on a fixture extending the T1 budget machinery.
- Config: `E2E_WALLET_MNEMONIC` (required for t2, value never echoed), `E2E_WALLET_MNEMONIC_2` (optional; falls back to a documented public unfunded test vector for connect-only use).
- Wiring: `t2` Playwright project + npm script (`npm run t1` behavior unchanged), `src/t2/**` excluded from unit coverage, coverage floors raised 79/78/73/79 → 82/79/77/81 (one-way), README T2 section incl. the note that the exposed signing binding makes the configured mnemonic a disposable-test-wallet-only value.

## Verification
- Ran the package gate in order: typecheck, format:check, lint at zero warnings, test:coverage — 107 unit tests pass, floors green.
- Ran the t2 suite against the live staging origin: 5/5 pass in ~4s on two workers, no retries.
- Ran three independent review passes over the full diff (generic 12-item bug checklist, security, project-convention conformance). One convention finding (positional numeric parameters) fixed in the final commit; security pass clear — mnemonic confined to Node, no secret or internal infrastructure value appears anywhere in the diff. Re-review after the fix came back clean on all three.
- Verified `npm run t1` still runs exactly the three original projects and `npm run t2` only the five T2 specs (`--list`).
- Verified unit signing tests enter at the outermost seam: a byte-exact StdSignDoc through `signAmino`, verified against the pubkey.

suite impact: T2 (new tier), covered by `e2e/src/t2/connect.spec.ts`; the funded Dashboard/Assets bridge remains open, owned by #282.