### PR TITLE
fix(e2e): install chromium system deps for the t3 smoke

### DIFF
--- a/.github/workflows/e2e-t3-engine.yaml
+++ b/.github/workflows/e2e-t3-engine.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           set -euo pipefail
           npm ci
-          npx playwright install chromium
+          npx playwright install --with-deps chromium
           npm run t3:engine
 
       - name: Upload T3 journal + report artifacts


### PR DESCRIPTION
The re-dispatched T3 engine smoke reached the deploy runner but every browser launch failed: the runner host is missing chromium shared libraries (libatk-1.0.so.0). `npx playwright install --with-deps chromium` installs the OS dependencies alongside the browser.

Verification: one-line change; the next smoke dispatch after merge is the live proof.