### PR TITLE
fix(e2e): run t3 engine smoke on the deploy runner

### DIFF
--- a/.github/workflows/e2e-t3-engine.yaml
+++ b/.github/workflows/e2e-t3-engine.yaml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   t3-engine:
     name: T3 tx engine smoke
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, frontend-deploy]
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
The manual T3 engine smoke workflow shipped with `runs-on: ubuntu-latest`, but GitHub-hosted runners cannot reach the deploy target — its first dispatch failed with connect timeouts on every spec. The deploy workflow already runs the post-deploy e2e step on the self-hosted deploy runner; this points the smoke at the same runner label.

Verification: one-line change; re-dispatching the smoke after merge is the live proof.