### PR TITLE
fix(e2e): probe staking delegations key in undelegate premise

### DIFF
--- a/e2e/src/t2/validation.spec.ts
+++ b/e2e/src/t2/validation.spec.ts
@@ -193,7 +193,7 @@ test.describe("funded-dependent boundary cells", () => {
   test("stake undelegate over-position requires an existing delegation", async ({ page, budget, wallet }, testInfo) => {
     budget.route = "/stake/undelegate";
     allowStagingNoise(budget);
-    const hasDelegation = await probeHasEntries(ctx, `/api/staking/positions?address=${wallet.address}`, "positions");
+    const hasDelegation = await probeHasEntries(ctx, `/api/staking/positions?address=${wallet.address}`, "delegations");
     requireOrSkip(testInfo, expectFunded, hasDelegation, "connected wallet has no delegation to over-undelegate");
     // Undelegate's submit catch never calls classifyError (logs only) — a submit failure
     // renders nothing (a documented app gap), so this cell asserts only the reactive


### PR DESCRIPTION
The undelegate empty-balance premise probe read the `positions` key from /api/staking/positions, but that response lists delegations under `delegations` — the probe silently returned false, the cell ran against an account with a live 500 NLS delegation, the form validated the typed amount against the staked total, no error rendered, and the cell went red (smoke dispatch run 29580044011, the one remaining failure).

Verification: full e2e gate green on a clean standalone install; the staking response shape confirmed live (`delegations`/`unbonding`/`rewards`, no `positions` key).