### PR TITLE
test(e2e): skip empty-balance t2 cells under a funded wallet

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -310,7 +310,11 @@ so assertions are auto-retrying `toContainText`. Expected strings come from the 
 `validateAmountAgainstBalance` gates before `validateMinMaxValues` (issue #192), so a
 zero-balance wallet can only reach insufficient-balance; below-min/above-max and the
 over-position cells require real funding and skip locally (or fail under
-`E2E_EXPECT_FUNDED`). `invalid-balance-low` and `invalid-amount` render byte-identical
+`E2E_EXPECT_FUNDED`). The empty-balance cells themselves rest on the opposite, **unfunded
+premise**: under a funded wallet the app correctly renders a min/max or over-position error
+instead, so each cell first probes the connected wallet's relevant balance/position and
+records a `matrix-skip` when funded — an unfunded-premise skip that `E2E_EXPECT_FUNDED`
+never escalates to a failure (distinct from the funded-gated cells above). `invalid-balance-low` and `invalid-amount` render byte-identical
 text ("Invalid amount") — an **accepted blind spot**: the cells are distinguished by
 trigger condition, so a key-swap between those two would pass.
 

--- a/e2e/src/t2/matrixHelpers.ts
+++ b/e2e/src/t2/matrixHelpers.ts
@@ -140,6 +140,33 @@ export async function probeNativeMicroBalance(ctx: OriginContext, address: strin
   return total;
 }
 
+/**
+ * True if the address holds any non-zero balance in a non-native denom. The downpayment/supply
+ * currency for a lease or earn form is a fungible token (USDC, an `ibc/...` denom), never the
+ * native `unls`, so this is the denom-agnostic signal that a funded wallet can cover such a form —
+ * used to skip the empty-balance validation premise when it can no longer hold.
+ */
+export async function probeHasNonNativeBalance(ctx: OriginContext, address: string): Promise<boolean> {
+  const payload = await getJson(`${ctx.origin}/api/balances?address=${address}`, ctx.dispatcher);
+  if (typeof payload !== "object" || payload === null) return false;
+  const balances = (payload as Record<string, unknown>).balances;
+  if (!Array.isArray(balances)) return false;
+  for (const entry of balances) {
+    const denom = readString(entry, "denom");
+    const amount = readString(entry, "amount");
+    if (
+      denom !== undefined &&
+      denom !== "unls" &&
+      amount !== undefined &&
+      /^\d+$/.test(amount) &&
+      BigInt(amount) > 0n
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** True if the address holds at least one non-empty entry at the given list path. */
 export async function probeHasEntries(ctx: OriginContext, path: string, listKey: string): Promise<boolean> {
   const payload = await getJson(`${ctx.origin}${path}`, ctx.dispatcher);

--- a/e2e/src/t2/validation.spec.ts
+++ b/e2e/src/t2/validation.spec.ts
@@ -14,28 +14,91 @@ import {
   fieldError,
   requireOrSkip,
   probeNativeMicroBalance,
+  probeHasNonNativeBalance,
   probeHasEntries,
   allowStagingNoise
 } from "./matrixHelpers.js";
 import { parseMatrixConfig } from "../config.js";
+
+/**
+ * The empty-balance premise each insufficient-balance cell rests on: a spend form is `native`
+ * (delegate spends NLS) or `spend-token` (a lease downpayment / earn supply spends a fungible
+ * token), an over-position form is `earn-position` / `stake-position` (withdraw / undelegate over
+ * a held position). Under a funded wallet the premise can no longer hold, so the cell skips.
+ */
+type BalancePremise = "native" | "spend-token" | "earn-position" | "stake-position";
 
 interface FormCell {
   name: string;
   path: string;
   inputId: string;
   submitKey: string;
+  premise: BalancePremise;
 }
 
 const INSUFFICIENT_CELLS: FormCell[] = [
-  { name: "lease long", path: "/positions/open/long", inputId: "receive-send", submitKey: "open-position" },
-  { name: "lease short", path: "/positions/open/short", inputId: "receive-send", submitKey: "open-position" },
-  { name: "earn supply", path: "/earn/supply", inputId: "receive-send", submitKey: "supply" },
-  { name: "earn withdraw", path: "/earn/withdraw", inputId: "receive-send", submitKey: "withdraw" },
-  { name: "stake delegate", path: "/stake/delegate", inputId: "receive-send", submitKey: "delegate" },
-  { name: "stake undelegate", path: "/stake/undelegate", inputId: "receive-send", submitKey: "undelegate" }
+  {
+    name: "lease long",
+    path: "/positions/open/long",
+    inputId: "receive-send",
+    submitKey: "open-position",
+    premise: "spend-token"
+  },
+  {
+    name: "lease short",
+    path: "/positions/open/short",
+    inputId: "receive-send",
+    submitKey: "open-position",
+    premise: "spend-token"
+  },
+  { name: "earn supply", path: "/earn/supply", inputId: "receive-send", submitKey: "supply", premise: "spend-token" },
+  {
+    name: "earn withdraw",
+    path: "/earn/withdraw",
+    inputId: "receive-send",
+    submitKey: "withdraw",
+    premise: "earn-position"
+  },
+  {
+    name: "stake delegate",
+    path: "/stake/delegate",
+    inputId: "receive-send",
+    submitKey: "delegate",
+    premise: "native"
+  },
+  {
+    name: "stake undelegate",
+    path: "/stake/undelegate",
+    inputId: "receive-send",
+    submitKey: "undelegate",
+    premise: "stake-position"
+  }
 ];
 
 const STAKE_CELLS = new Set(["stake delegate", "stake undelegate"]);
+
+/**
+ * Whether the cell's empty-balance premise still holds for the connected wallet — i.e. the
+ * relevant balance/position is empty and the "Insufficient balance" path is genuinely reachable.
+ * A funded wallet returns false, and the cell skips (an unfunded-premise cell, distinct from a
+ * funded-gated one — E2E_EXPECT_FUNDED never turns this skip into a failure).
+ */
+async function emptyBalancePremiseHolds(cell: FormCell, ctx: OriginContext, address: string): Promise<boolean> {
+  switch (cell.premise) {
+    case "native":
+      return (await probeNativeMicroBalance(ctx, address)) === 0n;
+    case "spend-token":
+      return !(await probeHasNonNativeBalance(ctx, address));
+    case "earn-position":
+      return !(await probeHasEntries(ctx, `/api/earn/positions?address=${address}`, "positions"));
+    case "stake-position":
+      return !(await probeHasEntries(ctx, `/api/staking/positions?address=${address}`, "positions"));
+    default: {
+      const unreachable: never = cell.premise;
+      throw new Error(`unhandled balance premise: ${String(unreachable)}`);
+    }
+  }
+}
 
 let ctx: OriginContext;
 let locale: unknown;
@@ -59,9 +122,21 @@ test.afterAll(async () => {
 
 test.describe("insufficient-balance validation", () => {
   for (const cell of INSUFFICIENT_CELLS) {
-    test(`${cell.name} rejects an amount over an empty balance`, async ({ page, budget, wallet }) => {
+    test(`${cell.name} rejects an amount over an empty balance`, async ({ page, budget, wallet }, testInfo) => {
       budget.route = cell.path;
       allowStagingNoise(budget);
+      // The cell asserts the empty-balance error path; a funded wallet renders a different
+      // (min/max or over-position) error instead, so the premise is unmet and the cell skips.
+      // This is an unfunded-premise skip, NOT a funded-gated one: E2E_EXPECT_FUNDED must never
+      // turn it into a failure, so it uses testInfo.skip directly rather than requireOrSkip.
+      if (!(await emptyBalancePremiseHolds(cell, ctx, wallet.address))) {
+        testInfo.annotations.push({
+          type: "matrix-skip",
+          description: `${cell.name}: empty-balance premise unmet under a funded wallet`
+        });
+        testInfo.skip(true, `${cell.name}: funded wallet, empty-balance premise unmet`);
+        return;
+      }
       await connectThenGoto(page, labels, wallet.address, cell.path);
       await typeAmount(page, cell.inputId, "1");
       // A zero-balance wallet can only reach the balance check (it gates min/max), so every


### PR DESCRIPTION
The six insufficient-balance validation cells assume the connected wallet holds nothing of the relevant denom; running the t2 chain in CI with the funded primary mnemonic broke that premise, and the app correctly rendered range errors instead (first funded CI run of these cells — dispatch run 29577060169).

Each cell now probes its premise (native balance, spend-token balance, or position existence) before connecting and skips with a machine-readable annotation when the wallet is funded — the exact mirror of the existing funded-gated skips. E2E_EXPECT_FUNDED semantics are unchanged: it never escalates these unfunded-premise skips into failures.

The funded variants those cells could become (min/max range, over-position) are tracked for a future matrix expansion rather than bolted on here.

Verification: full e2e package gate green on a clean standalone install (275 tests, coverage over floors, matrix guard unchanged at 35 mapped cells).