### PR TITLE
fix(e2e): declare dom lib in the e2e tsconfig

### DIFF
--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2023",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "DOM"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "types": ["node"],


### PR DESCRIPTION
The e2e package typechecks browser-evaluate callbacks that use DOM types (integrity.spec), but its tsconfig lib was ES2023-only. It compiled anyway because TypeScript auto-includes @types from enclosing node_modules directories, so the repo-root install leaked @types/jsdom — which references the dom lib — into the e2e program. A standalone e2e install (no root node_modules) fails typecheck on HTMLImageElement.

Declaring DOM in the package own lib removes the accidental coupling to the root install.

Verification: fresh worktree, e2e-only npm ci — typecheck and lint pass; before the change the same clean install failed with TS2304 on integrity.spec.ts:32.