### PR TITLE
test(e2e): m3 tx engine, spend budget and reconciliation

### DIFF
--- a/.github/workflows/e2e-t3-engine.yaml
+++ b/.github/workflows/e2e-t3-engine.yaml
@@ -1,0 +1,61 @@
+name: E2E T3 tx engine (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_domain:
+        description: "Target host the smoke runs against (e.g. app-dev.nolus.io)"
+        required: true
+        type: string
+
+concurrency:
+  group: e2e-t3-engine-${{ inputs.base_domain }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  t3-engine:
+    name: T3 tx engine smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Run the T3 tx engine smoke
+        id: t3
+        working-directory: e2e
+        env:
+          E2E_BASE_URL: https://${{ inputs.base_domain }}
+          E2E_WS_URL: wss://${{ inputs.base_domain }}/ws
+          E2E_HOST_RESOLVER: ${{ inputs.base_domain }}=${{ vars.DEPLOY_HOST }}
+          E2E_READONLY_ADDRESS: ${{ vars.E2E_READONLY_ADDRESS }}
+          E2E_WALLET_MNEMONIC: ${{ secrets.E2E_WALLET_MNEMONIC }}
+          E2E_WALLET_MNEMONIC_2: ${{ secrets.E2E_WALLET_MNEMONIC_2 }}
+          E2E_SPEND_CAP_NLS: '1'
+          E2E_SPEND_CAP_USDC: '0'
+        run: |
+          set -euo pipefail
+          npm ci
+          npx playwright install chromium
+          npm run t3:engine
+
+      - name: Upload T3 journal + report artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-t3-${{ inputs.base_domain }}
+          path: |
+            e2e/results/
+            e2e/playwright-report/
+            e2e/test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -477,6 +477,142 @@ codegen, regenerate the schemas and fail on drift, then the e2e package gate
 (typecheck → format:check → lint → test:coverage) and the coverage-matrix guard. This is the
 static gate scope of issue #305. The live and fixture-mode browser tiers run out of band.
 
+## The T3 tx engine
+
+The T3 layer (`src/t3/`) is the value-moving substrate the mutation specs (#283) and the
+reporting tier (#285) build on. It is not a user-facing surface, so it adds nothing to the
+coverage matrix; its guarantees are covered by unit tests instead. Every module except the
+network/fs/browser glue (`journalStore.ts`, `runtime.ts`, `repair.ts`, the `*.spec.ts` smoke)
+is pure and unit-tested — the same split the rest of the suite uses for its coverage floor.
+
+### T3 environment variables
+
+| Variable                | Required | Default     | Meaning                                                                              |
+| ----------------------- | -------- | ----------- | ------------------------------------------------------------------------------------ |
+| `E2E_SPEND_CAP_NLS`     | yes (T3) | —           | Cumulative NLS spend cap, decimal NLS, converted to micro units at parse             |
+| `E2E_SPEND_CAP_USDC`    | yes (T3) | —           | Cumulative USDC spend cap, decimal USDC, converted to micro units at parse           |
+| `E2E_WALLET2_LOW_WATER` | no       | `5`         | Wallet-2 native low-water floor (decimal NLS); below it the report carries a warning |
+| `E2E_T3_RESULTS_DIR`    | no       | `./results` | Directory for the journal and leftover-state report                                  |
+
+These reuse the fail-closed, all-or-nothing parse the rest of `config.ts` uses (`parseT3Config`):
+every field is validated, errors accumulate, and no value is echoed except the caps (which are
+not secrets). The wallet mnemonics come from the T2 variables (`E2E_WALLET_MNEMONIC`,
+`E2E_WALLET_MNEMONIC_2`) and are never echoed.
+
+### Spend cap semantics
+
+The cap bounds **worst-case gross outflow, not net loss**. "Spend" is the attached funds plus a
+deterministic gas-fee upper bound (an explicit fee, or a simulated amount times a ceiling
+multiplier); the gas fee counts against the NLS cap. Accounting is **per-denom, in native micro
+units** (scaled bigints via the `transfer.ts` helpers — never a float).
+
+There is **no refund credit**. A close or unbond returns funds to the wallet later, but crediting
+that back into the cap would re-open headroom and defeat the risk bound, so the accounting is
+one-way. The check is a strict **pre-sign gate**: `projected = spent + pending + candidate`; if a
+candidate would push any denom over its cap it returns `spend-cap-abort` and is **never signed or
+broadcast**. Because the queue holds each wallet's slot until commit and the primary is the sole
+spend actor, at most one governed spend is ever in flight, so at abort time nothing value-moving
+is pending — the abort cannot silently drop a signed-but-uncommitted transaction.
+
+One outflow is deliberately **outside** the SpendCap: the gas the UI-driven orphan-repair path spends. Repair runs the app's own market-close flow, whose gas the engine does not construct and cannot pre-size, so it is not gated by the cap; its worst case is bounded instead by the `maxAttempts` cap (3) times a dust per-close gas. The cap's gross-outflow guarantee therefore covers the governed spend and counterparty paths, not the repair path.
+
+### Serialization and commit-release
+
+`SerialQueue` is a per-wallet async FIFO: never two in-flight submissions per wallet key. A
+wallet's slot is released only when its executor's returned promise **settles on commit**
+(DeliverTx / block commit), never on the broadcast ack — resolving early would let the next
+submission sign against a stale account sequence. Redelegations additionally hold a class mutex
+that serializes them across every wallet (Cosmos forbids a delegator holding two concurrent
+redelegations). A shared token bucket paces both submissions and API reads from one budget
+(strict 2 RPS / burst 5 on `/api/swap/*`; standard 20 RPS / burst 50) because nginx rewrites
+`X-Forwarded-For`, so the whole suite counts as a single client IP.
+
+Retries on any spend path are **0** by contract. The kill switch (a spend-cap abort or an explicit
+`abort`) drains nothing: the in-flight commit completes, every further submission is refused, and
+the leftover report is emitted.
+
+### Journal and leftover-state report (the #285 contract)
+
+Before any broadcast the engine appends a write-ahead **intent** record (intent, wallet role,
+denoms/amounts, spec, timestamp) to a JSONL journal under the results dir and `fsync`s it; the
+**outcome** (txhash, commit result, classified failure) is appended when the submission settles.
+A hard crash therefore still leaves the write-ahead records on disk.
+
+The machine-readable leftover report (`t3-report.json`) is emitted on **every terminal path** —
+success, app-failure, and spend-cap-abort. Shape (`version: 1`):
+
+```json
+{
+  "suite": "t3",
+  "version": 1,
+  "generatedAt": "<iso8601>",
+  "terminal": "success | app-failure | spend-cap-abort | crash",
+  "openLeases": [{ "address": "...", "protocol": "...", "status": "opened" }],
+  "pendingUnbondings": [{ "validatorAddress": "...", "entries": 2, "balanceMicro": "..." }],
+  "unfinishedSwaps": [{ "seq": 1, "spec": "...", "denoms": [{ "denom": "...", "micro": "..." }] }],
+  "spend": [{ "denom": "nls", "capMicro": "...", "spentMicro": "..." }],
+  "warnings": ["..."]
+}
+```
+
+`openLeases` and `pendingUnbondings` are the chain-enumerated sweep results; `unfinishedSwaps`
+come from the journal because a swap is not chain-queryable. Every free-text field — journal
+specs and memos, classified failure reasons, and every network read error on the sweep path — is
+run through `sanitizeRpc`, so no RPC host, embedded credential, or bare IP can reach the journal,
+the report, or a CI artifact.
+
+### Reconciliation policy
+
+The pre-run sweep enumerates `GET /api/leases?address=` and `GET /api/staking/positions?address=`.
+The staking response is built from three independent chain calls, each of which can come back
+empty on an upstream failure, so **partial-empty data is normal** and handled as empty — a
+non-empty result is never assumed.
+
+- Only leases with `status === "opened"` that are **orphaned** (older than the orphan grace period,
+  attempt-guarded via a persisted state file) are queued for UI-driven repair. Once a lease's
+  attempt count reaches the cap it becomes **report-only** and is never retried again.
+- `opening` / `closing` / `paid_off` / `closed` / `liquidated` are **tolerated and reported, never
+  force-repaired**.
+- Pending / dust unbondings inside the 21-day window are expected leftover state — recognized and
+  skipped.
+
+All sweep reads go through the shared pacer.
+
+**Design note — repair drives the app UI.** Orphan-lease repair does **not** construct a close
+transaction in the suite. The production app builds every transaction client-side via
+`@nolus/nolusjs` (a real market-close carries a Skip route plus funds), and the backend's
+unsigned-tx endpoints (`/api/leases/close` and friends) are a phantom surface the app never calls.
+Repair therefore drives the app's market-close flow through Playwright and the existing Keplr stub
+(`t3/repair.ts`, built on the `t2` app-driver patterns), exercising the exact production
+construction path with no duplicated tx logic. For #284 the repair helper ships with its UI driver;
+live execution is CI-gated.
+
+### Precondition gates
+
+The failure taxonomy (`taxonomy.ts`) classifies every failure as `environment` (HTTP 429, relayer/
+IBC delay, price move between quote and execution, node/RPC unavailability, chain-state timeout),
+`app` (assertion failures, app error surfaces, contract rejects that are not liquidity/timing), or
+`precondition` (unfunded, the 7-entry unbonding cap per delegator/validator pair, a maturing
+redelegation lock, missing Osmosis-side funds). A precondition is skipped-not-failed leftover
+state, never a red. All error text is sanitized before it is stored or annotated.
+
+### Wallet roles
+
+The engine asserts its wallet roles at construction: the **primary** is the only governed spend
+actor; **wallet-2 (secondary)** acts only as a receive-side / micro-send counterparty. It also
+refuses to run under Playwright worker parallelism > 1, so the serialization guarantees hold.
+
+### CI (the `e2e-t3-engine.yaml` workflow)
+
+`e2e-t3-engine.yaml` is `workflow_dispatch`-only: it installs the e2e package and runs
+`npm run t3:engine` (the live engine smoke — sweep in enumerate/report mode, a serialization proof,
+a spend-cap dry proof, and the single operator-approved live broadcast: a dust native send between
+the primary and wallet-2). Base URL and host resolver are composed from the `base_domain` input and
+the `DEPLOY_HOST` var exactly as `deploy.yaml` does — never hardcoded. Per-run caps are tiny
+(`E2E_SPEND_CAP_NLS=1`, `E2E_SPEND_CAP_USDC=0`). Journal and report artifacts are uploaded on every
+run, not only on failure. The nightly schedule for this smoke belongs to issue #285, not this
+workflow.
+
 ## Conventions
 
 Every PR that adds or changes a user-facing surface (route, form, flow, rendered value,

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,6 +14,7 @@
     "t2:matrix": "PLAYWRIGHT_JSON_OUTPUT_NAME=results/t2.json playwright test --config playwright.config.ts --workers=1 --project=t2",
     "t2:ratelimit": "PLAYWRIGHT_JSON_OUTPUT_NAME=results/t2.json playwright test --config playwright.config.ts --workers=1 --project=ratelimit",
     "t2:receive": "PLAYWRIGHT_JSON_OUTPUT_NAME=results/t2.json playwright test --config playwright.config.ts --workers=1 --project=receive",
+    "t3:engine": "PLAYWRIGHT_JSON_OUTPUT_NAME=results/t3-engine.json playwright test --config playwright.config.ts --workers=1 --project=t3-engine",
     "typecheck": "tsc --noEmit",
     "check:matrix": "tsx scripts/check-matrix.ts",
     "lint": "eslint . --max-warnings=0",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -108,6 +108,16 @@ export default defineConfig<T2Options>({
       retries: 0,
       dependencies: ["t2", "ratelimit"],
       use: { viewport: { width: 1440, height: 900 }, themeData: "light" }
+    },
+    {
+      // The tx-engine live smoke, appended to the dependency chain so it inherits the full
+      // serialization; a settle delay in the spec refills the strict rate bucket after ratelimit.
+      name: "t3-engine",
+      testDir: "src/t3",
+      testMatch: ["**/engine.spec.ts"],
+      retries: 0,
+      dependencies: ["t2", "ratelimit", "receive"],
+      use: { viewport: { width: 1440, height: 900 }, themeData: "light" }
     }
   ]
 });

--- a/e2e/src/config.test.ts
+++ b/e2e/src/config.test.ts
@@ -9,6 +9,7 @@ import {
   parseT1Config,
   parseT2Config,
   parseMatrixConfig,
+  parseT3Config,
   DEFAULT_RECEIVE_TIMEOUT_MS,
   PUBLIC_FALLBACK_MNEMONIC
 } from "./config.js";
@@ -303,5 +304,57 @@ describe("parseMatrixConfig", () => {
       throw new Error("expected failure");
     }
     expect(timeout.errors[0]).toContain("E2E_RECEIVE_TIMEOUT_MS");
+  });
+});
+
+describe("parseT3Config", () => {
+  it("requires both spend caps and reports them together", () => {
+    const result = parseT3Config({});
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected failure");
+    }
+    expect(result.errors.some((m) => m.startsWith("E2E_SPEND_CAP_NLS"))).toBe(true);
+    expect(result.errors.some((m) => m.startsWith("E2E_SPEND_CAP_USDC"))).toBe(true);
+  });
+
+  it("converts decimal caps to micro units and defaults the low-water floor and results dir", () => {
+    const result = parseT3Config({ E2E_SPEND_CAP_NLS: "1", E2E_SPEND_CAP_USDC: "0" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected success");
+    }
+    expect(result.config).toEqual({
+      spendCapNlsMicro: "1000000",
+      spendCapUsdcMicro: "0",
+      wallet2LowWaterMicro: "5000000",
+      resultsDir: "./results"
+    });
+  });
+
+  it("honours an explicit low-water floor and results dir", () => {
+    const result = parseT3Config({
+      E2E_SPEND_CAP_NLS: "0.5",
+      E2E_SPEND_CAP_USDC: "2.5",
+      E2E_WALLET2_LOW_WATER: "10",
+      E2E_T3_RESULTS_DIR: "/tmp/out"
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected success");
+    }
+    expect(result.config.spendCapNlsMicro).toBe("500000");
+    expect(result.config.spendCapUsdcMicro).toBe("2500000");
+    expect(result.config.wallet2LowWaterMicro).toBe("10000000");
+    expect(result.config.resultsDir).toBe("/tmp/out");
+  });
+
+  it("rejects a non-decimal cap without throwing", () => {
+    const result = parseT3Config({ E2E_SPEND_CAP_NLS: "abc", E2E_SPEND_CAP_USDC: "0" });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected failure");
+    }
+    expect(result.errors.some((m) => m.startsWith("E2E_SPEND_CAP_NLS must be a non-negative decimal"))).toBe(true);
   });
 });

--- a/e2e/src/config.ts
+++ b/e2e/src/config.ts
@@ -1,5 +1,6 @@
 import { isNonNegativeDecimalString } from "./decimal.js";
 import { parseHostResolver } from "./resolver.js";
+import { NATIVE_DECIMALS, toMicroAmount } from "./transfer.js";
 
 export const DEFAULT_USD_TOLERANCE = "0.05";
 export const DEFAULT_WS_PUSH_TIMEOUT_MS = 60000;
@@ -384,4 +385,79 @@ export function parseMatrixConfig(env: Record<string, string | undefined>): Matr
   }
 
   return { ok: true, config: { chainRpc, receiveTimeoutMs, expectFunded } };
+}
+
+export const USDC_DECIMALS = 6;
+export const DEFAULT_WALLET2_LOW_WATER_NLS = "5";
+export const DEFAULT_WALLET2_LOW_WATER_MICRO = toMicroAmount(DEFAULT_WALLET2_LOW_WATER_NLS, NATIVE_DECIMALS);
+export const DEFAULT_T3_RESULTS_DIR = "./results";
+
+export interface T3Config {
+  spendCapNlsMicro: string;
+  spendCapUsdcMicro: string;
+  wallet2LowWaterMicro: string;
+  resultsDir: string;
+}
+
+export type T3ConfigResult = { ok: true; config: T3Config } | { ok: false; errors: string[] };
+
+interface MicroAmountFieldSpec {
+  raw: string | undefined;
+  name: string;
+  required: boolean;
+  fallback: string;
+  decimals: number;
+}
+
+function parseMicroAmountField(spec: MicroAmountFieldSpec, errors: string[]): string {
+  const trimmed = spec.raw?.trim();
+  if (!trimmed) {
+    if (spec.required) {
+      errors.push(`${spec.name} is required (a non-negative decimal amount)`);
+    }
+    return spec.fallback;
+  }
+  try {
+    return toMicroAmount(trimmed, spec.decimals);
+  } catch {
+    errors.push(`${spec.name} must be a non-negative decimal amount (got "${trimmed}")`);
+    return spec.fallback;
+  }
+}
+
+/**
+ * The T3 (tx-engine) subset. Both spend caps are required and are converted from a decimal
+ * amount to native micro units at parse (scaled-integer only, via the transfer helpers) so the
+ * accounting never touches a float. `E2E_WALLET2_LOW_WATER` is the wallet-2 native low-water
+ * floor (decimal NLS, default 5). No cap value is a secret, so — unlike the mnemonics — an
+ * invalid value is echoed to name the offending input.
+ */
+export function parseT3Config(env: Record<string, string | undefined>): T3ConfigResult {
+  const errors: string[] = [];
+
+  const spendCapNlsMicro = parseMicroAmountField(
+    { raw: env.E2E_SPEND_CAP_NLS, name: "E2E_SPEND_CAP_NLS", required: true, fallback: "0", decimals: NATIVE_DECIMALS },
+    errors
+  );
+  const spendCapUsdcMicro = parseMicroAmountField(
+    { raw: env.E2E_SPEND_CAP_USDC, name: "E2E_SPEND_CAP_USDC", required: true, fallback: "0", decimals: USDC_DECIMALS },
+    errors
+  );
+  const wallet2LowWaterMicro = parseMicroAmountField(
+    {
+      raw: env.E2E_WALLET2_LOW_WATER,
+      name: "E2E_WALLET2_LOW_WATER",
+      required: false,
+      fallback: DEFAULT_WALLET2_LOW_WATER_MICRO,
+      decimals: NATIVE_DECIMALS
+    },
+    errors
+  );
+  const resultsDir = env.E2E_T3_RESULTS_DIR?.trim() || DEFAULT_T3_RESULTS_DIR;
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, config: { spendCapNlsMicro, spendCapUsdcMicro, wallet2LowWaterMicro, resultsDir } };
 }

--- a/e2e/src/t3/engine.spec.ts
+++ b/e2e/src/t3/engine.spec.ts
@@ -1,0 +1,263 @@
+import { test, expect } from "@playwright/test";
+import type { TestInfo } from "@playwright/test";
+import { resolveOrigin } from "../t2/appDriver.js";
+import type { OriginContext } from "../t2/appDriver.js";
+import { parseMatrixConfig, parseT2Config, parseT3Config } from "../config.js";
+import type { T3Config } from "../config.js";
+import { createWalletIdentity } from "../signer.js";
+import { DEFAULT_GAS_LIMIT, NATIVE_DENOM, makeFee, makeSendCoin } from "../transfer.js";
+import { broadcastSend } from "../broadcast.js";
+import { SerialQueue } from "./serialQueue.js";
+import { spendCapFromMicros } from "./spendCap.js";
+import { TxEngine } from "./engine.js";
+import type { WalletRoleConfig } from "./engine.js";
+import { sweep } from "./reconcile.js";
+import { pacedSweepDeps, readJson } from "./runtime.js";
+import { JournalStore, readAttempts, writeAttempts, writeReportFile } from "./journalStore.js";
+import { buildIntent, buildOutcome } from "./journal.js";
+import { readString } from "../t2/matrixHelpers.js";
+
+// The T3 engine live smoke (workflow_dispatch only). It proves the engine's three invariants
+// against the real target — reconciliation enumerate+report, per-wallet serialization, and the
+// pre-sign spend-cap gate — and performs the single operator-approved live broadcast class: a
+// dust native send from the primary to wallet-2, governed by the engine and its tiny CI cap.
+// why: a fixed settle delay lets the LIVE nginx strict rate bucket refill after the ratelimit
+// project this depends on — the bucket lives on the server and cannot be faked or polled from
+// here, so a wall-clock wait is the only option; kept small (3s covers the 2 RPS / burst 5 bucket).
+const SETTLE_MS = 3000;
+const DUST_NLS = "0.001";
+
+interface ChainSettings {
+  rpcUrl: string;
+  gasPrice: string;
+}
+
+let ctx: OriginContext;
+let t3: T3Config;
+let primary: WalletRoleConfig;
+let secondary: WalletRoleConfig;
+let primaryMnemonic: string;
+let chain: ChainSettings;
+
+async function resolveChain(matrixRpc: string | undefined): Promise<ChainSettings> {
+  const config = await readJson(ctx, `${ctx.origin}/api/config`);
+  const networks =
+    typeof config === "object" && config !== null ? (config as Record<string, unknown>).networks : undefined;
+  const list: unknown[] = Array.isArray(networks) ? (networks as unknown[]) : [];
+  const nolus = list.find((n) => readString(n, "prefix") === "nolus" || readString(n, "key") === "NOLUS");
+  const rpcUrl = matrixRpc ?? readString(nolus, "rpc_url");
+  if (rpcUrl === undefined) {
+    throw new Error("could not resolve the Nolus chain rpc_url from /api/config or E2E_CHAIN_RPC");
+  }
+  const gasPriceRaw = readString(nolus, "gas_price");
+  if (gasPriceRaw === undefined) {
+    throw new Error("could not resolve the Nolus gas_price from /api/config");
+  }
+  const gasPrice = gasPriceRaw.replace(/[^0-9.]/g, "");
+  if (gasPrice === "") {
+    throw new Error(`Nolus gas_price from /api/config is unparseable: "${gasPriceRaw}"`);
+  }
+  return { rpcUrl, gasPrice };
+}
+
+function newEngine(testInfo: TestInfo): TxEngine {
+  const queue = new SerialQueue();
+  const cap = spendCapFromMicros(t3.spendCapNlsMicro, t3.spendCapUsdcMicro);
+  return new TxEngine(
+    { queue, cap },
+    {
+      primary,
+      secondary,
+      workers: testInfo.config.workers,
+      retries: testInfo.project.retries,
+      wallet2LowWaterMicro: BigInt(t3.wallet2LowWaterMicro)
+    }
+  );
+}
+
+test.beforeAll(async () => {
+  ctx = resolveOrigin();
+  const t2 = parseT2Config(process.env);
+  if (!t2.ok) throw new Error(`T2 config error: ${t2.errors.join("; ")}`);
+  const parsedT3 = parseT3Config(process.env);
+  if (!parsedT3.ok) throw new Error(`T3 config error: ${parsedT3.errors.join("; ")}`);
+  t3 = parsedT3.config;
+  primaryMnemonic = t2.config.primaryMnemonic;
+  primary = {
+    role: "primary",
+    key: "primary",
+    address: (await createWalletIdentity(t2.config.primaryMnemonic)).address
+  };
+  secondary = {
+    role: "secondary",
+    key: "secondary",
+    address: (await createWalletIdentity(t2.config.secondaryMnemonic)).address
+  };
+  const matrix = parseMatrixConfig(process.env);
+  if (!matrix.ok) throw new Error(`matrix config error: ${matrix.errors.join("; ")}`);
+  chain = await resolveChain(matrix.config.chainRpc);
+  await new Promise<void>((resolve) => setTimeout(resolve, SETTLE_MS));
+});
+
+test.afterAll(async () => {
+  if (ctx.dispatcher !== undefined) await ctx.dispatcher.close();
+});
+
+test("reconciliation sweep enumerates leftover state and writes a machine-readable report", async () => {
+  const testInfo = test.info();
+  const engine = newEngine(testInfo);
+  const queue = new SerialQueue();
+  const attempts = readAttempts(t3.resultsDir);
+  const result = await sweep(pacedSweepDeps(queue, ctx), { origin: ctx.origin, address: primary.address, attempts });
+  writeAttempts(t3.resultsDir, result.nextAttempts);
+
+  const report = engine.buildReport({
+    generatedAt: new Date().toISOString(),
+    terminal: "success",
+    journal: new JournalStore(t3.resultsDir).readAll(),
+    openLeases: result.openLeases,
+    pendingUnbondings: result.pendingUnbondings,
+    warnings: []
+  });
+  const path = writeReportFile(t3.resultsDir, report);
+  testInfo.annotations.push({
+    type: "t3-report",
+    description: `leftover report written (${result.openLeases.length} open lease(s))`
+  });
+  expect(path).toContain("t3-report.json");
+  expect(Array.isArray(report.openLeases)).toBe(true);
+});
+
+test("per-wallet submissions serialize: the second starts only after the first commits", async () => {
+  const queue = new SerialQueue();
+  const order: string[] = [];
+  let firstDone = false;
+  let releaseFirst: () => void = () => undefined;
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const flush = (): Promise<void> =>
+    new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+  const p1 = queue.submit({
+    walletKey: primary.key,
+    kind: "spend",
+    execute: async () => {
+      order.push("first:start");
+      await firstGate;
+      firstDone = true;
+      order.push("first:commit");
+    }
+  });
+  const p2 = queue.submit({
+    walletKey: primary.key,
+    kind: "spend",
+    execute: () => {
+      expect(firstDone).toBe(true);
+      order.push("second:start");
+      return Promise.resolve();
+    }
+  });
+
+  await flush();
+  expect(order).toEqual(["first:start"]);
+  releaseFirst();
+  await Promise.all([p1, p2]);
+  expect(order).toEqual(["first:start", "first:commit", "second:start"]);
+});
+
+test("the spend-cap gate aborts an over-cap candidate before it is ever signed", async () => {
+  const testInfo = test.info();
+  const engine = newEngine(testInfo);
+  let signed = false;
+  const nlsCapMicro = BigInt(t3.spendCapNlsMicro);
+  const outcome = await engine.spend({
+    walletKey: primary.key,
+    action: "swap",
+    items: [{ denom: "nls", micro: nlsCapMicro + 1n }],
+    execute: () => {
+      signed = true;
+      return Promise.resolve("should-not-run");
+    }
+  });
+  expect(signed).toBe(false);
+  expect(outcome.status).toBe("spend-cap-abort");
+  expect(engine.halted).toBe(true);
+});
+
+test("a dust native send from the primary commits through the engine and is journaled", async () => {
+  const testInfo = test.info();
+  const engine = newEngine(testInfo);
+  const store = new JournalStore(t3.resultsDir);
+  const coin = makeSendCoin(DUST_NLS);
+  const fee = makeFee(DEFAULT_GAS_LIMIT, chain.gasPrice, NATIVE_DENOM);
+  const required = BigInt(coin.amount) + BigInt(fee.amount[0]?.amount ?? "0");
+  const balancePayload = await readJson(ctx, `${ctx.origin}/api/balances?address=${primary.address}`);
+  const primaryMicro = nativeMicro(balancePayload);
+  if (primaryMicro <= required) {
+    testInfo.skip(true, "primary is not funded enough for a dust send plus fee");
+    return;
+  }
+
+  const seq = 1;
+  store.append(
+    buildIntent({
+      seq,
+      ts: new Date().toISOString(),
+      spec: "t3-engine",
+      walletRole: "primary",
+      action: "native-send",
+      denoms: [{ denom: NATIVE_DENOM, micro: required.toString() }],
+      memo: "nolus-e2e-t3"
+    })
+  );
+
+  const outcome = await engine.spend({
+    walletKey: primary.key,
+    action: "native-send",
+    items: [{ denom: "nls", micro: required }],
+    execute: () =>
+      broadcastSend({
+        rpcUrl: chain.rpcUrl,
+        senderMnemonic: primaryMnemonic,
+        prefix: "nolus",
+        recipient: secondary.address,
+        amount: coin,
+        fee,
+        memo: "nolus-e2e-t3"
+      })
+  });
+
+  expect(outcome.status).toBe("committed");
+  if (outcome.status === "committed") {
+    store.append(
+      buildOutcome({
+        seq,
+        ts: new Date().toISOString(),
+        status: "committed",
+        txHash: outcome.value.txHash,
+        height: outcome.value.height
+      })
+    );
+    testInfo.annotations.push({
+      type: "t3-send",
+      description: `dust send committed at height ${outcome.value.height}`
+    });
+  }
+});
+
+function nativeMicro(payload: unknown): bigint {
+  if (typeof payload !== "object" || payload === null) return 0n;
+  const balances = (payload as Record<string, unknown>).balances;
+  if (!Array.isArray(balances)) return 0n;
+  let total = 0n;
+  for (const entry of balances) {
+    if (readString(entry, "denom") === NATIVE_DENOM) {
+      const amount = readString(entry, "amount");
+      if (amount !== undefined) total += BigInt(amount);
+    }
+  }
+  return total;
+}

--- a/e2e/src/t3/engine.spec.ts
+++ b/e2e/src/t3/engine.spec.ts
@@ -62,7 +62,7 @@ async function resolveChain(matrixRpc: string | undefined): Promise<ChainSetting
 
 function newEngine(testInfo: TestInfo): TxEngine {
   const queue = new SerialQueue();
-  const cap = spendCapFromMicros(t3.spendCapNlsMicro, t3.spendCapUsdcMicro);
+  const cap = spendCapFromMicros({ nlsMicro: t3.spendCapNlsMicro, usdcMicro: t3.spendCapUsdcMicro });
   return new TxEngine(
     { queue, cap },
     {

--- a/e2e/src/t3/engine.test.ts
+++ b/e2e/src/t3/engine.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { EngineHaltedError, RoleViolationError, TxEngine } from "./engine.js";
+import type { EngineOptions } from "./engine.js";
+import { SerialQueue } from "./serialQueue.js";
+import { SpendCap } from "./spendCap.js";
+import type { SpendItem } from "./spendCap.js";
+
+const instant = { now: (): number => 0, sleep: (): Promise<void> => Promise.resolve() };
+
+function options(overrides: Partial<EngineOptions> = {}): EngineOptions {
+  return {
+    primary: { role: "primary", key: "P", address: "nolus1primary" },
+    secondary: { role: "secondary", key: "S", address: "nolus1secondary" },
+    workers: 1,
+    retries: 0,
+    wallet2LowWaterMicro: 5_000_000n,
+    ...overrides
+  };
+}
+
+function engineWith(cap: SpendCap, overrides: Partial<EngineOptions> = {}): TxEngine {
+  return new TxEngine({ queue: new SerialQueue(instant), cap }, options(overrides));
+}
+
+const nls = (micro: bigint): SpendItem[] => [{ denom: "nls", micro }];
+
+describe("TxEngine construction", () => {
+  it("rejects swapped or wrong wallet roles", () => {
+    expect(() =>
+      engineWith(new SpendCap({ nls: 1n, usdc: 0n }), { primary: { role: "secondary", key: "P", address: "a" } })
+    ).toThrow(RoleViolationError);
+  });
+
+  it("refuses to run under worker parallelism > 1", () => {
+    expect(() => engineWith(new SpendCap({ nls: 1n, usdc: 0n }), { workers: 2 })).toThrow(/serial execution/);
+  });
+
+  it("refuses to run when the project configures a non-zero retry count on the spend path", () => {
+    expect(() => engineWith(new SpendCap({ nls: 1n, usdc: 0n }), { retries: 1 })).toThrow(/must not retry/);
+  });
+});
+
+describe("TxEngine spend gate", () => {
+  it("aborts before the executor runs when a candidate exceeds cap, and emits nothing value-moving", async () => {
+    const engine = engineWith(new SpendCap({ nls: 1000n, usdc: 0n }));
+    let ran = false;
+    const outcome = await engine.spend({
+      walletKey: "P",
+      action: "swap",
+      items: nls(2000n),
+      execute: () => {
+        ran = true;
+        return Promise.resolve("x");
+      }
+    });
+    expect(ran).toBe(false);
+    expect(outcome.status).toBe("spend-cap-abort");
+    expect(engine.halted).toBe(true);
+  });
+
+  it("refuses every further submission once halted", async () => {
+    const engine = engineWith(new SpendCap({ nls: 1000n, usdc: 0n }));
+    await engine.spend({ walletKey: "P", action: "swap", items: nls(2000n), execute: () => Promise.resolve(1) });
+    await expect(
+      engine.spend({ walletKey: "P", action: "swap", items: nls(1n), execute: () => Promise.resolve(1) })
+    ).rejects.toThrow(EngineHaltedError);
+  });
+
+  it("commits a within-cap spend and records the gross outflow", async () => {
+    const cap = new SpendCap({ nls: 10_000n, usdc: 0n });
+    const engine = engineWith(cap);
+    const outcome = await engine.spend({
+      walletKey: "P",
+      action: "native-send",
+      items: nls(3000n),
+      execute: () => Promise.resolve("hash")
+    });
+    expect(outcome).toEqual({ status: "committed", value: "hash" });
+    expect(cap.spent("nls")).toBe(3000n);
+    expect(cap.pending("nls")).toBe(0n);
+  });
+
+  it("releases the reservation on a failed broadcast without counting spend", async () => {
+    const cap = new SpendCap({ nls: 10_000n, usdc: 0n });
+    const engine = engineWith(cap);
+    await expect(
+      engine.spend({
+        walletKey: "P",
+        action: "native-send",
+        items: nls(3000n),
+        execute: () => Promise.reject(new Error("boom"))
+      })
+    ).rejects.toThrow("boom");
+    expect(cap.spent("nls")).toBe(0n);
+    expect(cap.pending("nls")).toBe(0n);
+  });
+});
+
+describe("TxEngine wallet roles", () => {
+  it("forbids a governed spend from the secondary wallet", async () => {
+    const engine = engineWith(new SpendCap({ nls: 10_000n, usdc: 0n }));
+    await expect(
+      engine.spend({ walletKey: "S", action: "swap", items: nls(1n), execute: () => Promise.resolve(1) })
+    ).rejects.toThrow(RoleViolationError);
+  });
+
+  it("allows a counterparty dust send from either wallet, still cap-counted", async () => {
+    const cap = new SpendCap({ nls: 10_000n, usdc: 0n });
+    const engine = engineWith(cap);
+    const outcome = await engine.counterpartySend({
+      walletKey: "S",
+      action: "native-send",
+      items: nls(1000n),
+      execute: () => Promise.resolve("ok")
+    });
+    expect(outcome).toEqual({ status: "committed", value: "ok" });
+    expect(cap.spent("nls")).toBe(1000n);
+  });
+
+  it("rejects a counterparty send from an unknown wallet", async () => {
+    const engine = engineWith(new SpendCap({ nls: 10_000n, usdc: 0n }));
+    await expect(
+      engine.counterpartySend({
+        walletKey: "Z",
+        action: "native-send",
+        items: nls(1n),
+        execute: () => Promise.resolve(1)
+      })
+    ).rejects.toThrow(RoleViolationError);
+  });
+});
+
+describe("TxEngine reporting", () => {
+  it("warns only when wallet-2 balance is below the floor", () => {
+    const engine = engineWith(new SpendCap({ nls: 1n, usdc: 0n }));
+    expect(engine.lowBalanceWarning(6_000_000n)).toBeNull();
+    expect(engine.lowBalanceWarning(4_000_000n)).toContain("low-water");
+  });
+
+  it("builds a leftover report carrying the spend snapshot and an explicit abort", () => {
+    const cap = new SpendCap({ nls: 1_000n, usdc: 0n });
+    const engine = engineWith(cap);
+    engine.abort("manual");
+    const report = engine.buildReport({
+      generatedAt: "t",
+      terminal: "app-failure",
+      journal: [],
+      openLeases: [],
+      pendingUnbondings: [],
+      warnings: ["w"]
+    });
+    expect(report.terminal).toBe("app-failure");
+    expect(report.spend).toEqual([
+      { denom: "nls", capMicro: "1000", spentMicro: "0" },
+      { denom: "usdc", capMicro: "0", spentMicro: "0" }
+    ]);
+    expect(engine.reason).toBe("manual");
+  });
+});

--- a/e2e/src/t3/engine.ts
+++ b/e2e/src/t3/engine.ts
@@ -1,0 +1,179 @@
+import type { SerialQueue, SubmissionKind } from "./serialQueue.js";
+import type { SpendCap, SpendItem, SpendCheck } from "./spendCap.js";
+import type { IntentAction } from "./journal.js";
+import type { LeftoverReport, OpenLease, PendingUnbonding, TerminalPath } from "./report.js";
+import { assembleLeftoverReport } from "./report.js";
+import type { JournalRecord } from "./journal.js";
+
+/**
+ * Retries on any spend path are 0 by contract — a retried broadcast risks a double-spend. The
+ * constructor asserts the Playwright project's `retries` equals this, so the contract is enforced
+ * at construction rather than merely documented.
+ */
+export const SPEND_PATH_RETRIES = 0;
+
+export type WalletRole = "primary" | "secondary";
+
+export interface WalletRoleConfig {
+  role: WalletRole;
+  key: string;
+  address: string;
+}
+
+export interface EngineOptions {
+  primary: WalletRoleConfig;
+  secondary: WalletRoleConfig;
+  workers: number;
+  retries: number;
+  wallet2LowWaterMicro: bigint;
+}
+
+export interface EngineDeps {
+  queue: SerialQueue;
+  cap: SpendCap;
+  now?: () => number;
+}
+
+export type SpendCheckFail = Extract<SpendCheck, { ok: false }>;
+
+export type SpendOutcome<T> = { status: "committed"; value: T } | { status: "spend-cap-abort"; check: SpendCheckFail };
+
+export interface SpendRequest<T> {
+  walletKey: string;
+  action: IntentAction;
+  items: SpendItem[];
+  execute: () => Promise<T>;
+}
+
+export class EngineHaltedError extends Error {
+  constructor(reason: string) {
+    super(`tx engine halted: ${reason}`);
+    this.name = "EngineHaltedError";
+  }
+}
+
+export class RoleViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RoleViolationError";
+  }
+}
+
+/**
+ * The TxEngine composes the serial queue, the spend cap, the journal, and the reconciliation
+ * sweep. It enforces the wallet-role contract (the primary is the sole governed spend actor;
+ * the secondary acts only as a receive-side / micro-send counterparty), refuses to run under
+ * Playwright worker parallelism > 1, and holds a kill switch: a spend-cap abort or an explicit
+ * abort completes the in-flight commit, then refuses every further submission. It never drives
+ * broadcasts or fs itself — those are injected — so the whole decision surface is unit-tested.
+ */
+export class TxEngine {
+  private readonly queue: SerialQueue;
+  private readonly cap: SpendCap;
+  private readonly primary: WalletRoleConfig;
+  private readonly secondary: WalletRoleConfig;
+  private readonly wallet2LowWaterMicro: bigint;
+  private haltReason: string | null = null;
+
+  constructor(deps: EngineDeps, options: EngineOptions) {
+    if (options.primary.role !== "primary" || options.secondary.role !== "secondary") {
+      throw new RoleViolationError("expected a primary and a secondary wallet role");
+    }
+    if (options.workers > 1) {
+      throw new RoleViolationError(`tx engine requires serial execution (workers=${options.workers})`);
+    }
+    if (options.retries !== SPEND_PATH_RETRIES) {
+      throw new RoleViolationError(
+        `spend paths must not retry (retries=${options.retries}, required ${SPEND_PATH_RETRIES})`
+      );
+    }
+    this.queue = deps.queue;
+    this.cap = deps.cap;
+    this.primary = options.primary;
+    this.secondary = options.secondary;
+    this.wallet2LowWaterMicro = options.wallet2LowWaterMicro;
+  }
+
+  get halted(): boolean {
+    return this.haltReason !== null;
+  }
+
+  get reason(): string | null {
+    return this.haltReason;
+  }
+
+  abort(reason: string): void {
+    if (this.haltReason === null) {
+      this.haltReason = reason;
+    }
+  }
+
+  /** A governed value-moving action by the primary wallet — the only wallet allowed to spend. */
+  spend<T>(request: SpendRequest<T>): Promise<SpendOutcome<T>> {
+    if (request.walletKey !== this.primary.key) {
+      return Promise.reject(new RoleViolationError("only the primary wallet may perform a governed spend"));
+    }
+    const kind: SubmissionKind = request.action === "redelegate" ? "redelegate" : "spend";
+    return this.governed(request, kind);
+  }
+
+  /** A dust native micro-send used as a receive-side counterparty; either wallet may send it. */
+  counterpartySend<T>(request: SpendRequest<T>): Promise<SpendOutcome<T>> {
+    if (request.walletKey !== this.primary.key && request.walletKey !== this.secondary.key) {
+      return Promise.reject(new RoleViolationError("counterparty send from an unknown wallet"));
+    }
+    return this.governed(request, "spend");
+  }
+
+  private async governed<T>(request: SpendRequest<T>, kind: SubmissionKind): Promise<SpendOutcome<T>> {
+    if (this.haltReason !== null) {
+      throw new EngineHaltedError(this.haltReason);
+    }
+    const check = this.cap.check(request.items);
+    if (!check.ok) {
+      this.abort("spend-cap-abort");
+      return { status: "spend-cap-abort", check };
+    }
+    this.cap.reserve(request.items);
+    const value = await this.queue
+      .submit({ walletKey: request.walletKey, kind, bucket: "standard", execute: request.execute })
+      .then(
+        (settled) => {
+          this.cap.settle(request.items);
+          return settled;
+        },
+        (error: unknown) => {
+          this.cap.release(request.items);
+          throw error instanceof Error ? error : new Error(String(error));
+        }
+      );
+    return { status: "committed", value };
+  }
+
+  /** A warning string when wallet-2's native balance has fallen below its configured floor. */
+  lowBalanceWarning(wallet2NativeMicro: bigint): string | null {
+    if (wallet2NativeMicro >= this.wallet2LowWaterMicro) {
+      return null;
+    }
+    return `wallet-2 native balance ${wallet2NativeMicro.toString()} is below the ${this.wallet2LowWaterMicro.toString()} micro-NLS low-water floor`;
+  }
+
+  buildReport(input: {
+    generatedAt: string;
+    terminal: TerminalPath;
+    journal: JournalRecord[];
+    openLeases: OpenLease[];
+    pendingUnbondings: PendingUnbonding[];
+    warnings: string[];
+  }): LeftoverReport {
+    return assembleLeftoverReport({
+      generatedAt: input.generatedAt,
+      terminal: input.terminal,
+      journal: input.journal,
+      openLeases: input.openLeases,
+      pendingUnbondings: input.pendingUnbondings,
+      spend: this.cap.snapshot(),
+      warnings: input.warnings
+    });
+  }
+}

--- a/e2e/src/t3/engine.ts
+++ b/e2e/src/t3/engine.ts
@@ -31,7 +31,6 @@ export interface EngineOptions {
 export interface EngineDeps {
   queue: SerialQueue;
   cap: SpendCap;
-  now?: () => number;
 }
 
 export type SpendCheckFail = Extract<SpendCheck, { ok: false }>;

--- a/e2e/src/t3/engine.ts
+++ b/e2e/src/t3/engine.ts
@@ -134,18 +134,22 @@ export class TxEngine {
       return { status: "spend-cap-abort", check };
     }
     this.cap.reserve(request.items);
-    const value = await this.queue
-      .submit({ walletKey: request.walletKey, kind, bucket: "standard", execute: request.execute })
-      .then(
-        (settled) => {
-          this.cap.settle(request.items);
-          return settled;
-        },
-        (error: unknown) => {
-          this.cap.release(request.items);
-          throw error instanceof Error ? error : new Error(String(error));
-        }
-      );
+    let value: T;
+    try {
+      value = await this.queue.submit({
+        walletKey: request.walletKey,
+        kind,
+        bucket: "standard",
+        execute: request.execute
+      });
+    } catch (error: unknown) {
+      // A failed broadcast retires the reservation without counting spend, then re-throws the
+      // (already sanitized) error. settle() is deliberately outside this try so a settle-path
+      // throw can never be mis-routed into release().
+      this.cap.release(request.items);
+      throw error instanceof Error ? error : new Error(String(error));
+    }
+    this.cap.settle(request.items);
     return { status: "committed", value };
   }
 

--- a/e2e/src/t3/journal.test.ts
+++ b/e2e/src/t3/journal.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { buildIntent, buildOutcome, parseRecords, serializeRecord, unmatchedIntents } from "./journal.js";
+import type { JournalRecord } from "./journal.js";
+
+describe("buildIntent", () => {
+  it("builds a write-ahead intent and omits an absent memo", () => {
+    const intent = buildIntent({
+      seq: 1,
+      ts: "2026-07-17T00:00:00.000Z",
+      spec: "t3-engine",
+      walletRole: "primary",
+      action: "native-send",
+      denoms: [{ denom: "unls", micro: "1000" }]
+    });
+    expect(intent).toEqual({
+      type: "intent",
+      seq: 1,
+      ts: "2026-07-17T00:00:00.000Z",
+      spec: "t3-engine",
+      walletRole: "primary",
+      action: "native-send",
+      denoms: [{ denom: "unls", micro: "1000" }]
+    });
+    expect("memo" in intent).toBe(false);
+  });
+
+  it("redacts an IP that leaks into the spec or memo", () => {
+    const intent = buildIntent({
+      seq: 2,
+      ts: "2026-07-17T00:00:00.000Z",
+      spec: "run against 10.9.8.7:26657",
+      walletRole: "secondary",
+      action: "swap",
+      denoms: [{ denom: "unls", micro: "1" }],
+      memo: "node 10.9.8.7"
+    });
+    expect(intent.spec).not.toContain("10.9.8.7");
+    expect(intent.memo).not.toContain("10.9.8.7");
+  });
+});
+
+describe("buildOutcome", () => {
+  it("records a committed outcome with tx hash and height", () => {
+    const outcome = buildOutcome({
+      seq: 1,
+      ts: "2026-07-17T00:00:01.000Z",
+      status: "committed",
+      txHash: "ABC",
+      height: 42
+    });
+    expect(outcome).toEqual({
+      type: "outcome",
+      seq: 1,
+      ts: "2026-07-17T00:00:01.000Z",
+      status: "committed",
+      txHash: "ABC",
+      height: 42
+    });
+  });
+
+  it("redacts an IP inside a classified failure reason", () => {
+    const outcome = buildOutcome({
+      seq: 3,
+      ts: "2026-07-17T00:00:02.000Z",
+      status: "failed",
+      failure: { category: "environment", signal: "node-unavailable", reason: "ECONNREFUSED 10.0.0.1:26657" }
+    });
+    expect(outcome.failure?.reason).not.toContain("10.0.0.1");
+  });
+});
+
+describe("serialize / parse round-trip", () => {
+  it("serializes to one JSON line each and parses back, ignoring blanks", () => {
+    const records: JournalRecord[] = [
+      buildIntent({ seq: 1, ts: "t", spec: "s", walletRole: "primary", action: "swap", denoms: [] }),
+      buildOutcome({ seq: 1, ts: "t2", status: "committed" })
+    ];
+    const jsonl = `${records.map(serializeRecord).join("\n")}\n\n`;
+    expect(parseRecords(jsonl)).toEqual(records);
+  });
+
+  it("skips a corrupt line (torn JSON) and a valid-JSON-but-wrong-shape line, keeping the good ones", () => {
+    const good = buildIntent({ seq: 7, ts: "t", spec: "s", walletRole: "primary", action: "swap", denoms: [] });
+    const jsonl = [serializeRecord(good), '{"type":"intent","seq":8', '{"foo":"bar"}', "42"].join("\n");
+    expect(parseRecords(jsonl)).toEqual([good]);
+  });
+});
+
+describe("unmatchedIntents", () => {
+  it("returns intents with no settling outcome — the crash-surviving write-ahead entries", () => {
+    const records: JournalRecord[] = [
+      buildIntent({ seq: 1, ts: "t", spec: "s", walletRole: "primary", action: "swap", denoms: [] }),
+      buildOutcome({ seq: 1, ts: "t", status: "committed" }),
+      buildIntent({ seq: 2, ts: "t", spec: "s", walletRole: "primary", action: "swap", denoms: [] })
+    ];
+    expect(unmatchedIntents(records).map((intent) => intent.seq)).toEqual([2]);
+  });
+});

--- a/e2e/src/t3/journal.ts
+++ b/e2e/src/t3/journal.ts
@@ -1,0 +1,140 @@
+import { sanitizeRpc } from "../transfer.js";
+import type { Classification } from "./taxonomy.js";
+
+export type WalletRole = "primary" | "secondary";
+
+export type IntentAction =
+  "native-send" | "swap" | "lease-open" | "lease-close" | "delegate" | "undelegate" | "redelegate";
+
+export interface DenomAmount {
+  denom: string;
+  micro: string;
+}
+
+export interface JournalIntent {
+  type: "intent";
+  seq: number;
+  ts: string;
+  spec: string;
+  walletRole: WalletRole;
+  action: IntentAction;
+  denoms: DenomAmount[];
+  memo?: string;
+}
+
+export type OutcomeStatus = "committed" | "failed" | "aborted";
+
+export interface JournalOutcome {
+  type: "outcome";
+  seq: number;
+  ts: string;
+  status: OutcomeStatus;
+  txHash?: string;
+  height?: number;
+  failure?: Classification;
+}
+
+export type JournalRecord = JournalIntent | JournalOutcome;
+
+const redact = (value: string): string => sanitizeRpc(value, "");
+
+export function isIntent(record: JournalRecord): record is JournalIntent {
+  return record.type === "intent";
+}
+
+export function isOutcome(record: JournalRecord): record is JournalOutcome {
+  return record.type === "outcome";
+}
+
+export interface IntentInput {
+  seq: number;
+  ts: string;
+  spec: string;
+  walletRole: WalletRole;
+  action: IntentAction;
+  denoms: DenomAmount[];
+  memo?: string;
+}
+
+export function buildIntent(input: IntentInput): JournalIntent {
+  const record: JournalIntent = {
+    type: "intent",
+    seq: input.seq,
+    ts: input.ts,
+    spec: redact(input.spec),
+    walletRole: input.walletRole,
+    action: input.action,
+    denoms: input.denoms.map((d) => ({ denom: redact(d.denom), micro: d.micro }))
+  };
+  if (input.memo !== undefined) {
+    record.memo = redact(input.memo);
+  }
+  return record;
+}
+
+export interface OutcomeInput {
+  seq: number;
+  ts: string;
+  status: OutcomeStatus;
+  txHash?: string;
+  height?: number;
+  failure?: Classification;
+}
+
+export function buildOutcome(input: OutcomeInput): JournalOutcome {
+  const record: JournalOutcome = { type: "outcome", seq: input.seq, ts: input.ts, status: input.status };
+  if (input.txHash !== undefined) {
+    record.txHash = redact(input.txHash);
+  }
+  if (input.height !== undefined) {
+    record.height = input.height;
+  }
+  if (input.failure !== undefined) {
+    record.failure = { ...input.failure, reason: redact(input.failure.reason) };
+  }
+  return record;
+}
+
+export function serializeRecord(record: JournalRecord): string {
+  return JSON.stringify(record);
+}
+
+function isJournalRecord(value: unknown): value is JournalRecord {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const type = (value as { type?: unknown }).type;
+  return type === "intent" || type === "outcome";
+}
+
+/**
+ * Parse a JSONL journal back into records. A corrupt or malformed line (bad JSON, or valid JSON
+ * of the wrong shape) is skipped rather than thrown — a hard crash can leave a half-written final
+ * line, and one torn record must not lose the whole journal. Every kept line is narrowed through
+ * `unknown` and validated on its discriminant, never cast blindly.
+ */
+export function parseRecords(contents: string): JournalRecord[] {
+  const records: JournalRecord[] = [];
+  for (const raw of contents.split("\n")) {
+    const line = raw.trim();
+    if (line.length === 0) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (isJournalRecord(parsed)) {
+      records.push(parsed);
+    }
+  }
+  return records;
+}
+
+/** Intents with no matching outcome record — the write-ahead entries a crash would leave behind. */
+export function unmatchedIntents(records: JournalRecord[]): JournalIntent[] {
+  const settled = new Set(records.filter(isOutcome).map((outcome) => outcome.seq));
+  return records.filter(isIntent).filter((intent) => !settled.has(intent.seq));
+}

--- a/e2e/src/t3/journalStore.ts
+++ b/e2e/src/t3/journalStore.ts
@@ -1,0 +1,90 @@
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeFileSync
+} from "node:fs";
+import { join, resolve } from "node:path";
+import type { JournalRecord } from "./journal.js";
+import { parseRecords, serializeRecord } from "./journal.js";
+
+export const JOURNAL_FILE_NAME = "t3-journal.jsonl";
+export const REPORT_FILE_NAME = "t3-report.json";
+
+// Thin fs glue over the pure journal model in journal.ts. Coverage-excluded (see
+// vitest.config.ts) alongside the other network/fs runners; the record shapes and the
+// leftover-report assembly it drives are unit-tested in journal.ts / report.ts.
+
+/**
+ * A write-ahead JSONL journal. Every record is flushed with `fsync` before the call returns, so
+ * a record written before a broadcast survives a hard crash of the run. Append opens the file
+ * per record (O_APPEND) — the write volume is a handful of records per run, not a hot path.
+ */
+export class JournalStore {
+  private readonly path: string;
+
+  constructor(resultsDir: string) {
+    const dir = resolve(resultsDir);
+    mkdirSync(dir, { recursive: true });
+    this.path = join(dir, JOURNAL_FILE_NAME);
+  }
+
+  append(record: JournalRecord): void {
+    const fd = openSync(this.path, "a");
+    try {
+      appendFileSync(fd, `${serializeRecord(record)}\n`);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  readAll(): JournalRecord[] {
+    if (!existsSync(this.path)) {
+      return [];
+    }
+    return parseRecords(readFileSync(this.path, "utf8"));
+  }
+}
+
+export function writeReportFile(resultsDir: string, report: unknown): string {
+  const dir = resolve(resultsDir);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, REPORT_FILE_NAME);
+  writeFileSync(path, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  return path;
+}
+
+const ATTEMPTS_FILE_NAME = "t3-repair-attempts.json";
+
+/** Read the orphan-lease repair attempt counters persisted across runs. Tolerates a missing/bad file. */
+export function readAttempts(resultsDir: string): Map<string, number> {
+  const path = join(resolve(resultsDir), ATTEMPTS_FILE_NAME);
+  if (!existsSync(path)) {
+    return new Map();
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (typeof parsed !== "object" || parsed === null) {
+      return new Map();
+    }
+    const out = new Map<string, number>();
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value === "number" && Number.isInteger(value)) {
+        out.set(key, value);
+      }
+    }
+    return out;
+  } catch {
+    return new Map();
+  }
+}
+
+export function writeAttempts(resultsDir: string, attempts: Map<string, number>): void {
+  const path = join(resolve(resultsDir), ATTEMPTS_FILE_NAME);
+  writeFileSync(path, `${JSON.stringify(Object.fromEntries(attempts), null, 2)}\n`, "utf8");
+}

--- a/e2e/src/t3/reconcile.test.ts
+++ b/e2e/src/t3/reconcile.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { sweep } from "./reconcile.js";
+import type { SweepDeps, SweepOptions } from "./reconcile.js";
+
+const NOW = Date.parse("2026-07-17T12:00:00.000Z");
+const OLD = "2026-07-17T10:00:00.000Z";
+const RECENT = "2026-07-17T11:59:00.000Z";
+
+function depsFrom(leases: unknown, staking: unknown): { deps: SweepDeps; state: { fetches: number } } {
+  const state = { fetches: 0 };
+  const deps: SweepDeps = {
+    now: () => NOW,
+    fetchJson: (url: string) => {
+      state.fetches += 1;
+      return Promise.resolve(url.includes("/api/leases") ? leases : staking);
+    }
+  };
+  return { deps, state };
+}
+
+function options(extra: Partial<SweepOptions> = {}): SweepOptions {
+  return { origin: "https://app", address: "nolus1owner", attempts: new Map(), ...extra };
+}
+
+describe("sweep lease classification", () => {
+  it("queues an old opened lease for repair and reads both enumeration endpoints", async () => {
+    const { deps, state } = depsFrom(
+      { leases: [{ address: "nolus1a", protocol: "OSMOSIS", status: "opened", opened_at: OLD }] },
+      {}
+    );
+    const result = await sweep(deps, options());
+    expect(result.queuedForRepair).toEqual([{ address: "nolus1a", protocol: "OSMOSIS", openedAt: OLD, attempt: 0 }]);
+    expect(result.nextAttempts.get("nolus1a")).toBe(1);
+    expect(result.openLeases).toEqual([{ address: "nolus1a", protocol: "OSMOSIS", status: "opened" }]);
+    expect(state.fetches).toBe(2);
+  });
+
+  it("demotes an orphan to report-only once attempts are exhausted", async () => {
+    const { deps } = depsFrom(
+      { leases: [{ address: "nolus1a", protocol: "OSMOSIS", status: "opened", opened_at: OLD }] },
+      {}
+    );
+    const result = await sweep(deps, options({ attempts: new Map([["nolus1a", 3]]), maxAttempts: 3 }));
+    expect(result.queuedForRepair).toEqual([]);
+    expect(result.reportOnly.map((c) => c.address)).toEqual(["nolus1a"]);
+    expect(result.nextAttempts.get("nolus1a")).toBe(3);
+  });
+
+  it("tolerates a recently-opened lease and every non-opened status without repairing", async () => {
+    const { deps } = depsFrom(
+      {
+        leases: [
+          { address: "nolus1fresh", protocol: "OSMOSIS", status: "opened", opened_at: RECENT },
+          { address: "nolus1closing", protocol: "OSMOSIS", status: "closing" },
+          { address: "nolus1paid", protocol: "OSMOSIS", status: "paid_off" }
+        ]
+      },
+      {}
+    );
+    const result = await sweep(deps, options());
+    expect(result.queuedForRepair).toEqual([]);
+    expect(result.tolerated.map((t) => t.status).sort()).toEqual(["closing", "opened", "paid_off"]);
+  });
+});
+
+describe("sweep unbondings and partial data", () => {
+  it("recognizes pending unbondings and never queues them for repair", async () => {
+    const staking = {
+      delegations: [],
+      unbonding: [{ validator_address: "nolusvaloper1", entries: [{ balance: "1000" }, { balance: "500" }] }]
+    };
+    const { deps } = depsFrom({ leases: [] }, staking);
+    const result = await sweep(deps, options());
+    expect(result.pendingUnbondings).toEqual([{ validatorAddress: "nolusvaloper1", entries: 2, balanceMicro: "1500" }]);
+    expect(result.queuedForRepair).toEqual([]);
+  });
+
+  it("handles a partial-empty staking response (missing arrays) as empty", async () => {
+    const { deps } = depsFrom({ leases: [] }, { rewards: [] });
+    const result = await sweep(deps, options());
+    expect(result.pendingUnbondings).toEqual([]);
+    expect(result.openLeases).toEqual([]);
+  });
+
+  it("handles a leases payload with no leases array as empty", async () => {
+    const { deps } = depsFrom({}, {});
+    const result = await sweep(deps, options());
+    expect(result.openLeases).toEqual([]);
+    expect(result.tolerated).toEqual([]);
+  });
+});

--- a/e2e/src/t3/reconcile.ts
+++ b/e2e/src/t3/reconcile.ts
@@ -53,6 +53,13 @@ interface RawLease {
   openedAt: string | undefined;
 }
 
+/** The resolved knobs for one sweep, threaded as an object so the numbers can't be transposed. */
+interface SweepSettings {
+  now: number;
+  minAgeMs: number;
+  maxAttempts: number;
+}
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
 }
@@ -118,12 +125,12 @@ function ageMs(openedAt: string | undefined, now: number): number | undefined {
   return Number.isNaN(parsed) ? undefined : now - parsed;
 }
 
-function isOrphan(lease: RawLease, now: number, minAgeMs: number): boolean {
+function isOrphan(lease: RawLease, settings: SweepSettings): boolean {
   if (lease.status !== OPENED) {
     return false;
   }
-  const age = ageMs(lease.openedAt, now);
-  return age !== undefined && age >= minAgeMs;
+  const age = ageMs(lease.openedAt, settings.now);
+  return age !== undefined && age >= settings.minAgeMs;
 }
 
 /**
@@ -135,23 +142,23 @@ function isOrphan(lease: RawLease, now: number, minAgeMs: number): boolean {
  * the three staking sub-calls can come back empty on an upstream failure) are handled as empty.
  */
 export async function sweep(deps: SweepDeps, options: SweepOptions): Promise<SweepResult> {
-  const now = deps.now?.() ?? Date.now();
-  const minAgeMs = options.orphanMinAgeMs ?? DEFAULT_ORPHAN_MIN_AGE_MS;
-  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const settings: SweepSettings = {
+    now: deps.now?.() ?? Date.now(),
+    minAgeMs: options.orphanMinAgeMs ?? DEFAULT_ORPHAN_MIN_AGE_MS,
+    maxAttempts: options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+  };
 
   const leasesPayload = await deps.fetchJson(`${options.origin}/api/leases?address=${options.address}`);
   const stakingPayload = await deps.fetchJson(`${options.origin}/api/staking/positions?address=${options.address}`);
 
-  return classify(extractLeases(leasesPayload), extractUnbondings(stakingPayload), options, now, minAgeMs, maxAttempts);
+  return classify(extractLeases(leasesPayload), extractUnbondings(stakingPayload), options, settings);
 }
 
 function classify(
   leases: RawLease[],
   pendingUnbondings: PendingUnbonding[],
   options: SweepOptions,
-  now: number,
-  minAgeMs: number,
-  maxAttempts: number
+  settings: SweepSettings
 ): SweepResult {
   const result: SweepResult = {
     queuedForRepair: [],
@@ -162,23 +169,16 @@ function classify(
     nextAttempts: new Map(options.attempts)
   };
   for (const lease of leases) {
-    partition(lease, options, now, minAgeMs, maxAttempts, result);
+    partition(lease, options, settings, result);
   }
   return result;
 }
 
-function partition(
-  lease: RawLease,
-  options: SweepOptions,
-  now: number,
-  minAgeMs: number,
-  maxAttempts: number,
-  result: SweepResult
-): void {
+function partition(lease: RawLease, options: SweepOptions, settings: SweepSettings, result: SweepResult): void {
   if (lease.status === OPENED) {
     result.openLeases.push({ address: lease.address, protocol: lease.protocol, status: lease.status });
   }
-  if (!isOrphan(lease, now, minAgeMs)) {
+  if (!isOrphan(lease, settings)) {
     result.tolerated.push({ address: lease.address, protocol: lease.protocol, status: lease.status });
     return;
   }
@@ -189,7 +189,7 @@ function partition(
     openedAt: lease.openedAt,
     attempt
   };
-  if (attempt >= maxAttempts) {
+  if (attempt >= settings.maxAttempts) {
     result.reportOnly.push(candidate);
     return;
   }

--- a/e2e/src/t3/reconcile.ts
+++ b/e2e/src/t3/reconcile.ts
@@ -1,0 +1,198 @@
+import type { OpenLease, PendingUnbonding } from "./report.js";
+
+/**
+ * Injected so the sweep stays pure. `fetchJson` is the sole rate-pacing owner: it self-paces
+ * per URL (strict bucket for `/api/swap/*`, standard otherwise), so the sweep never double-draws.
+ */
+export interface SweepDeps {
+  fetchJson: (url: string) => Promise<unknown>;
+  now?: () => number;
+}
+
+export interface SweepOptions {
+  origin: string;
+  address: string;
+  attempts: Map<string, number>;
+  orphanMinAgeMs?: number;
+  maxAttempts?: number;
+}
+
+export interface RepairCandidate {
+  address: string;
+  protocol: string;
+  openedAt: string | undefined;
+  attempt: number;
+}
+
+export interface ToleratedLease {
+  address: string;
+  protocol: string;
+  status: string;
+}
+
+export interface SweepResult {
+  queuedForRepair: RepairCandidate[];
+  reportOnly: RepairCandidate[];
+  tolerated: ToleratedLease[];
+  openLeases: OpenLease[];
+  pendingUnbondings: PendingUnbonding[];
+  nextAttempts: Map<string, number>;
+}
+
+const DEFAULT_ORPHAN_MIN_AGE_MS = 30 * 60 * 1000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+
+// The one status a stuck E2E run leaves value in and that the app can drive closed. Every other
+// status is a transient or terminal chain state that must be tolerated, never force-repaired.
+const OPENED = "opened";
+
+interface RawLease {
+  address: string;
+  protocol: string;
+  status: string;
+  openedAt: string | undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function extractLeases(payload: unknown): RawLease[] {
+  const root = asRecord(payload);
+  const list = root?.leases;
+  if (!Array.isArray(list)) {
+    return [];
+  }
+  const out: RawLease[] = [];
+  for (const entry of list) {
+    const rec = asRecord(entry);
+    const address = str(rec?.address);
+    const status = str(rec?.status);
+    if (address === undefined || status === undefined) {
+      continue;
+    }
+    out.push({ address, protocol: str(rec?.protocol) ?? "", status, openedAt: str(rec?.opened_at) });
+  }
+  return out;
+}
+
+function extractUnbondings(payload: unknown): PendingUnbonding[] {
+  const root = asRecord(payload);
+  const list = root?.unbonding;
+  if (!Array.isArray(list)) {
+    return [];
+  }
+  const out: PendingUnbonding[] = [];
+  for (const entry of list) {
+    const rec = asRecord(entry);
+    const validatorAddress = str(rec?.validator_address);
+    const entries = Array.isArray(rec?.entries) ? rec.entries : [];
+    if (validatorAddress === undefined) {
+      continue;
+    }
+    out.push({ validatorAddress, entries: entries.length, balanceMicro: sumEntryBalances(entries) });
+  }
+  return out;
+}
+
+function sumEntryBalances(entries: unknown[]): string {
+  let total = 0n;
+  for (const entry of entries) {
+    const balance = str(asRecord(entry)?.balance);
+    if (balance !== undefined && /^\d+$/.test(balance)) {
+      total += BigInt(balance);
+    }
+  }
+  return total.toString();
+}
+
+function ageMs(openedAt: string | undefined, now: number): number | undefined {
+  if (openedAt === undefined) {
+    return undefined;
+  }
+  const parsed = Date.parse(openedAt);
+  return Number.isNaN(parsed) ? undefined : now - parsed;
+}
+
+function isOrphan(lease: RawLease, now: number, minAgeMs: number): boolean {
+  if (lease.status !== OPENED) {
+    return false;
+  }
+  const age = ageMs(lease.openedAt, now);
+  return age !== undefined && age >= minAgeMs;
+}
+
+/**
+ * Pre-run sweep: enumerate leases and unbondings for `address` and classify them. An `opened`
+ * lease older than the orphan grace period is queued for UI-driven repair while its recorded
+ * attempt count is under the cap, else it is report-only (never endlessly retried). Every other
+ * lease status is tolerated and reported, never repaired. Pending unbondings inside the 21-day
+ * window are recognized leftover state and only reported. Partial-empty API responses (any of
+ * the three staking sub-calls can come back empty on an upstream failure) are handled as empty.
+ */
+export async function sweep(deps: SweepDeps, options: SweepOptions): Promise<SweepResult> {
+  const now = deps.now?.() ?? Date.now();
+  const minAgeMs = options.orphanMinAgeMs ?? DEFAULT_ORPHAN_MIN_AGE_MS;
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+
+  const leasesPayload = await deps.fetchJson(`${options.origin}/api/leases?address=${options.address}`);
+  const stakingPayload = await deps.fetchJson(`${options.origin}/api/staking/positions?address=${options.address}`);
+
+  return classify(extractLeases(leasesPayload), extractUnbondings(stakingPayload), options, now, minAgeMs, maxAttempts);
+}
+
+function classify(
+  leases: RawLease[],
+  pendingUnbondings: PendingUnbonding[],
+  options: SweepOptions,
+  now: number,
+  minAgeMs: number,
+  maxAttempts: number
+): SweepResult {
+  const result: SweepResult = {
+    queuedForRepair: [],
+    reportOnly: [],
+    tolerated: [],
+    openLeases: [],
+    pendingUnbondings,
+    nextAttempts: new Map(options.attempts)
+  };
+  for (const lease of leases) {
+    partition(lease, options, now, minAgeMs, maxAttempts, result);
+  }
+  return result;
+}
+
+function partition(
+  lease: RawLease,
+  options: SweepOptions,
+  now: number,
+  minAgeMs: number,
+  maxAttempts: number,
+  result: SweepResult
+): void {
+  if (lease.status === OPENED) {
+    result.openLeases.push({ address: lease.address, protocol: lease.protocol, status: lease.status });
+  }
+  if (!isOrphan(lease, now, minAgeMs)) {
+    result.tolerated.push({ address: lease.address, protocol: lease.protocol, status: lease.status });
+    return;
+  }
+  const attempt = options.attempts.get(lease.address) ?? 0;
+  const candidate: RepairCandidate = {
+    address: lease.address,
+    protocol: lease.protocol,
+    openedAt: lease.openedAt,
+    attempt
+  };
+  if (attempt >= maxAttempts) {
+    result.reportOnly.push(candidate);
+    return;
+  }
+  result.queuedForRepair.push(candidate);
+  result.nextAttempts.set(lease.address, attempt + 1);
+}

--- a/e2e/src/t3/repair.ts
+++ b/e2e/src/t3/repair.ts
@@ -1,0 +1,65 @@
+import type { Page } from "@playwright/test";
+import type { ConnectLabels } from "../t2/appDriver.js";
+import { assertConnected, connectKeplr, waitForAppShell } from "../t2/appDriver.js";
+import type { RepairCandidate } from "./reconcile.js";
+
+// Browser glue (coverage-excluded, see vitest.config.ts). Orphan-lease repair is performed by
+// DRIVING THE APP UI, never by constructing a close transaction here: the production app builds
+// every tx client-side via @nolus/nolusjs (a real market-close carries a Skip route + funds),
+// and the backend's unsigned-tx endpoints are a phantom surface the app never calls. Repairing
+// through the market-close UI therefore exercises the exact production construction path with no
+// duplicated tx logic. Live execution is CI-gated; the sweep's classification is unit-tested.
+
+const POSITIONS_ROUTE = "/positions";
+const DIALOG_TIMEOUT = 20000;
+
+export interface RepairOutcome {
+  address: string;
+  attempted: boolean;
+  note: string;
+}
+
+/** Connect the primary wallet on a light route and land on the positions list. */
+async function connectOnPositions(page: Page, labels: ConnectLabels, address: string): Promise<void> {
+  await page.goto(POSITIONS_ROUTE, { waitUntil: "domcontentloaded" });
+  await waitForAppShell(page);
+  await connectKeplr(page, labels);
+  await assertConnected(page, address);
+}
+
+/** Open the lease's detail dialog by its on-chain address, then start the market-close flow. */
+async function openMarketClose(page: Page, leaseAddress: string): Promise<void> {
+  await page.getByText(leaseAddress, { exact: false }).first().click({ timeout: DIALOG_TIMEOUT });
+  const dialog = page.locator("#dialog-scroll").first();
+  await dialog.waitFor({ state: "visible", timeout: DIALOG_TIMEOUT });
+  await page.getByRole("button", { name: /close/i }).first().click();
+  await page
+    .getByRole("button", { name: /market/i })
+    .first()
+    .click();
+}
+
+/**
+ * Drive the app's market-close flow for a single orphaned lease, signing through the scripted
+ * Keplr stub already installed on `page`. Returns an outcome record for the leftover report; a
+ * failure to reach the close control is surfaced as `attempted: false` so the caller can leave
+ * the lease report-only rather than treating a UI miss as a repair.
+ */
+export async function repairOrphanLease(
+  page: Page,
+  labels: ConnectLabels,
+  primaryAddress: string,
+  candidate: RepairCandidate
+): Promise<RepairOutcome> {
+  await connectOnPositions(page, labels, primaryAddress);
+  try {
+    await openMarketClose(page, candidate.address);
+  } catch {
+    return { address: candidate.address, attempted: false, note: "market-close control not reachable" };
+  }
+  await page
+    .getByRole("button", { name: /confirm|submit|send/i })
+    .first()
+    .click({ timeout: DIALOG_TIMEOUT });
+  return { address: candidate.address, attempted: true, note: "market-close submitted via app UI" };
+}

--- a/e2e/src/t3/report.test.ts
+++ b/e2e/src/t3/report.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { assembleLeftoverReport } from "./report.js";
+import { buildIntent, buildOutcome } from "./journal.js";
+import type { JournalRecord } from "./journal.js";
+
+const swapIntent = (seq: number): JournalRecord =>
+  buildIntent({
+    seq,
+    ts: "t",
+    spec: "t3-engine",
+    walletRole: "primary",
+    action: "swap",
+    denoms: [{ denom: "unls", micro: "5" }]
+  });
+
+describe("assembleLeftoverReport", () => {
+  it("emits open leases, pending unbondings, unfinished swaps and spend on a terminal path", () => {
+    const journal: JournalRecord[] = [
+      swapIntent(1),
+      buildOutcome({ seq: 1, ts: "t", status: "committed" }),
+      swapIntent(2)
+    ];
+    const report = assembleLeftoverReport({
+      generatedAt: "2026-07-17T00:00:00.000Z",
+      terminal: "spend-cap-abort",
+      journal,
+      openLeases: [{ address: "nolus1lease", protocol: "OSMOSIS", status: "opened" }],
+      pendingUnbondings: [{ validatorAddress: "nolusvaloper1", entries: 2, balanceMicro: "1500" }],
+      spend: [{ denom: "nls", capMicro: 1_000_000n, spentMicro: 5n }],
+      warnings: ["wallet-2 low"]
+    });
+
+    expect(report).toEqual({
+      suite: "t3",
+      version: 1,
+      generatedAt: "2026-07-17T00:00:00.000Z",
+      terminal: "spend-cap-abort",
+      openLeases: [{ address: "nolus1lease", protocol: "OSMOSIS", status: "opened" }],
+      pendingUnbondings: [{ validatorAddress: "nolusvaloper1", entries: 2, balanceMicro: "1500" }],
+      unfinishedSwaps: [{ seq: 2, spec: "t3-engine", denoms: [{ denom: "unls", micro: "5" }] }],
+      spend: [{ denom: "nls", capMicro: "1000000", spentMicro: "5" }],
+      warnings: ["wallet-2 low"]
+    });
+  });
+
+  it("reports no unfinished swaps when every swap intent settled", () => {
+    const journal: JournalRecord[] = [swapIntent(1), buildOutcome({ seq: 1, ts: "t", status: "committed" })];
+    const report = assembleLeftoverReport({
+      generatedAt: "t",
+      terminal: "success",
+      journal,
+      openLeases: [],
+      pendingUnbondings: [],
+      spend: [],
+      warnings: []
+    });
+    expect(report.unfinishedSwaps).toEqual([]);
+  });
+});

--- a/e2e/src/t3/report.ts
+++ b/e2e/src/t3/report.ts
@@ -1,0 +1,79 @@
+import type { DenomAmount, JournalRecord } from "./journal.js";
+import { unmatchedIntents } from "./journal.js";
+import type { SpendSnapshot } from "./spendCap.js";
+
+export type TerminalPath = "success" | "app-failure" | "spend-cap-abort" | "crash";
+
+export interface OpenLease {
+  address: string;
+  protocol: string;
+  status: string;
+}
+
+export interface PendingUnbonding {
+  validatorAddress: string;
+  entries: number;
+  balanceMicro: string;
+}
+
+export interface UnfinishedSwap {
+  seq: number;
+  spec: string;
+  denoms: DenomAmount[];
+}
+
+export interface SpendLine {
+  denom: string;
+  capMicro: string;
+  spentMicro: string;
+}
+
+/**
+ * The machine-readable leftover-state report consumed by the #285 reporting tier. `version`
+ * is bumped on any shape change. `openLeases` and `pendingUnbondings` are the chain-enumerated
+ * sweep results; `unfinishedSwaps` come from the journal because a swap is not chain-queryable.
+ * Emitted on every terminal path (success, app-failure, spend-cap-abort); a hard crash still
+ * leaves the write-ahead journal from which this same shape can be reconstructed.
+ */
+export interface LeftoverReport {
+  suite: "t3";
+  version: 1;
+  generatedAt: string;
+  terminal: TerminalPath;
+  openLeases: OpenLease[];
+  pendingUnbondings: PendingUnbonding[];
+  unfinishedSwaps: UnfinishedSwap[];
+  spend: SpendLine[];
+  warnings: string[];
+}
+
+export interface LeftoverReportInput {
+  generatedAt: string;
+  terminal: TerminalPath;
+  journal: JournalRecord[];
+  openLeases: OpenLease[];
+  pendingUnbondings: PendingUnbonding[];
+  spend: SpendSnapshot[];
+  warnings: string[];
+}
+
+export function assembleLeftoverReport(input: LeftoverReportInput): LeftoverReport {
+  const unfinishedSwaps = unmatchedIntents(input.journal)
+    .filter((intent) => intent.action === "swap")
+    .map((intent) => ({ seq: intent.seq, spec: intent.spec, denoms: intent.denoms }));
+  return {
+    suite: "t3",
+    version: 1,
+    generatedAt: input.generatedAt,
+    terminal: input.terminal,
+    openLeases: input.openLeases,
+    pendingUnbondings: input.pendingUnbondings,
+    unfinishedSwaps,
+    spend: input.spend.map((line) => ({
+      denom: line.denom,
+      capMicro: line.capMicro.toString(),
+      spentMicro: line.spentMicro.toString()
+    })),
+    warnings: input.warnings
+  };
+}

--- a/e2e/src/t3/runtime.ts
+++ b/e2e/src/t3/runtime.ts
@@ -1,0 +1,43 @@
+import type { OriginContext } from "../t2/appDriver.js";
+import { getJson } from "../http.js";
+import { sanitizeRpc } from "../transfer.js";
+import type { SerialQueue } from "./serialQueue.js";
+import type { SweepDeps } from "./reconcile.js";
+
+// Live wiring that binds the pure engine to the real network / fs. Coverage-excluded (see
+// vitest.config.ts): this is the only place src/t3 touches undici and the chain. Every unit of
+// logic it composes — the pacer, the sweep classification, the cap, the journal — is unit-tested
+// through its pure module.
+
+const SWAP_PATH = /\/api\/swap\//;
+
+/**
+ * A host-resolver-aware JSON read whose failures are stripped of any RPC/target host before they
+ * escape — the host resolver maps the public base domain to an internal address, so a raw undici
+ * connect error would otherwise carry that internal host/IP into a report or a CI artifact. This
+ * mirrors the sanitize-on-throw posture `broadcast.ts` already holds for the write path.
+ */
+export async function readJson(ctx: OriginContext, url: string): Promise<unknown> {
+  try {
+    return await getJson(url, ctx.dispatcher);
+  } catch (error) {
+    const raw = error instanceof Error ? error.message : String(error);
+    // eslint-disable-next-line preserve-caught-error -- cause intentionally dropped: it carries the raw RPC host; message re-thrown through sanitizeRpc
+    throw new Error(sanitizeRpc(raw, ctx.origin));
+  }
+}
+
+/**
+ * A rate-paced JSON reader for the reconciliation sweep. Reads to `/api/swap/*` draw from the
+ * strict bucket, every other read from the standard bucket — the same single budget the queue's
+ * submissions share, because nginx rewrites XFF so the whole suite counts as one client IP.
+ * Read failures are sanitized so the sweep never leaks the internal target host.
+ */
+export function pacedSweepDeps(queue: SerialQueue, ctx: OriginContext): SweepDeps {
+  return {
+    fetchJson: async (url: string): Promise<unknown> => {
+      await queue.pace(SWAP_PATH.test(url) ? "strict" : "standard");
+      return readJson(ctx, url);
+    }
+  };
+}

--- a/e2e/src/t3/serialQueue.test.ts
+++ b/e2e/src/t3/serialQueue.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { SerialQueue } from "./serialQueue.js";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Drain the microtask queue completely — setImmediate fires after every pending microtask. */
+function flush(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+const instant = { now: (): number => 0, sleep: (): Promise<void> => Promise.resolve() };
+
+describe("SerialQueue serialization", () => {
+  it("runs one submission per wallet at a time; the second starts only after the first settles", async () => {
+    const queue = new SerialQueue(instant);
+    const started: string[] = [];
+    const first = deferred<string>();
+
+    const p1 = queue.submit({
+      walletKey: "w",
+      kind: "spend",
+      execute: () => {
+        started.push("a");
+        return first.promise;
+      }
+    });
+    const p2 = queue.submit({
+      walletKey: "w",
+      kind: "spend",
+      execute: () => {
+        started.push("b");
+        return Promise.resolve("b");
+      }
+    });
+
+    await flush();
+    expect(started).toEqual(["a"]);
+
+    first.resolve("a");
+    expect(await p1).toBe("a");
+    expect(await p2).toBe("b");
+    expect(started).toEqual(["a", "b"]);
+  });
+
+  it("runs distinct wallets concurrently", async () => {
+    const queue = new SerialQueue(instant);
+    const started: string[] = [];
+    const held = deferred<undefined>();
+
+    const p1 = queue.submit({
+      walletKey: "w1",
+      kind: "spend",
+      execute: async () => {
+        started.push("w1");
+        await held.promise;
+      }
+    });
+    const p2 = queue.submit({
+      walletKey: "w2",
+      kind: "spend",
+      execute: () => {
+        started.push("w2");
+        return Promise.resolve();
+      }
+    });
+
+    await flush();
+    expect(started).toEqual(["w1", "w2"]);
+    held.resolve(undefined);
+    await Promise.all([p1, p2]);
+  });
+
+  it("releases the slot even when a submission rejects, letting the next run", async () => {
+    const queue = new SerialQueue(instant);
+    const p1 = queue.submit({ walletKey: "w", kind: "spend", execute: () => Promise.reject(new Error("boom")) });
+    const p2 = queue.submit({ walletKey: "w", kind: "spend", execute: () => Promise.resolve("ok") });
+    await expect(p1).rejects.toThrow("boom");
+    expect(await p2).toBe("ok");
+  });
+});
+
+describe("SerialQueue redelegate mutex", () => {
+  it("never overlaps two redelegations even across different wallets", async () => {
+    const queue = new SerialQueue(instant);
+    let concurrent = 0;
+    let maxConcurrent = 0;
+    const hold = deferred<undefined>();
+
+    const make = (key: string): Promise<void> =>
+      queue.submit({
+        walletKey: key,
+        kind: "redelegate",
+        execute: async () => {
+          concurrent += 1;
+          maxConcurrent = Math.max(maxConcurrent, concurrent);
+          if (key === "w1") {
+            await hold.promise;
+          }
+          concurrent -= 1;
+        }
+      });
+
+    const p1 = make("w1");
+    const p2 = make("w2");
+    await flush();
+    expect(maxConcurrent).toBe(1);
+
+    hold.resolve(undefined);
+    await Promise.all([p1, p2]);
+    expect(maxConcurrent).toBe(1);
+  });
+});
+
+describe("SerialQueue pacing", () => {
+  it("waits on a bucket once its burst is exhausted, then refills over time", async () => {
+    let clock = 0;
+    let slept = 0;
+    const queue = new SerialQueue({
+      now: () => clock,
+      sleep: (ms: number) => {
+        clock += ms;
+        slept += ms;
+        return Promise.resolve();
+      },
+      strict: { ratePerSecond: 2, burst: 1 }
+    });
+
+    await queue.pace("strict");
+    expect(slept).toBe(0);
+    await queue.pace("strict");
+    expect(slept).toBeGreaterThan(0);
+  });
+});

--- a/e2e/src/t3/serialQueue.ts
+++ b/e2e/src/t3/serialQueue.ts
@@ -1,0 +1,121 @@
+export type SubmissionKind = "spend" | "redelegate" | "read";
+export type BucketName = "strict" | "standard";
+
+export interface BucketConfig {
+  ratePerSecond: number;
+  burst: number;
+}
+
+/** The nginx strict bucket for `/api/swap/*`: 2 RPS, burst 5, shared across the whole suite. */
+export const STRICT_BUCKET: BucketConfig = { ratePerSecond: 2, burst: 5 };
+/** The standard per-client-IP bucket: 20 RPS, burst 50. All suite egress shares one instance. */
+export const STANDARD_BUCKET: BucketConfig = { ratePerSecond: 20, burst: 50 };
+
+export interface SerialQueueDeps {
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  strict?: BucketConfig;
+  standard?: BucketConfig;
+}
+
+/**
+ * A submission's `execute` MUST resolve only once the transaction has committed
+ * (DeliverTx / block commit), never on the mere broadcast ack. The queue releases a wallet's
+ * slot the instant `execute`'s returned promise settles, so resolving early would let a second
+ * submission for the same wallet sign against a not-yet-committed account sequence.
+ */
+export interface SubmitOptions<T> {
+  walletKey: string;
+  kind: SubmissionKind;
+  bucket?: BucketName;
+  execute: () => Promise<T>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/** A refilling token bucket. Deterministic under an injected clock + sleep for unit tests. */
+class TokenBucket {
+  private tokens: number;
+  private last: number;
+
+  constructor(
+    private readonly config: BucketConfig,
+    private readonly now: () => number,
+    private readonly sleep: (ms: number) => Promise<void>
+  ) {
+    this.tokens = config.burst;
+    this.last = now();
+  }
+
+  private refill(): void {
+    const at = this.now();
+    const elapsedSec = (at - this.last) / 1000;
+    if (elapsedSec <= 0) {
+      return;
+    }
+    this.tokens = Math.min(this.config.burst, this.tokens + elapsedSec * this.config.ratePerSecond);
+    this.last = at;
+  }
+
+  async take(): Promise<void> {
+    for (;;) {
+      this.refill();
+      if (this.tokens >= 1) {
+        this.tokens -= 1;
+        return;
+      }
+      const deficit = 1 - this.tokens;
+      await this.sleep(Math.ceil((deficit / this.config.ratePerSecond) * 1000));
+    }
+  }
+}
+
+/**
+ * A per-wallet async FIFO. At most one submission per wallet key is ever in flight; the next
+ * only begins after the previous submission's `execute` promise settles (commit or throw).
+ * Redelegations additionally serialize against each other across every wallet — Cosmos forbids
+ * a delegator holding two concurrent redelegations. Every start is gated on a shared token
+ * bucket so submissions and API reads (via `pace`) draw from one rate budget, matching the
+ * single nginx bucket the suite is billed against.
+ */
+export class SerialQueue {
+  private readonly strict: TokenBucket;
+  private readonly standard: TokenBucket;
+  private readonly walletTails = new Map<string, Promise<unknown>>();
+  private redelegateTail: Promise<unknown> = Promise.resolve();
+
+  constructor(deps: SerialQueueDeps = {}) {
+    const now = deps.now ?? ((): number => Date.now());
+    const sleep = deps.sleep ?? defaultSleep;
+    this.strict = new TokenBucket(deps.strict ?? STRICT_BUCKET, now, sleep);
+    this.standard = new TokenBucket(deps.standard ?? STANDARD_BUCKET, now, sleep);
+  }
+
+  /** Consume one token from the named bucket, awaiting a refill if the bucket is empty. */
+  async pace(bucket: BucketName = "standard"): Promise<void> {
+    await (bucket === "strict" ? this.strict : this.standard).take();
+  }
+
+  submit<T>(options: SubmitOptions<T>): Promise<T> {
+    const prior = this.walletTails.get(options.walletKey) ?? Promise.resolve();
+    const guards = options.kind === "redelegate" ? [prior, this.redelegateTail] : [prior];
+    const result = this.runAfter(guards, options.bucket ?? "standard", options.execute);
+    const tail = result.then(swallow, swallow);
+    this.walletTails.set(options.walletKey, tail);
+    if (options.kind === "redelegate") {
+      this.redelegateTail = tail;
+    }
+    return result;
+  }
+
+  private async runAfter<T>(guards: Promise<unknown>[], bucket: BucketName, execute: () => Promise<T>): Promise<T> {
+    await Promise.allSettled(guards);
+    await this.pace(bucket);
+    return execute();
+  }
+}
+
+const swallow = (): void => undefined;

--- a/e2e/src/t3/spendCap.test.ts
+++ b/e2e/src/t3/spendCap.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { SpendCap, spendCapFromMicros } from "./spendCap.js";
+import type { SpendItem } from "./spendCap.js";
+
+const nls = (micro: bigint): SpendItem => ({ denom: "nls", micro });
+const usdc = (micro: bigint): SpendItem => ({ denom: "usdc", micro });
+
+describe("SpendCap.check", () => {
+  it("passes a candidate within cap and reports the over-denom when it exceeds", () => {
+    const cap = new SpendCap({ nls: 1_000_000n, usdc: 0n });
+    expect(cap.check([nls(999_999n)])).toEqual({ ok: true });
+
+    const over = cap.check([nls(1_000_001n)]);
+    expect(over).toEqual({ ok: false, overDenom: "nls", projectedMicro: 1_000_001n, capMicro: 1_000_000n });
+  });
+
+  it("aborts a swap that attaches a zero-cap denom (usdc cap 0)", () => {
+    const cap = new SpendCap({ nls: 1_000_000n, usdc: 0n });
+    const check = cap.check([nls(1000n), usdc(1n)]);
+    expect(check).toEqual({ ok: false, overDenom: "usdc", projectedMicro: 1n, capMicro: 0n });
+  });
+
+  it("counts gross outflow cumulatively and never credits a later return of funds", () => {
+    const cap = new SpendCap({ nls: 10_000n, usdc: 0n });
+    cap.record([nls(6000n)]);
+    expect(cap.spent("nls")).toBe(6000n);
+    // A second spend that would breach the cap given what is already spent is refused; there is
+    // no API that could credit the first spend back to re-open headroom.
+    expect(cap.check([nls(5000n)])).toEqual({
+      ok: false,
+      overDenom: "nls",
+      projectedMicro: 11_000n,
+      capMicro: 10_000n
+    });
+    cap.record([nls(4000n)]);
+    expect(cap.spent("nls")).toBe(10_000n);
+  });
+
+  it("rejects a negative micro amount", () => {
+    const cap = new SpendCap({ nls: 10n, usdc: 0n });
+    expect(() => cap.check([nls(-1n)])).toThrow(/non-negative/);
+  });
+});
+
+describe("SpendCap pending accounting", () => {
+  it("reserves before sign and settles on commit, leaving pending at zero", () => {
+    const cap = new SpendCap({ nls: 10_000n, usdc: 0n });
+    const items = [nls(3000n)];
+    cap.reserve(items);
+    expect(cap.pending("nls")).toBe(3000n);
+    // The projection includes pending: a second candidate sees the reservation.
+    expect(cap.check([nls(8000n)])).toEqual({
+      ok: false,
+      overDenom: "nls",
+      projectedMicro: 11_000n,
+      capMicro: 10_000n
+    });
+    cap.settle(items);
+    expect(cap.pending("nls")).toBe(0n);
+    expect(cap.spent("nls")).toBe(3000n);
+  });
+
+  it("releases a reservation on failure without crediting spend", () => {
+    const cap = new SpendCap({ nls: 10_000n, usdc: 0n });
+    const items = [nls(3000n)];
+    cap.reserve(items);
+    cap.release(items);
+    expect(cap.pending("nls")).toBe(0n);
+    expect(cap.spent("nls")).toBe(0n);
+  });
+});
+
+describe("spendCapFromMicros / snapshot", () => {
+  it("builds from micro strings and snapshots caps and spend", () => {
+    const cap = spendCapFromMicros("1000000", "0");
+    cap.record([nls(250_000n)]);
+    expect(cap.snapshot()).toEqual([
+      { denom: "nls", capMicro: 1_000_000n, spentMicro: 250_000n },
+      { denom: "usdc", capMicro: 0n, spentMicro: 0n }
+    ]);
+  });
+});

--- a/e2e/src/t3/spendCap.test.ts
+++ b/e2e/src/t3/spendCap.test.ts
@@ -72,7 +72,7 @@ describe("SpendCap pending accounting", () => {
 
 describe("spendCapFromMicros / snapshot", () => {
   it("builds from micro strings and snapshots caps and spend", () => {
-    const cap = spendCapFromMicros("1000000", "0");
+    const cap = spendCapFromMicros({ nlsMicro: "1000000", usdcMicro: "0" });
     cap.record([nls(250_000n)]);
     expect(cap.snapshot()).toEqual([
       { denom: "nls", capMicro: 1_000_000n, spentMicro: 250_000n },

--- a/e2e/src/t3/spendCap.ts
+++ b/e2e/src/t3/spendCap.ts
@@ -109,6 +109,6 @@ function aggregate(items: SpendItem[]): Map<CapDenom, bigint> {
   return totals;
 }
 
-export function spendCapFromMicros(nlsMicro: string, usdcMicro: string): SpendCap {
-  return new SpendCap({ nls: BigInt(nlsMicro), usdc: BigInt(usdcMicro) });
+export function spendCapFromMicros(micros: { nlsMicro: string; usdcMicro: string }): SpendCap {
+  return new SpendCap({ nls: BigInt(micros.nlsMicro), usdc: BigInt(micros.usdcMicro) });
 }

--- a/e2e/src/t3/spendCap.ts
+++ b/e2e/src/t3/spendCap.ts
@@ -1,0 +1,114 @@
+export type CapDenom = "nls" | "usdc";
+
+/** A single unit of gross outflow, in native micro units (never a float). */
+export interface SpendItem {
+  denom: CapDenom;
+  micro: bigint;
+}
+
+export type SpendCheck = { ok: true } | { ok: false; overDenom: CapDenom; projectedMicro: bigint; capMicro: bigint };
+
+export interface SpendSnapshot {
+  denom: CapDenom;
+  capMicro: bigint;
+  spentMicro: bigint;
+}
+
+/**
+ * Per-denom cumulative spend accounting in native micro units. "Spend" is GROSS outflow —
+ * attached funds plus a deterministic gas-fee upper bound — and is never credited back when a
+ * close/unbond later returns funds: netting would re-open headroom and blow the worst-case
+ * bound the cap exists to hold. `check` is a strict pre-sign gate over `spent + pending +
+ * candidate`; a candidate that projects over its cap is refused before it is ever signed.
+ * The gate is safe under concurrency because `pending` is part of that projection: a
+ * counterparty send from the secondary wallet can be reserved-but-not-yet-committed while the
+ * primary checks a candidate, and that in-flight outflow is already counted, so a racing
+ * candidate can never push a denom past its cap.
+ */
+export class SpendCap {
+  private readonly caps: Map<CapDenom, bigint>;
+  private readonly spentMicro = new Map<CapDenom, bigint>();
+  private readonly pendingMicro = new Map<CapDenom, bigint>();
+
+  constructor(caps: { nls: bigint; usdc: bigint }) {
+    this.caps = new Map([
+      ["nls", caps.nls],
+      ["usdc", caps.usdc]
+    ]);
+  }
+
+  cap(denom: CapDenom): bigint {
+    return this.caps.get(denom) ?? 0n;
+  }
+
+  spent(denom: CapDenom): bigint {
+    return this.spentMicro.get(denom) ?? 0n;
+  }
+
+  pending(denom: CapDenom): bigint {
+    return this.pendingMicro.get(denom) ?? 0n;
+  }
+
+  check(candidate: SpendItem[]): SpendCheck {
+    for (const [denom, add] of aggregate(candidate)) {
+      const projectedMicro = this.spent(denom) + this.pending(denom) + add;
+      const capMicro = this.cap(denom);
+      if (projectedMicro > capMicro) {
+        return { ok: false, overDenom: denom, projectedMicro, capMicro };
+      }
+    }
+    return { ok: true };
+  }
+
+  /** Directly count a committed gross outflow as spent, with no prior reservation. */
+  record(items: SpendItem[]): void {
+    for (const [denom, add] of aggregate(items)) {
+      this.spentMicro.set(denom, this.spent(denom) + add);
+    }
+  }
+
+  /** Move a candidate into `pending` after a passing `check`, before the executor signs. */
+  reserve(items: SpendItem[]): void {
+    for (const [denom, add] of aggregate(items)) {
+      this.pendingMicro.set(denom, this.pending(denom) + add);
+    }
+  }
+
+  /** On commit: retire the reservation and count it as permanently spent. */
+  settle(items: SpendItem[]): void {
+    for (const [denom, add] of aggregate(items)) {
+      this.pendingMicro.set(denom, this.pending(denom) - add);
+      this.spentMicro.set(denom, this.spent(denom) + add);
+    }
+  }
+
+  /** On a failed broadcast: drop the reservation without crediting spend. */
+  release(items: SpendItem[]): void {
+    for (const [denom, add] of aggregate(items)) {
+      this.pendingMicro.set(denom, this.pending(denom) - add);
+    }
+  }
+
+  snapshot(): SpendSnapshot[] {
+    return [...this.caps.keys()].map((denom) => ({
+      denom,
+      capMicro: this.cap(denom),
+      spentMicro: this.spent(denom)
+    }));
+  }
+}
+
+function aggregate(items: SpendItem[]): Map<CapDenom, bigint> {
+  const totals = new Map<CapDenom, bigint>();
+  for (const item of items) {
+    if (item.micro < 0n) {
+      throw new Error("spend item micro amount must be non-negative");
+    }
+    totals.set(item.denom, (totals.get(item.denom) ?? 0n) + item.micro);
+  }
+  return totals;
+}
+
+export function spendCapFromMicros(nlsMicro: string, usdcMicro: string): SpendCap {
+  return new SpendCap({ nls: BigInt(nlsMicro), usdc: BigInt(usdcMicro) });
+}

--- a/e2e/src/t3/taxonomy.test.ts
+++ b/e2e/src/t3/taxonomy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { classify } from "./taxonomy.js";
+
+describe("classify environment", () => {
+  it("classifies an HTTP 429 status as environment", () => {
+    expect(classify({ message: "request failed", status: 429 }).category).toBe("environment");
+  });
+
+  it("classifies rate-limit text, relayer delay, price move and node-down as environment", () => {
+    expect(classify({ message: "Too Many Requests" }).signal).toBe("rate-limited");
+    expect(classify({ message: "IBC packet not relayed yet" }).category).toBe("environment");
+    expect(classify({ message: "quote expired: price moved out of tolerance" }).category).toBe("environment");
+    expect(classify({ message: "connect ETIMEDOUT waiting for RPC" }).category).toBe("environment");
+    expect(classify({ message: "timed out waiting for chain state" }).signal).toBe("chain-state-timeout");
+  });
+});
+
+describe("classify app", () => {
+  it("classifies an assertion failure as app", () => {
+    expect(classify({ message: "expected true toBe false" }).category).toBe("app");
+  });
+
+  it("defaults an unrecognized failure to app", () => {
+    expect(classify({ message: "the widget rendered upside down" })).toMatchObject({
+      category: "app",
+      signal: "unclassified"
+    });
+  });
+});
+
+describe("classify precondition", () => {
+  it("classifies unfunded, unbonding-entry cap and redelegation lock as precondition", () => {
+    expect(classify({ message: "account is unfunded" }).category).toBe("precondition");
+    expect(classify({ message: "too many unbonding delegation entries" }).signal).toBe("unbonding-entry-cap");
+    expect(classify({ message: "redelegation is in progress for this delegator" }).signal).toBe("redelegation-lock");
+    expect(classify({ message: "missing osmosis balance for the swap leg" }).category).toBe("precondition");
+  });
+});
+
+describe("classify redaction", () => {
+  it("redacts an embedded IP from the stored reason while keeping the environment signal", () => {
+    const result = classify({ message: "connect ECONNREFUSED 10.1.2.3:26657" });
+    expect(result.category).toBe("environment");
+    expect(result.signal).toBe("node-unavailable");
+    expect(result.reason).not.toContain("10.1.2.3");
+    expect(result.reason).toContain("ECONNREFUSED");
+  });
+
+  it("redacts a specific rpc host when one is provided", () => {
+    const result = classify({
+      message: "dial tcp rpc.internal.example:26657 refused",
+      rpcUrl: "http://rpc.internal.example:26657"
+    });
+    expect(result.reason).not.toContain("rpc.internal.example");
+  });
+
+  it("reads the message from an Error instance", () => {
+    expect(classify({ error: new Error("HTTP 503 from upstream") }).category).toBe("environment");
+  });
+});

--- a/e2e/src/t3/taxonomy.ts
+++ b/e2e/src/t3/taxonomy.ts
@@ -21,8 +21,14 @@ interface Rule {
   matches: (text: string, status: number | undefined) => boolean;
 }
 
-function pattern(category: FailureCategory, signal: string, regex: RegExp): Rule {
-  return { category, signal, matches: (text) => regex.test(text) };
+interface PatternRule {
+  category: FailureCategory;
+  signal: string;
+  regex: RegExp;
+}
+
+function pattern(rule: PatternRule): Rule {
+  return { category: rule.category, signal: rule.signal, matches: (text) => rule.regex.test(text) };
 }
 
 // Ordered most-specific-first. A precondition (a state the operator must fix) outranks an
@@ -31,14 +37,26 @@ function pattern(category: FailureCategory, signal: string, regex: RegExp): Rule
 // an app bug. Rules test the raw (pre-redaction) text so a host/IP-bearing transport error
 // still matches; only the stored `reason` is sanitized.
 const RULES: Rule[] = [
-  pattern("precondition", "unfunded", /unfunded|insufficient funds|not funded|no balance/i),
-  pattern("precondition", "unbonding-entry-cap", /too many unbonding|unbonding.*entries|max(imum)? entries/i),
-  pattern(
-    "precondition",
-    "redelegation-lock",
-    /redelegation.*(in progress|not complete|locked)|receiving redelegation/i
-  ),
-  pattern("precondition", "osmosis-side-funds", /osmosis.*(funds|balance|liquidity is missing)|missing osmosis/i),
+  pattern({
+    category: "precondition",
+    signal: "unfunded",
+    regex: /unfunded|insufficient funds|not funded|no balance/i
+  }),
+  pattern({
+    category: "precondition",
+    signal: "unbonding-entry-cap",
+    regex: /too many unbonding|unbonding.*entries|max(imum)? entries/i
+  }),
+  pattern({
+    category: "precondition",
+    signal: "redelegation-lock",
+    regex: /redelegation.*(in progress|not complete|locked)|receiving redelegation/i
+  }),
+  pattern({
+    category: "precondition",
+    signal: "osmosis-side-funds",
+    regex: /osmosis.*(funds|balance|liquidity is missing)|missing osmosis/i
+  }),
   {
     category: "environment",
     signal: "rate-limited",
@@ -53,23 +71,31 @@ const RULES: Rule[] = [
         text
       )
   },
-  pattern(
-    "environment",
-    "relayer-delay",
-    /relayer|ibc.*(delay|timeout|pending|not relayed)|packet.*(timeout|pending|not relayed)/i
-  ),
-  pattern(
-    "environment",
-    "price-move",
-    /price.*(move|moved|change|changed|slippage)|slippage|quote.*expired|expired quote|out of tolerance/i
-  ),
-  pattern("environment", "liquidity", /insufficient liquidity|not enough liquidity|no route|route not found/i),
-  pattern(
-    "environment",
-    "chain-state-timeout",
-    /timed?\s?out|timeout waiting|deadline exceeded|wait.*(chain|block|commit)/i
-  ),
-  pattern("app", "assertion", /\bexpect\(|assertion|to(Be|Equal|Contain|Match|HaveScreenshot)\b/i)
+  pattern({
+    category: "environment",
+    signal: "relayer-delay",
+    regex: /relayer|ibc.*(delay|timeout|pending|not relayed)|packet.*(timeout|pending|not relayed)/i
+  }),
+  pattern({
+    category: "environment",
+    signal: "price-move",
+    regex: /price.*(move|moved|change|changed|slippage)|slippage|quote.*expired|expired quote|out of tolerance/i
+  }),
+  pattern({
+    category: "environment",
+    signal: "liquidity",
+    regex: /insufficient liquidity|not enough liquidity|no route|route not found/i
+  }),
+  pattern({
+    category: "environment",
+    signal: "chain-state-timeout",
+    regex: /timed?\s?out|timeout waiting|deadline exceeded|wait.*(chain|block|commit)/i
+  }),
+  pattern({
+    category: "app",
+    signal: "assertion",
+    regex: /\bexpect\(|assertion|to(Be|Equal|Contain|Match|HaveScreenshot)\b/i
+  })
 ];
 
 function isUpstream5xx(status: number | undefined): boolean {

--- a/e2e/src/t3/taxonomy.ts
+++ b/e2e/src/t3/taxonomy.ts
@@ -1,0 +1,105 @@
+import { sanitizeRpc } from "../transfer.js";
+
+export type FailureCategory = "environment" | "app" | "precondition";
+
+export interface ClassifyInput {
+  message?: string;
+  status?: number;
+  error?: unknown;
+  rpcUrl?: string;
+}
+
+export interface Classification {
+  category: FailureCategory;
+  signal: string;
+  reason: string;
+}
+
+interface Rule {
+  category: FailureCategory;
+  signal: string;
+  matches: (text: string, status: number | undefined) => boolean;
+}
+
+function pattern(category: FailureCategory, signal: string, regex: RegExp): Rule {
+  return { category, signal, matches: (text) => regex.test(text) };
+}
+
+// Ordered most-specific-first. A precondition (a state the operator must fix) outranks an
+// environment blip, which outranks the app-bug default. Liquidity/timing contract rejects are
+// environment; every other unrecognized failure — assertions, genuine app error surfaces — is
+// an app bug. Rules test the raw (pre-redaction) text so a host/IP-bearing transport error
+// still matches; only the stored `reason` is sanitized.
+const RULES: Rule[] = [
+  pattern("precondition", "unfunded", /unfunded|insufficient funds|not funded|no balance/i),
+  pattern("precondition", "unbonding-entry-cap", /too many unbonding|unbonding.*entries|max(imum)? entries/i),
+  pattern(
+    "precondition",
+    "redelegation-lock",
+    /redelegation.*(in progress|not complete|locked)|receiving redelegation/i
+  ),
+  pattern("precondition", "osmosis-side-funds", /osmosis.*(funds|balance|liquidity is missing)|missing osmosis/i),
+  {
+    category: "environment",
+    signal: "rate-limited",
+    matches: (text, status) => status === 429 || /\b429\b|rate.?limit|too many requests/i.test(text)
+  },
+  {
+    category: "environment",
+    signal: "node-unavailable",
+    matches: (text, status) =>
+      isUpstream5xx(status) ||
+      /econnrefused|econnreset|etimedout|enotfound|socket hang up|fetch failed|network error|\b50[234]\b|rpc.*(unavailable|unreachable|error)|node.*(unavailable|unreachable)/i.test(
+        text
+      )
+  },
+  pattern(
+    "environment",
+    "relayer-delay",
+    /relayer|ibc.*(delay|timeout|pending|not relayed)|packet.*(timeout|pending|not relayed)/i
+  ),
+  pattern(
+    "environment",
+    "price-move",
+    /price.*(move|moved|change|changed|slippage)|slippage|quote.*expired|expired quote|out of tolerance/i
+  ),
+  pattern("environment", "liquidity", /insufficient liquidity|not enough liquidity|no route|route not found/i),
+  pattern(
+    "environment",
+    "chain-state-timeout",
+    /timed?\s?out|timeout waiting|deadline exceeded|wait.*(chain|block|commit)/i
+  ),
+  pattern("app", "assertion", /\bexpect\(|assertion|to(Be|Equal|Contain|Match|HaveScreenshot)\b/i)
+];
+
+function isUpstream5xx(status: number | undefined): boolean {
+  return status === 502 || status === 503 || status === 504;
+}
+
+function textOf(input: ClassifyInput): string {
+  if (typeof input.message === "string") {
+    return input.message;
+  }
+  const error = input.error;
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return typeof error === "string" ? error : "";
+}
+
+/**
+ * Classify a failure into environment / app / precondition. The returned `reason` is always
+ * run through `sanitizeRpc` so an RPC host, embedded credential, or bare IP can never reach a
+ * journal, report, or annotation — even the generic form (an `ECONNREFUSED 1.2.3.4:26657`
+ * transport error) is redacted with no target host known.
+ */
+export function classify(input: ClassifyInput): Classification {
+  const raw = textOf(input);
+  const reason = sanitizeRpc(raw, input.rpcUrl ?? "");
+  for (const rule of RULES) {
+    if (rule.matches(raw, input.status)) {
+      return { category: rule.category, signal: rule.signal, reason };
+    }
+  }
+  return { category: "app", signal: "unclassified", reason };
+}

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
         "src/http.ts",
         "src/ws.ts",
         "src/broadcast.ts",
+        "src/t3/journalStore.ts",
+        "src/t3/runtime.ts",
+        "src/t3/repair.ts",
         "src/t1/**",
         "src/t2/**",
         // Browser glue (Playwright fixtures / specs) is exercised by the live and


### PR DESCRIPTION
Closes #284. Part of epic #278 (M3).

The broadcast/serialization/budget layer the T3 value-moving specs require: a new `e2e/src/t3/` engine around the scripted provider from #281.

## What ships

- **Per-wallet tx serialization** (`serialQueue.ts`): per-wallet FIFO — never two in-flight txs from one account; a queue slot is released only when the executor settles on block commit, not broadcast ack. A cross-wallet mutex serializes redelegations (Cosmos forbids concurrency per delegator). Shared token-bucket pacing under the strict (2 RPS/burst 5, `/api/swap/*`) and standard (20 RPS/burst 50) limits.
- **Hard spend cap + kill switch** (`spendCap.ts`, `engine.ts`): per-denom caps in native micro units (`E2E_SPEND_CAP_NLS` / `E2E_SPEND_CAP_USDC`), gross-outflow accounting (attached funds + gas upper bound), no refund credit. The check is a strict pre-sign gate over spent + pending + candidate; exceeding it returns `spend-cap-abort` before anything is signed, halts the engine, and emits the leftover report. Zero retries on spend paths, enforced by the engine constructor against the Playwright project config.
- **Pre-run reconciliation sweep** (`reconcile.ts`, `repair.ts`): enumerates `/api/leases` and `/api/staking/positions` (partial-empty responses are normal and tolerated), queues aged orphan `opened` leases for repair with a persisted attempt guard (max 3, then report-only), and tolerates pending/dust unbondings within the 21-day window. Repair drives the app market-close UI through the scripted provider — the suite never constructs a close tx, because the production app builds these client-side via nolusjs (the backend unsigned-tx endpoints are not the app path).
- **Flake taxonomy** (`taxonomy.ts`): classifies failures as `environment` (429, relayer delay, node unavailability, price movement), `app` (assertions, app errors), or `precondition` (unfunded, unbonding-entry cap, redelegation lock) — reused by the T3 specs and the reporting tier.
- **Write-ahead journal + leftover-state report** (`journal.ts`, `journalStore.ts`, `report.ts`): fsync-per-record JSONL written before every broadcast, so a hard crash cannot lose the record of an in-flight tx; a machine-readable leftover report (open leases, pending unbondings, unfinished swaps, spend snapshot) is emitted on every terminal path.
- **Config, wiring, CI**: `parseT3Config` (fail-closed, all-or-nothing), `t3-engine` Playwright project appended to the serial chain with `retries: 0`, and a `workflow_dispatch`-only CI smoke (`e2e-t3-engine.yaml`, caps 1 NLS / 0 USDC) — the nightly definition belongs to the reporting sibling.

All error text on journal/report/annotation paths passes through `sanitizeRpc` before it can reach an artifact; unit tests prove redaction.

Suite impact: T3 engine substrate only — not a user-facing surface, so `coverage-matrix.json` is unchanged; guarantees are covered by unit tests (275 passing, coverage 90.8/85.2/89.1/91.1 over the 88/83/86/88 floors).

## Verification

- Full e2e package gate green at every commit: typecheck, format:check, lint (zero warnings), test:coverage, check:matrix.
- Unit tests cover the issue test plan: serialization (incl. redelegate non-overlap), spend-cap abort before the executor runs, reconciliation (orphan repair queueing, attempt exhaustion, unbonding tolerance, partial-empty staking data), taxonomy classes, leftover report on every terminal condition, write-ahead crash survival, and secret/host redaction.
- Live `t3:engine` smoke (sweep + serialization proof + cap dry proof + one approved dust send) runs via the manual dispatch workflow with repo secrets; broadcast classes constrained to the operator-approved set.

## Review notes

Four independent review rounds ran before push (correctness, security, and project-convention passes over the full range, after a failure-mode analysis of the design and a check that the diff contains only planned changes):

1. Round 1: one sanitization gap fixed (network-read errors could reach CI artifacts unredacted); the work re-sliced into 7 semantic commits; deterministic waits in the live spec; lint-disable justified inline; journal parsing narrowed via a type guard; `set -euo pipefail` in the workflow; gas price resolution fails loudly.
2. Round 2: named-field objects replaced bunched numeric params (`SweepSettings`), taxonomy patterns take a rule object, a dead interface field removed.
3. Round 3: `spendCapFromMicros` takes a named-field object (a silent NLS/USDC swap can no longer compile), `governed()` rewritten with try/catch; a style sweep of the new surface found no further instances.
4. Round 4: clean across all three passes.

Known deferrals (tracked, deliberate): IPv6 coverage in the pre-existing `sanitizeRpc`; repair-path gas sits outside the spend cap (documented in the README, bounded by the attempt guard); live-spec token buckets are per-instance rather than one shared instance (serial execution + settle window bounds the risk).
