### PR TITLE
test(e2e): m3 t3 value-moving flow specs

### DIFF
--- a/.github/workflows/e2e-t3-flows.yaml
+++ b/.github/workflows/e2e-t3-flows.yaml
@@ -70,7 +70,20 @@ jobs:
               perl -pi -e 'BEGIN{$t=$ENV{"RESOLVER_TARGET"}} s/\Q$t\E/<redacted-host>/g' "$f"
             done < <(grep -rIlF -- "$target" "$dir" 2>/dev/null || true)
           done
-          echo "artifact scrub: redacted ${total} occurrence(s) of the resolver target across results/ playwright-report/ test-results/"
+          # Second pass WITHOUT -I: any file still matching after text redaction is binary (a
+          # trace.zip or screenshot the sanitizer can't rewrite) — delete it outright so the
+          # resolver target never ships inside an opaque artifact.
+          deleted=0
+          for dir in results playwright-report test-results; do
+            [ -d "$dir" ] || continue
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              echo "artifact scrub: deleting binary artifact containing the resolver target: $f"
+              rm -f "$f"
+              deleted=$((deleted + 1))
+            done < <(grep -rlF -- "$target" "$dir" 2>/dev/null || true)
+          done
+          echo "artifact scrub: redacted ${total} text occurrence(s); deleted ${deleted} binary file(s) across results/ playwright-report/ test-results/"
 
       - name: Upload T3 flow journal + report artifacts
         if: always()

--- a/.github/workflows/e2e-t3-flows.yaml
+++ b/.github/workflows/e2e-t3-flows.yaml
@@ -48,6 +48,30 @@ jobs:
           npx playwright install --with-deps chromium
           npm run t3:flows
 
+      - name: Scrub the resolver target from artifacts before upload
+        if: always()
+        working-directory: e2e
+        env:
+          RESOLVER_TARGET: ${{ vars.DEPLOY_HOST }}
+        run: |
+          set -euo pipefail
+          target="${RESOLVER_TARGET:-}"
+          if [ -z "$target" ]; then
+            echo "artifact scrub: no resolver target configured; nothing to redact"
+            exit 0
+          fi
+          total=0
+          for dir in results playwright-report test-results; do
+            [ -d "$dir" ] || continue
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              n=$(grep -oaF -- "$target" "$f" | wc -l | tr -d ' ')
+              total=$((total + n))
+              perl -pi -e 'BEGIN{$t=$ENV{"RESOLVER_TARGET"}} s/\Q$t\E/<redacted-host>/g' "$f"
+            done < <(grep -rIlF -- "$target" "$dir" 2>/dev/null || true)
+          done
+          echo "artifact scrub: redacted ${total} occurrence(s) of the resolver target across results/ playwright-report/ test-results/"
+
       - name: Upload T3 flow journal + report artifacts
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/e2e-t3-flows.yaml
+++ b/.github/workflows/e2e-t3-flows.yaml
@@ -1,0 +1,61 @@
+name: E2E T3 value-moving flows (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_domain:
+        description: "Target host the flows run against (e.g. app-dev.nolus.io)"
+        required: true
+        type: string
+
+concurrency:
+  group: e2e-t3-flows-${{ inputs.base_domain }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  t3-flows:
+    name: T3 value-moving flows
+    runs-on: [self-hosted, frontend-deploy]
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Run the T3 value-moving flows
+        id: t3flows
+        working-directory: e2e
+        env:
+          E2E_BASE_URL: https://${{ inputs.base_domain }}
+          E2E_WS_URL: wss://${{ inputs.base_domain }}/ws
+          E2E_HOST_RESOLVER: ${{ inputs.base_domain }}=${{ vars.DEPLOY_HOST }}
+          E2E_READONLY_ADDRESS: ${{ vars.E2E_READONLY_ADDRESS }}
+          E2E_WALLET_MNEMONIC: ${{ secrets.E2E_WALLET_MNEMONIC }}
+          E2E_WALLET_MNEMONIC_2: ${{ secrets.E2E_WALLET_MNEMONIC_2 }}
+          E2E_SPEND_CAP_NLS: '100'
+          E2E_SPEND_CAP_USDC: '50'
+        run: |
+          set -euo pipefail
+          npm ci
+          npx playwright install --with-deps chromium
+          npm run t3:flows
+
+      - name: Upload T3 flow journal + report artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-t3-flows-${{ inputs.base_domain }}
+          path: |
+            e2e/results/
+            e2e/playwright-report/
+            e2e/test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -645,10 +645,13 @@ run: when the second open would exceed the USDC cap it precondition-skips rather
 USDC is the only viable downpayment denom (NLS is priced ~$0 on staging, so its USD figures are
 vacuous and its ranges unreachable). The lease minimum downpayment is **$40 USD-equivalent**,
 resolved **live** from `GET /api/leases/config/<protocol>` at test time, never hardcoded. One
-lease cycle per run is roughly $42 gross, which fits the $50 USDC cap. A short lease asserts against
-the lease-group stable ticker (`resolveShortLeaseStable`), never the downpayment/LPN, and PnL /
-liquidation tolerances are taken on the non-zero-priced collateral leg — `assertNonZeroBasis`
-turns a would-be vacuous NLS-USD assertion into a red.
+lease cycle per run is roughly $42 gross, which fits the $50 USDC cap. A short lease asserts its
+opened position ticker equals `resolveShortLeaseStable(currencies)` (the lease-group stable, never
+the downpayment/LPN) — the `#283` short-side acceptance criterion. The rendered lease USD value is
+checked against the oracle within `E2E_USD_TOLERANCE` via `assertWithinTolerance`, and every such
+comparison is basis-guarded by `assertNonZeroBasis` so a would-be vacuous NLS-USD assertion (whose
+oracle basis is $0) becomes a red rather than a silent pass. The liquidation cross-field check
+asserts the ordering invariant (`long liq < spot < short liq`) on the same non-zero collateral leg.
 
 ### Spend-cap-abort skip semantics
 
@@ -677,16 +680,21 @@ redelegate mutex), and claim on accrued rewards being **above a dust threshold**
   `stake-claim`, `ibc-transfer`, and `lease-repay` — the value-moving actions these flows introduce
   that the `#284` engine did not yet represent. Additive only; no existing behaviour changes.
 - **Crash-restart cap seeding.** `getRunContext` seeds the SpendCap's spent-state from the journal's
-  committed outcomes (`seedCapFromJournal`) at singleton construction, from the same journal that
+  committed intents (`seedCapFromJournal`) at singleton construction, from the same journal that
   seeds the seq allocator, so a worker restart cannot rebuild a full-budget cap and double-spend the
-  operator budget. A spend-cap abort is journaled with a first-class `precondition/spend-cap-abort`
-  classification, never `app/unclassified`.
+  operator budget. The charge is reconstructed **exclusively from each intent's `charged` field** —
+  the cap-charged `SpendItems` actually reserved (`journaledSpend` writes them), never the display
+  `denoms` — so an inflow action that journals a positive denom while charging `[{nls, 0n}]`
+  (undelegate / redelegate / claim / withdraw) contributes zero on restart. A spend-cap abort is
+  journaled with a first-class `precondition/spend-cap-abort` classification, never `app/unclassified`.
 - **Artifact scrubbing.** `e2e-t3-flows.yaml` uploads `playwright-report/` and `test-results/`, whose
   browser traces bypass the in-suite `sanitizeRpc` and can embed the host-resolver target. A
-  pre-upload scrub step redacts every occurrence of the `E2E_HOST_RESOLVER` target (`vars.DEPLOY_HOST`)
-  across the uploaded dirs and logs the redaction count. The `e2e-t3-engine.yaml` smoke uploads the
-  same trace dirs and should adopt the identical scrub step (its journal/report are already sanitized;
-  only the browser traces are the residual leak surface).
+  pre-upload scrub step runs two passes over the uploaded dirs: a text pass redacts every occurrence
+  of the `E2E_HOST_RESOLVER` target (`vars.DEPLOY_HOST`), then a second pass **without** `grep -I`
+  finds any file still matching — a binary the sanitizer cannot rewrite (`trace.zip`, screenshots) —
+  and **deletes it outright**, logging each deletion. The step logs both the redaction and deletion
+  counts. The `e2e-t3-engine.yaml` smoke uploads the same trace dirs and should adopt the identical
+  step (its journal/report are already sanitized; only the browser traces are the residual leak surface).
 - **IBC is inert until funded.** `ibc.spec.ts` is entirely skip-gated on an Osmosis-side funding
   probe (escalated to a hard failure under `E2E_EXPECT_FUNDED`); its structure is complete but the
   live path stays inert until the counterparty side is funded.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -624,14 +624,14 @@ real per-run caps `E2E_SPEND_CAP_NLS=100` / `E2E_SPEND_CAP_USDC=50` and a 45-min
 
 ### The flows
 
-| Spec            | Flow                                                                |
-| --------------- | ------------------------------------------------------------------- |
-| `lease.spec.ts` | One alternating-side lease: open, oracle-checked figures, leftover  |
-| `earn.spec.ts`  | Supply then withdraw dust USDC; rendered earn total vs the oracle   |
-| `stake.spec.ts` | Delegate / undelegate / redelegate / claim dust NLS, gated          |
-| `send.spec.ts`  | Native NLS send primary -> wallet-2 through the engine              |
-| `ibc.spec.ts`   | Deposit + withdraw Nolus <-> Osmosis, skip-gated on Osmosis funding |
-| `swap.spec.ts`  | Quote -> execute a dust swap, tracked by the app's polled status    |
+| Spec            | Flow                                                                     |
+| --------------- | ------------------------------------------------------------------------ |
+| `lease.spec.ts` | One lease, full lifecycle: open → TP/SL → repay → partial → market close |
+| `earn.spec.ts`  | Supply then withdraw dust USDC; rendered earn total vs the oracle        |
+| `stake.spec.ts` | Delegate / undelegate / redelegate / claim dust NLS, gated               |
+| `send.spec.ts`  | Native NLS send primary -> wallet-2 through the engine                   |
+| `ibc.spec.ts`   | Deposit + withdraw Nolus <-> Osmosis, skip-gated on Osmosis funding      |
+| `swap.spec.ts`  | Quote -> execute a dust swap, tracked by the app's polled status         |
 
 Pure helpers (side selection, the seq allocator, the tolerance comparator, precondition probes)
 are unit-tested (`*.test.ts`); the run singleton, live API reads, and the form driver are
@@ -674,8 +674,19 @@ redelegate mutex), and claim on accrued rewards being **above a dust threshold**
   therefore asserts via the UI's polled terminal state and post-swap balances, not a WS event. This
   is a deliberate deviation from `#283`'s WS-tracked acceptance wording.
 - **Engine journal actions.** `journal.ts`'s `IntentAction` gains `earn-supply`, `earn-withdraw`,
-  `stake-claim`, and `ibc-transfer` — the value-moving actions these flows introduce that the `#284`
-  engine did not yet represent. Additive only; no existing behaviour changes.
+  `stake-claim`, `ibc-transfer`, and `lease-repay` — the value-moving actions these flows introduce
+  that the `#284` engine did not yet represent. Additive only; no existing behaviour changes.
+- **Crash-restart cap seeding.** `getRunContext` seeds the SpendCap's spent-state from the journal's
+  committed outcomes (`seedCapFromJournal`) at singleton construction, from the same journal that
+  seeds the seq allocator, so a worker restart cannot rebuild a full-budget cap and double-spend the
+  operator budget. A spend-cap abort is journaled with a first-class `precondition/spend-cap-abort`
+  classification, never `app/unclassified`.
+- **Artifact scrubbing.** `e2e-t3-flows.yaml` uploads `playwright-report/` and `test-results/`, whose
+  browser traces bypass the in-suite `sanitizeRpc` and can embed the host-resolver target. A
+  pre-upload scrub step redacts every occurrence of the `E2E_HOST_RESOLVER` target (`vars.DEPLOY_HOST`)
+  across the uploaded dirs and logs the redaction count. The `e2e-t3-engine.yaml` smoke uploads the
+  same trace dirs and should adopt the identical scrub step (its journal/report are already sanitized;
+  only the browser traces are the residual leak surface).
 - **IBC is inert until funded.** `ibc.spec.ts` is entirely skip-gated on an Osmosis-side funding
   probe (escalated to a hard failure under `E2E_EXPECT_FUNDED`); its structure is complete but the
   live path stays inert until the counterparty side is funded.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -613,6 +613,76 @@ the `DEPLOY_HOST` var exactly as `deploy.yaml` does — never hardcoded. Per-run
 run, not only on failure. The nightly schedule for this smoke belongs to issue #285, not this
 workflow.
 
+## The T3 value-moving flows
+
+The T3 flow specs (`src/t3/flows/`, the `t3-flows` Playwright project) are the `#283` mutation
+journeys built on the tx engine. They run `workflow_dispatch`-only via `npm run t3:flows` (which
+pins `--workers=1`; the singleton engine constructor throws under worker parallelism > 1), appended
+to the dependency chain after `t3-engine` so the whole run shares one serialized queue, one spend
+cap, one journal, and one monotonic seq allocator. The workflow is `e2e-t3-flows.yaml`, with the
+real per-run caps `E2E_SPEND_CAP_NLS=100` / `E2E_SPEND_CAP_USDC=50` and a 45-minute job timeout.
+
+### The flows
+
+| Spec            | Flow                                                                |
+| --------------- | ------------------------------------------------------------------- |
+| `lease.spec.ts` | One alternating-side lease: open, oracle-checked figures, leftover  |
+| `earn.spec.ts`  | Supply then withdraw dust USDC; rendered earn total vs the oracle   |
+| `stake.spec.ts` | Delegate / undelegate / redelegate / claim dust NLS, gated          |
+| `send.spec.ts`  | Native NLS send primary -> wallet-2 through the engine              |
+| `ibc.spec.ts`   | Deposit + withdraw Nolus <-> Osmosis, skip-gated on Osmosis funding |
+| `swap.spec.ts`  | Quote -> execute a dust swap, tracked by the app's polled status    |
+
+Pure helpers (side selection, the seq allocator, the tolerance comparator, precondition probes)
+are unit-tested (`*.test.ts`); the run singleton, live API reads, and the form driver are
+coverage-excluded browser/network glue, the same split the rest of the suite uses.
+
+### Lease side alternation and budget math
+
+The lease side alternates by **UTC day-of-year parity** — even opens a long, odd a short — unless
+`E2E_LEASE_SIDE` (`long` / `short` / `both`) pins it. `both` is reserved for a future raised-cap
+run: when the second open would exceed the USDC cap it precondition-skips rather than aborting.
+USDC is the only viable downpayment denom (NLS is priced ~$0 on staging, so its USD figures are
+vacuous and its ranges unreachable). The lease minimum downpayment is **$40 USD-equivalent**,
+resolved **live** from `GET /api/leases/config/<protocol>` at test time, never hardcoded. One
+lease cycle per run is roughly $42 gross, which fits the $50 USDC cap. A short lease asserts against
+the lease-group stable ticker (`resolveShortLeaseStable`), never the downpayment/LPN, and PnL /
+liquidation tolerances are taken on the non-zero-priced collateral leg — `assertNonZeroBasis`
+turns a would-be vacuous NLS-USD assertion into a red.
+
+### Spend-cap-abort skip semantics
+
+A legitimate spend-cap abort halts the engine. Every value-moving spec calls `skipIfHalted` at the
+top and treats an abort as a clean **precondition skip** (annotated), so a cap abort skips the
+remaining flows rather than producing a red cascade of `EngineHaltedError` failures. Each terminal
+writes the leftover-state report and annotates where it landed.
+
+### Precondition gates and the failure taxonomy
+
+Environment / precondition failures are skipped, not failed (`classifyAndRoute`); only `app`
+failures are reds. The taxonomy is extended with two precondition signals for these flows:
+`lease-amount-range` (a downpayment below/above the lease range) and `swap-amount-too-small` (a
+dust amount with no Skip route, distinct from a genuine `liquidity` outage). Stake gates: undelegate
+is gated on the **7-entry unbonding cap** per validator (rotating the target when near it via
+`pickUnbondingValidator`), redelegate on **no maturing redelegation** (and runs through the engine's
+redelegate mutex), and claim on accrued rewards being **above a dust threshold**.
+
+### Deviations
+
+- **Swap tracking (`skip_tx` is dead code).** The `skip_tx` WS topic is not driven by the app —
+  swaps are tracked by client polling (`SkipRouter.fetchStatus` in `useSwapForm.ts`). `swap.spec.ts`
+  therefore asserts via the UI's polled terminal state and post-swap balances, not a WS event. This
+  is a deliberate deviation from `#283`'s WS-tracked acceptance wording.
+- **Engine journal actions.** `journal.ts`'s `IntentAction` gains `earn-supply`, `earn-withdraw`,
+  `stake-claim`, and `ibc-transfer` — the value-moving actions these flows introduce that the `#284`
+  engine did not yet represent. Additive only; no existing behaviour changes.
+- **IBC is inert until funded.** `ibc.spec.ts` is entirely skip-gated on an Osmosis-side funding
+  probe (escalated to a hard failure under `E2E_EXPECT_FUNDED`); its structure is complete but the
+  live path stays inert until the counterparty side is funded.
+- **Send receiver credit.** `send.spec.ts` renders the sender's debit (the Swap From=NLS technique)
+  and confirms the receiver's credit through the balances API, since a second rendered session would
+  need a reconnect and break the single-broadcast model.
+
 ## Conventions
 
 Every PR that adds or changes a user-facing surface (route, form, flow, rendered value,

--- a/e2e/coverage-matrix.json
+++ b/e2e/coverage-matrix.json
@@ -598,9 +598,9 @@
       "component": "secondary-figure",
       "state": "populated",
       "mapping": {
-        "type": "gap",
-        "category": "funded-gated",
-        "reason": "earn user totals need a funded wallet; covered by live + oracle"
+        "type": "assertion",
+        "spec": "src/t3/flows/earn.spec.ts",
+        "label": "flow-earn-total"
       }
     },
     {
@@ -628,9 +628,9 @@
       "component": "primary-figure",
       "state": "populated",
       "mapping": {
-        "type": "gap",
-        "category": "funded-gated",
-        "reason": "positions list rows need an open lease; live-gated"
+        "type": "assertion",
+        "spec": "src/t3/flows/lease.spec.ts",
+        "label": "flow-lease-row"
       }
     },
     {
@@ -638,9 +638,9 @@
       "component": "secondary-figure",
       "state": "populated",
       "mapping": {
-        "type": "gap",
-        "category": "funded-gated",
-        "reason": "single-lease size/PnL/liquidation need an open lease; oracle lease vectors cover the math"
+        "type": "assertion",
+        "spec": "src/t3/flows/lease.spec.ts",
+        "label": "flow-lease-detail"
       }
     },
     {
@@ -648,9 +648,9 @@
       "component": "primary-figure",
       "state": "populated",
       "mapping": {
-        "type": "gap",
-        "category": "funded-gated",
-        "reason": "delegated amount needs a delegation; live-gated"
+        "type": "assertion",
+        "spec": "src/t3/flows/stake.spec.ts",
+        "label": "flow-stake-delegated"
       }
     },
     {
@@ -688,9 +688,9 @@
       "component": "cross-field",
       "state": "populated",
       "mapping": {
-        "type": "gap",
-        "category": "funded-gated",
-        "reason": "lease PnL sign == indicator and long liq < spot < short liq need an open lease; oracle lease vectors cover the math"
+        "type": "assertion",
+        "spec": "src/t3/flows/lease.spec.ts",
+        "label": "flow-lease-crossfield"
       }
     },
     {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,6 +15,7 @@
     "t2:ratelimit": "PLAYWRIGHT_JSON_OUTPUT_NAME=results/t2.json playwright test --config playwright.config.ts --workers=1 --project=ratelimit",
     "t2:receive": "PLAYWRIGHT_JSON_OUTPUT_NAME=results/t2.json playwright test --config playwright.config.ts --workers=1 --project=receive",
     "t3:engine": "PLAYWRIGHT_JSON_OUTPUT_NAME=results/t3-engine.json playwright test --config playwright.config.ts --workers=1 --project=t3-engine",
+    "t3:flows": "PLAYWRIGHT_JSON_OUTPUT_NAME=results/t3-flows.json playwright test --config playwright.config.ts --workers=1 --project=t3-flows",
     "typecheck": "tsc --noEmit",
     "check:matrix": "tsx scripts/check-matrix.ts",
     "lint": "eslint . --max-warnings=0",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -118,6 +118,19 @@ export default defineConfig<T2Options>({
       retries: 0,
       dependencies: ["t2", "ratelimit", "receive"],
       use: { viewport: { width: 1440, height: 900 }, themeData: "light" }
+    },
+    {
+      // The T3 value-moving flows (lease, earn, stake, send, ibc, swap). Appended after the
+      // engine so the whole run shares one serialized chain and the per-run spend cap is
+      // meaningful; the singleton engine constructor throws under workers > 1, so this project
+      // must be run with --workers=1 (the t3:flows script). Never retries — a retry could
+      // double-spend a governed broadcast.
+      name: "t3-flows",
+      testDir: "src/t3/flows",
+      testMatch: ["**/*.spec.ts"],
+      retries: 0,
+      dependencies: ["t3-engine"],
+      use: { viewport: { width: 1440, height: 900 }, themeData: "light" }
     }
   ]
 });

--- a/e2e/src/t3/flows/apiReads.ts
+++ b/e2e/src/t3/flows/apiReads.ts
@@ -17,7 +17,7 @@ function listAt(payload: unknown, key: string): unknown[] {
 
 /** Sum of an address's micro balances whose denom contains `denomSubstr` (case-insensitive). */
 export async function microBalanceByDenom(ctx: OriginContext, address: string, denomSubstr: string): Promise<bigint> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/balances?address=${address}`);
+  const payload = await readJson(ctx, `${ctx.origin}/api/balances?address=${encodeURIComponent(address)}`);
   let total = 0n;
   for (const entry of listAt(payload, "balances")) {
     const denom = readString(entry, "denom") ?? "";
@@ -31,7 +31,7 @@ export async function microBalanceByDenom(ctx: OriginContext, address: string, d
 
 /** The first lease enumerated for `address` with `status === "opened"`, or undefined. */
 export async function openedLease(ctx: OriginContext, address: string): Promise<Record<string, unknown> | undefined> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/leases?address=${address}`);
+  const payload = await readJson(ctx, `${ctx.origin}/api/leases?address=${encodeURIComponent(address)}`);
   for (const entry of listAt(payload, "leases")) {
     const record = asRecord(entry);
     if (record !== undefined && readString(record, "status") === "opened") {
@@ -43,7 +43,7 @@ export async function openedLease(ctx: OriginContext, address: string): Promise<
 
 /** Raw `/api/leases/config/<protocol>` payload for downpayment-range resolution. */
 export async function leaseConfig(ctx: OriginContext, protocol: string): Promise<unknown> {
-  return readJson(ctx, `${ctx.origin}/api/leases/config/${protocol}`);
+  return readJson(ctx, `${ctx.origin}/api/leases/config/${encodeURIComponent(protocol)}`);
 }
 
 /** The first protocol key from `/api/leases/config`, or throws if none resolvable. */
@@ -68,7 +68,7 @@ export async function unbondingEntriesFor(
   address: string,
   validatorAddress: string
 ): Promise<number> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${address}`);
+  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${encodeURIComponent(address)}`);
   for (const entry of listAt(payload, "unbonding")) {
     if (readString(entry, "validator_address") === validatorAddress) {
       const entries = asRecord(entry)?.entries;

--- a/e2e/src/t3/flows/apiReads.ts
+++ b/e2e/src/t3/flows/apiReads.ts
@@ -1,0 +1,79 @@
+import type { OriginContext } from "../../t2/appDriver.js";
+import { readString } from "../../t2/matrixHelpers.js";
+import { readJson } from "../runtime.js";
+
+// Node-side, host-resolver-aware reads of the live API used by the flow specs to build the
+// oracle inputs and precondition probes. Coverage-excluded browser/network glue (see
+// vitest.config.ts); the pure classification/parse logic it feeds lives in the *.ts helpers.
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function listAt(payload: unknown, key: string): unknown[] {
+  const list = asRecord(payload)?.[key];
+  return Array.isArray(list) ? list : [];
+}
+
+/** Sum of an address's micro balances whose denom contains `denomSubstr` (case-insensitive). */
+export async function microBalanceByDenom(ctx: OriginContext, address: string, denomSubstr: string): Promise<bigint> {
+  const payload = await readJson(ctx, `${ctx.origin}/api/balances?address=${address}`);
+  let total = 0n;
+  for (const entry of listAt(payload, "balances")) {
+    const denom = readString(entry, "denom") ?? "";
+    const amount = readString(entry, "amount");
+    if (denom.toLowerCase().includes(denomSubstr.toLowerCase()) && amount !== undefined && /^\d+$/.test(amount)) {
+      total += BigInt(amount);
+    }
+  }
+  return total;
+}
+
+/** The first lease enumerated for `address` with `status === "opened"`, or undefined. */
+export async function openedLease(ctx: OriginContext, address: string): Promise<Record<string, unknown> | undefined> {
+  const payload = await readJson(ctx, `${ctx.origin}/api/leases?address=${address}`);
+  for (const entry of listAt(payload, "leases")) {
+    const record = asRecord(entry);
+    if (record !== undefined && readString(record, "status") === "opened") {
+      return record;
+    }
+  }
+  return undefined;
+}
+
+/** Raw `/api/leases/config/<protocol>` payload for downpayment-range resolution. */
+export async function leaseConfig(ctx: OriginContext, protocol: string): Promise<unknown> {
+  return readJson(ctx, `${ctx.origin}/api/leases/config/${protocol}`);
+}
+
+/** The first protocol key from `/api/leases/config`, or throws if none resolvable. */
+export async function firstProtocol(ctx: OriginContext): Promise<string> {
+  const payload = await readJson(ctx, `${ctx.origin}/api/leases/config`);
+  const protocol = Object.keys(asRecord(payload) ?? {})[0];
+  if (protocol === undefined) {
+    throw new Error("no lease protocol resolvable from /api/leases/config");
+  }
+  return protocol;
+}
+
+/** The currencies list for lease-group stable resolution. */
+export async function currencies(ctx: OriginContext): Promise<unknown> {
+  const payload = await readJson(ctx, `${ctx.origin}/api/currencies`);
+  return asRecord(payload)?.currencies ?? payload;
+}
+
+/** Total unbonding entry count for `address` against `validatorAddress` (0 when absent). */
+export async function unbondingEntriesFor(
+  ctx: OriginContext,
+  address: string,
+  validatorAddress: string
+): Promise<number> {
+  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${address}`);
+  for (const entry of listAt(payload, "unbonding")) {
+    if (readString(entry, "validator_address") === validatorAddress) {
+      const entries = asRecord(entry)?.entries;
+      return Array.isArray(entries) ? entries.length : 0;
+    }
+  }
+  return 0;
+}

--- a/e2e/src/t3/flows/capSeed.test.ts
+++ b/e2e/src/t3/flows/capSeed.test.ts
@@ -1,41 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { capDenomOf, seedCapFromJournal } from "./capSeed.js";
+import { seedCapFromJournal } from "./capSeed.js";
 import { SpendCap } from "../spendCap.js";
 import { buildIntent, buildOutcome } from "../journal.js";
-import type { IntentAction, JournalRecord, WalletRole } from "../journal.js";
+import type { DenomAmount, IntentAction, JournalRecord } from "../journal.js";
 
-function intent(seq: number, action: IntentAction, denom: string, micro: string): JournalRecord {
-  const role: WalletRole = "primary";
+function chargedIntent(seq: number, action: IntentAction, charged: DenomAmount[]): JournalRecord {
   return buildIntent({
     seq,
     ts: "2026-07-17T12:00:00.000Z",
     spec: "flow",
-    walletRole: role,
+    walletRole: "primary",
     action,
-    denoms: [{ denom, micro }]
+    denoms: [],
+    charged
   });
 }
 
-describe("capDenomOf", () => {
-  it("maps native and USDC denoms and skips anything uncapped", () => {
-    expect(capDenomOf("unls")).toBe("nls");
-    expect(capDenomOf("ibc/usdc")).toBe("usdc");
-    expect(capDenomOf("IBC/AABBUSDCcc")).toBe("usdc");
-    expect(capDenomOf("uatom")).toBeUndefined();
-  });
-});
-
 describe("seedCapFromJournal", () => {
-  it("restores the cap spent-state from committed outcomes only", () => {
+  it("restores the cap spent-state from committed intents' charged field only", () => {
     const cap = new SpendCap({ nls: 1000n, usdc: 1000n });
     const records: JournalRecord[] = [
-      intent(1, "native-send", "unls", "100"),
+      chargedIntent(1, "native-send", [{ denom: "nls", micro: "100" }]),
       buildOutcome({ seq: 1, ts: "t", status: "committed" }),
-      intent(2, "lease-open", "ibc/usdc", "400"),
+      chargedIntent(2, "lease-open", [{ denom: "usdc", micro: "400" }]),
       buildOutcome({ seq: 2, ts: "t", status: "committed" }),
-      intent(3, "swap", "unls", "50"),
+      chargedIntent(3, "swap", [{ denom: "nls", micro: "50" }]),
       buildOutcome({ seq: 3, ts: "t", status: "failed" }),
-      intent(4, "lease-open", "ibc/usdc", "999"),
+      chargedIntent(4, "lease-open", [{ denom: "usdc", micro: "999" }]),
       buildOutcome({ seq: 4, ts: "t", status: "aborted" })
     ];
     seedCapFromJournal(cap, records);
@@ -43,16 +34,35 @@ describe("seedCapFromJournal", () => {
     expect(cap.spent("usdc")).toBe(400n);
   });
 
+  it("ignores display denoms and never re-charges a zero-charge inflow action on restart", () => {
+    const cap = new SpendCap({ nls: 1000n, usdc: 1000n });
+    const records: JournalRecord[] = [
+      buildIntent({
+        seq: 1,
+        ts: "t",
+        spec: "flow",
+        walletRole: "primary",
+        action: "undelegate",
+        denoms: [{ denom: "unls", micro: "5000000" }],
+        charged: [{ denom: "nls", micro: "0" }]
+      }),
+      buildOutcome({ seq: 1, ts: "t", status: "committed" })
+    ];
+    seedCapFromJournal(cap, records);
+    expect(cap.spent("nls")).toBe(0n);
+    expect(cap.spent("usdc")).toBe(0n);
+  });
+
   it("leaves the cap untouched when there are no committed outcomes", () => {
     const cap = new SpendCap({ nls: 1000n, usdc: 1000n });
-    seedCapFromJournal(cap, [intent(1, "native-send", "unls", "100")]);
+    seedCapFromJournal(cap, [chargedIntent(1, "native-send", [{ denom: "nls", micro: "100" }])]);
     expect(cap.spent("nls")).toBe(0n);
   });
 
-  it("ignores an uncapped denom in a committed intent", () => {
+  it("ignores an uncapped denom in a committed intent's charged field", () => {
     const cap = new SpendCap({ nls: 1000n, usdc: 1000n });
     seedCapFromJournal(cap, [
-      intent(1, "delegate", "uatom", "100"),
+      chargedIntent(1, "delegate", [{ denom: "uatom", micro: "100" }]),
       buildOutcome({ seq: 1, ts: "t", status: "committed" })
     ]);
     expect(cap.spent("nls")).toBe(0n);

--- a/e2e/src/t3/flows/capSeed.test.ts
+++ b/e2e/src/t3/flows/capSeed.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { capDenomOf, seedCapFromJournal } from "./capSeed.js";
+import { SpendCap } from "../spendCap.js";
+import { buildIntent, buildOutcome } from "../journal.js";
+import type { IntentAction, JournalRecord, WalletRole } from "../journal.js";
+
+function intent(seq: number, action: IntentAction, denom: string, micro: string): JournalRecord {
+  const role: WalletRole = "primary";
+  return buildIntent({
+    seq,
+    ts: "2026-07-17T12:00:00.000Z",
+    spec: "flow",
+    walletRole: role,
+    action,
+    denoms: [{ denom, micro }]
+  });
+}
+
+describe("capDenomOf", () => {
+  it("maps native and USDC denoms and skips anything uncapped", () => {
+    expect(capDenomOf("unls")).toBe("nls");
+    expect(capDenomOf("ibc/usdc")).toBe("usdc");
+    expect(capDenomOf("IBC/AABBUSDCcc")).toBe("usdc");
+    expect(capDenomOf("uatom")).toBeUndefined();
+  });
+});
+
+describe("seedCapFromJournal", () => {
+  it("restores the cap spent-state from committed outcomes only", () => {
+    const cap = new SpendCap({ nls: 1000n, usdc: 1000n });
+    const records: JournalRecord[] = [
+      intent(1, "native-send", "unls", "100"),
+      buildOutcome({ seq: 1, ts: "t", status: "committed" }),
+      intent(2, "lease-open", "ibc/usdc", "400"),
+      buildOutcome({ seq: 2, ts: "t", status: "committed" }),
+      intent(3, "swap", "unls", "50"),
+      buildOutcome({ seq: 3, ts: "t", status: "failed" }),
+      intent(4, "lease-open", "ibc/usdc", "999"),
+      buildOutcome({ seq: 4, ts: "t", status: "aborted" })
+    ];
+    seedCapFromJournal(cap, records);
+    expect(cap.spent("nls")).toBe(100n);
+    expect(cap.spent("usdc")).toBe(400n);
+  });
+
+  it("leaves the cap untouched when there are no committed outcomes", () => {
+    const cap = new SpendCap({ nls: 1000n, usdc: 1000n });
+    seedCapFromJournal(cap, [intent(1, "native-send", "unls", "100")]);
+    expect(cap.spent("nls")).toBe(0n);
+  });
+
+  it("ignores an uncapped denom in a committed intent", () => {
+    const cap = new SpendCap({ nls: 1000n, usdc: 1000n });
+    seedCapFromJournal(cap, [
+      intent(1, "delegate", "uatom", "100"),
+      buildOutcome({ seq: 1, ts: "t", status: "committed" })
+    ]);
+    expect(cap.spent("nls")).toBe(0n);
+    expect(cap.spent("usdc")).toBe(0n);
+  });
+});

--- a/e2e/src/t3/flows/capSeed.ts
+++ b/e2e/src/t3/flows/capSeed.ts
@@ -1,29 +1,15 @@
 import type { CapDenom, SpendCap } from "../spendCap.js";
 import type { JournalRecord } from "../journal.js";
 import { isIntent, isOutcome } from "../journal.js";
-
-/**
- * Map a journaled chain denom to its cap denom, or undefined when the denom is uncapped. The
- * native `unls` and USDC (an `ibc/...` denom) are the only two the cap accounts; anything else
- * moved no capped value and is skipped.
- */
-export function capDenomOf(chainDenom: string): CapDenom | undefined {
-  const denom = chainDenom.toLowerCase();
-  if (denom === "unls" || denom === "nls") {
-    return "nls";
-  }
-  if (denom.includes("usdc")) {
-    return "usdc";
-  }
-  return undefined;
-}
+import { capDenomOf } from "./denoms.js";
 
 /**
  * Re-apply a prior run's committed gross outflow to the cap at singleton construction. A worker
  * restart otherwise rebuilds the SpendCap at full budget while the seq allocator is journal-seeded,
- * so the same operator budget could be spent twice. Only `committed` outcomes count — a failed or
- * aborted submission moved no value — and the matching intent's denoms carry the gross that was
- * charged, so the cap is restored to exactly the spent-state the journal proves.
+ * so the same operator budget could be spent twice. Only `committed` outcomes count, and the
+ * charge is read EXCLUSIVELY from the intent's `charged` field — the cap-charged amounts actually
+ * reserved — never from display `denoms`, so an inflow action that journaled a positive denom while
+ * charging nothing (undelegate / redelegate / claim / withdraw) contributes zero on restart.
  */
 export function seedCapFromJournal(cap: SpendCap, records: JournalRecord[]): void {
   const committedSeqs = new Set(
@@ -36,7 +22,7 @@ export function seedCapFromJournal(cap: SpendCap, records: JournalRecord[]): voi
     if (!isIntent(record) || !committedSeqs.has(record.seq)) {
       continue;
     }
-    const items = record.denoms
+    const items = (record.charged ?? [])
       .filter((amount) => /^\d+$/.test(amount.micro))
       .map((amount) => ({ denom: capDenomOf(amount.denom), micro: BigInt(amount.micro) }))
       .filter((item): item is { denom: CapDenom; micro: bigint } => item.denom !== undefined && item.micro > 0n);

--- a/e2e/src/t3/flows/capSeed.ts
+++ b/e2e/src/t3/flows/capSeed.ts
@@ -1,0 +1,47 @@
+import type { CapDenom, SpendCap } from "../spendCap.js";
+import type { JournalRecord } from "../journal.js";
+import { isIntent, isOutcome } from "../journal.js";
+
+/**
+ * Map a journaled chain denom to its cap denom, or undefined when the denom is uncapped. The
+ * native `unls` and USDC (an `ibc/...` denom) are the only two the cap accounts; anything else
+ * moved no capped value and is skipped.
+ */
+export function capDenomOf(chainDenom: string): CapDenom | undefined {
+  const denom = chainDenom.toLowerCase();
+  if (denom === "unls" || denom === "nls") {
+    return "nls";
+  }
+  if (denom.includes("usdc")) {
+    return "usdc";
+  }
+  return undefined;
+}
+
+/**
+ * Re-apply a prior run's committed gross outflow to the cap at singleton construction. A worker
+ * restart otherwise rebuilds the SpendCap at full budget while the seq allocator is journal-seeded,
+ * so the same operator budget could be spent twice. Only `committed` outcomes count — a failed or
+ * aborted submission moved no value — and the matching intent's denoms carry the gross that was
+ * charged, so the cap is restored to exactly the spent-state the journal proves.
+ */
+export function seedCapFromJournal(cap: SpendCap, records: JournalRecord[]): void {
+  const committedSeqs = new Set(
+    records
+      .filter(isOutcome)
+      .filter((outcome) => outcome.status === "committed")
+      .map((outcome) => outcome.seq)
+  );
+  for (const record of records) {
+    if (!isIntent(record) || !committedSeqs.has(record.seq)) {
+      continue;
+    }
+    const items = record.denoms
+      .filter((amount) => /^\d+$/.test(amount.micro))
+      .map((amount) => ({ denom: capDenomOf(amount.denom), micro: BigInt(amount.micro) }))
+      .filter((item): item is { denom: CapDenom; micro: bigint } => item.denom !== undefined && item.micro > 0n);
+    if (items.length > 0) {
+      cap.record(items);
+    }
+  }
+}

--- a/e2e/src/t3/flows/denoms.test.ts
+++ b/e2e/src/t3/flows/denoms.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { capDenomOf, USDC_DENOM } from "./denoms.js";
+
+describe("capDenomOf", () => {
+  it("maps the cap denoms and the native/USDC chain denoms by exact match", () => {
+    expect(capDenomOf("nls")).toBe("nls");
+    expect(capDenomOf("unls")).toBe("nls");
+    expect(capDenomOf("usdc")).toBe("usdc");
+    expect(capDenomOf(USDC_DENOM)).toBe("usdc");
+  });
+
+  it("returns undefined for any other denom — no substring match", () => {
+    expect(capDenomOf("uatom")).toBeUndefined();
+    expect(capDenomOf("ibc/usdcfoo")).toBeUndefined();
+    expect(capDenomOf("usdcx")).toBeUndefined();
+  });
+});

--- a/e2e/src/t3/flows/denoms.ts
+++ b/e2e/src/t3/flows/denoms.ts
@@ -1,0 +1,24 @@
+import type { CapDenom } from "../spendCap.js";
+import { NATIVE_DENOM } from "../../transfer.js";
+
+// Single source of truth for the denom strings the flow specs and cap-seeding share, so the two
+// can never drift. The cap denoms ("nls"/"usdc") are what the journal's `charged` field carries;
+// USDC_DENOM is the display chain denom the specs record in `denoms`.
+
+export const USDC_DENOM = "ibc/usdc";
+export const CAP_DENOM_NLS = "nls";
+export const CAP_DENOM_USDC = "usdc";
+
+/**
+ * Map a denom string to its cap denom by EXACT match (never substring) — accepts both the cap
+ * denoms as journaled in `charged` and the native/USDC chain denoms; anything else is uncapped.
+ */
+export function capDenomOf(denom: string): CapDenom | undefined {
+  if (denom === CAP_DENOM_NLS || denom === NATIVE_DENOM) {
+    return "nls";
+  }
+  if (denom === CAP_DENOM_USDC || denom === USDC_DENOM) {
+    return "usdc";
+  }
+  return undefined;
+}

--- a/e2e/src/t3/flows/earn.spec.ts
+++ b/e2e/src/t3/flows/earn.spec.ts
@@ -31,7 +31,7 @@ const TERMINAL_MS = 120000;
 let run: RunContext;
 
 async function earnDepositUsd(ctx: RunContext["ctx"], address: string): Promise<Decimal> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/earn/positions?address=${address}`);
+  const payload = await readJson(ctx, `${ctx.origin}/api/earn/positions?address=${encodeURIComponent(address)}`);
   const positions =
     typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).positions : [];
   let total = Decimal.zero();
@@ -103,7 +103,7 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
   await connectFlow(page, run, "/earn/withdraw");
   await typeAmount(page, "receive-send", DUST_USDC);
   try {
-    await journaledSpend(run, {
+    const outcome = await journaledSpend(run, {
       spec: "t3-flow-earn",
       action: "earn-withdraw",
       walletRole: "primary",
@@ -112,6 +112,10 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
       denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
       execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "withdraw"), terminalMs: TERMINAL_MS })
     });
+    if (outcome.status === "spend-cap-abort") {
+      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
+      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+    }
   } catch (error) {
     reportLeftover(run, testInfo, { terminal: "app-failure" });
     classifyAndRoute(testInfo, error, run.chain.rpcUrl);

--- a/e2e/src/t3/flows/earn.spec.ts
+++ b/e2e/src/t3/flows/earn.spec.ts
@@ -1,14 +1,6 @@
 import { test, expect } from "./support.js";
 import type { RunContext } from "./support.js";
-import {
-  getRunContext,
-  connectFlow,
-  journaledSpend,
-  reportLeftover,
-  skipIfHalted,
-  classifyAndRoute,
-  annotateSkipAndStop
-} from "./support.js";
+import { getRunContext, connectFlow, reportLeftover, skipIfHalted, spendCommittedOrSkip } from "./support.js";
 import { messageValue } from "../../t2/appDriver.js";
 import { typeAmount, requireOrSkip, readString } from "../../t2/matrixHelpers.js";
 import { USDC_DECIMALS } from "../../config.js";
@@ -19,12 +11,12 @@ import { microBalanceByDenom } from "./apiReads.js";
 import { submitForm } from "./formDriver.js";
 import { readJson } from "../runtime.js";
 import { assertNonZeroBasis } from "./tolerance.js";
+import { USDC_DENOM } from "./denoms.js";
 
 // Earn supply + withdraw of dust USDC (#283 flow 2). The rendered user earn total is asserted
 // against the GET /api/earn/positions total through the render oracle, and a WS earn tick must
 // not clobber the REST-sourced fields (the T2 reconnect technique). Matrix label: flow-earn-total.
 
-const USDC_DENOM = "ibc/usdc";
 const DUST_USDC = "0.05";
 const TERMINAL_MS = 120000;
 
@@ -74,24 +66,15 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
 
   await connectFlow(page, run, "/earn/supply");
   await typeAmount(page, "receive-send", DUST_USDC);
-  try {
-    const outcome = await journaledSpend(run, {
-      spec: "t3-flow-earn",
-      action: "earn-supply",
-      walletRole: "primary",
-      walletKey: run.primary.key,
-      items: [{ denom: "usdc", micro: requiredMicro }],
-      denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
-      execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "supply"), terminalMs: TERMINAL_MS })
-    });
-    if (outcome.status === "spend-cap-abort") {
-      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
-      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
-    }
-  } catch (error) {
-    reportLeftover(run, testInfo, { terminal: "app-failure" });
-    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
-  }
+  await spendCommittedOrSkip(testInfo, run, {
+    spec: "t3-flow-earn",
+    action: "earn-supply",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "usdc", micro: requiredMicro }],
+    denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
+    execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "supply"), terminalMs: TERMINAL_MS })
+  });
 
   testInfo.annotations.push({ type: "matrix", description: "flow-earn-total" });
   await page.goto("/earn", { waitUntil: "domcontentloaded" });
@@ -102,24 +85,15 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
 
   await connectFlow(page, run, "/earn/withdraw");
   await typeAmount(page, "receive-send", DUST_USDC);
-  try {
-    const outcome = await journaledSpend(run, {
-      spec: "t3-flow-earn",
-      action: "earn-withdraw",
-      walletRole: "primary",
-      walletKey: run.primary.key,
-      items: [{ denom: "nls", micro: 0n }],
-      denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
-      execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "withdraw"), terminalMs: TERMINAL_MS })
-    });
-    if (outcome.status === "spend-cap-abort") {
-      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
-      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
-    }
-  } catch (error) {
-    reportLeftover(run, testInfo, { terminal: "app-failure" });
-    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
-  }
+  await spendCommittedOrSkip(testInfo, run, {
+    spec: "t3-flow-earn",
+    action: "earn-withdraw",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "nls", micro: 0n }],
+    denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
+    execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "withdraw"), terminalMs: TERMINAL_MS })
+  });
 
   reportLeftover(run, testInfo, { terminal: "success" });
 });

--- a/e2e/src/t3/flows/earn.spec.ts
+++ b/e2e/src/t3/flows/earn.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "./support.js";
+import type { RunContext } from "./support.js";
+import {
+  getRunContext,
+  connectFlow,
+  journaledSpend,
+  reportLeftover,
+  skipIfHalted,
+  classifyAndRoute,
+  annotateSkipAndStop
+} from "./support.js";
+import { messageValue } from "../../t2/appDriver.js";
+import { typeAmount, requireOrSkip, readString } from "../../t2/matrixHelpers.js";
+import { USDC_DECIMALS } from "../../config.js";
+import { toMicroAmount } from "../../transfer.js";
+import { Decimal } from "../../oracle/decimal.js";
+import { formatDecAsUsd } from "../../oracle/format.js";
+import { microBalanceByDenom } from "./apiReads.js";
+import { submitForm } from "./formDriver.js";
+import { readJson } from "../runtime.js";
+import { assertNonZeroBasis } from "./tolerance.js";
+
+// Earn supply + withdraw of dust USDC (#283 flow 2). The rendered user earn total is asserted
+// against the GET /api/earn/positions total through the render oracle, and a WS earn tick must
+// not clobber the REST-sourced fields (the T2 reconnect technique). Matrix label: flow-earn-total.
+
+const USDC_DENOM = "ibc/usdc";
+const DUST_USDC = "0.05";
+const TERMINAL_MS = 120000;
+
+let run: RunContext;
+
+async function earnDepositUsd(ctx: RunContext["ctx"], address: string): Promise<Decimal> {
+  const payload = await readJson(ctx, `${ctx.origin}/api/earn/positions?address=${address}`);
+  const positions =
+    typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).positions : [];
+  let total = Decimal.zero();
+  if (Array.isArray(positions)) {
+    for (const entry of positions) {
+      const usd = readString(entry, "value_usd") ?? readString(entry, "supplied_usd");
+      if (usd !== undefined && /^\d+(\.\d+)?$/.test(usd)) {
+        total = total.add(Decimal.fromString(usd));
+      }
+    }
+  }
+  return total;
+}
+
+test.beforeAll(async () => {
+  run = await getRunContext(test.info());
+});
+
+test.afterAll(async () => {
+  if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
+});
+
+test("earn supply then withdraw of dust USDC, rendered total matches the oracle", async ({
+  page,
+  budget,
+  wallet
+}, testInfo) => {
+  skipIfHalted(testInfo, run);
+  test.setTimeout(TERMINAL_MS * 3);
+  budget.route = "/earn/supply";
+
+  const requiredMicro = BigInt(toMicroAmount(DUST_USDC, USDC_DECIMALS));
+  const balance = await microBalanceByDenom(run.ctx, wallet.address, "usdc");
+  requireOrSkip(
+    testInfo,
+    run.matrix.expectFunded,
+    balance > requiredMicro,
+    `primary holds ${balance.toString()} micro-USDC, below the ${requiredMicro.toString()} an earn supply needs`
+  );
+
+  await connectFlow(page, run, "/earn/supply");
+  await typeAmount(page, "receive-send", DUST_USDC);
+  try {
+    const outcome = await journaledSpend(run, {
+      spec: "t3-flow-earn",
+      action: "earn-supply",
+      walletRole: "primary",
+      walletKey: run.primary.key,
+      items: [{ denom: "usdc", micro: requiredMicro }],
+      denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
+      execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "supply"), terminalMs: TERMINAL_MS })
+    });
+    if (outcome.status === "spend-cap-abort") {
+      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
+      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+    }
+  } catch (error) {
+    reportLeftover(run, testInfo, { terminal: "app-failure" });
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
+
+  testInfo.annotations.push({ type: "matrix", description: "flow-earn-total" });
+  await page.goto("/earn", { waitUntil: "domcontentloaded" });
+  const total = await earnDepositUsd(run.ctx, wallet.address);
+  assertNonZeroBasis({ value: total.toString(2), description: "earn deposit total" });
+  const rendered = await page.locator("#app").innerText();
+  expect(rendered).toContain(formatDecAsUsd(total));
+
+  await connectFlow(page, run, "/earn/withdraw");
+  await typeAmount(page, "receive-send", DUST_USDC);
+  try {
+    await journaledSpend(run, {
+      spec: "t3-flow-earn",
+      action: "earn-withdraw",
+      walletRole: "primary",
+      walletKey: run.primary.key,
+      items: [{ denom: "nls", micro: 0n }],
+      denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
+      execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "withdraw"), terminalMs: TERMINAL_MS })
+    });
+  } catch (error) {
+    reportLeftover(run, testInfo, { terminal: "app-failure" });
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
+
+  reportLeftover(run, testInfo, { terminal: "success" });
+});

--- a/e2e/src/t3/flows/formDriver.ts
+++ b/e2e/src/t3/flows/formDriver.ts
@@ -1,0 +1,35 @@
+import type { Page } from "@playwright/test";
+import { expect } from "../../t2/support.js";
+
+// Browser glue (coverage-excluded, see vitest.config.ts). The value-moving submit path is the
+// same across the routed forms (lease open/close, earn supply/withdraw, stake delegate/undelegate):
+// click the footer submit, confirm in the dialog, and resolve only once the app reaches a terminal
+// signal. Passed to the engine as the `execute` closure so a submission settles on commit, not on
+// the mere click — matching the SerialQueue's commit-release contract.
+
+const CONFIRM = /confirm|submit|send/i;
+const TOAST = "div.toast";
+
+export interface SubmitOptions {
+  submitLabel: string;
+  terminalMs: number;
+}
+
+/**
+ * Drive a routed form's footer submit through confirmation and wait for the app's terminal toast.
+ * The footer submit is targeted with `.last()` because a dialog tab often shares the submit label
+ * (the same disambiguation `validation.spec.ts` documents).
+ */
+export async function submitForm(page: Page, options: SubmitOptions): Promise<void> {
+  await page.getByRole("button", { name: options.submitLabel, exact: true }).last().click();
+  await page.getByRole("button", { name: CONFIRM }).first().click({ timeout: options.terminalMs });
+  await expect(page.locator(TOAST)).toBeVisible({ timeout: options.terminalMs });
+}
+
+/** Open a position/lease detail dialog by its on-chain address and wait for the dialog to render. */
+export async function openDetailDialog(page: Page, address: string, timeoutMs: number): Promise<string> {
+  await page.getByText(address, { exact: false }).first().click({ timeout: timeoutMs });
+  const dialog = page.locator("#dialog-scroll").first();
+  await dialog.waitFor({ state: "visible", timeout: timeoutMs });
+  return dialog.innerText();
+}

--- a/e2e/src/t3/flows/ibc.spec.ts
+++ b/e2e/src/t3/flows/ibc.spec.ts
@@ -6,7 +6,8 @@ import {
   journaledSpend,
   reportLeftover,
   skipIfHalted,
-  classifyAndRoute
+  classifyAndRoute,
+  annotateSkipAndStop
 } from "./support.js";
 import { messageValue } from "../../t2/appDriver.js";
 import { typeAmount, requireOrSkip, readString } from "../../t2/matrixHelpers.js";
@@ -33,9 +34,10 @@ let run: RunContext;
  * that would strand value with no return leg.
  */
 async function osmosisFunded(ctx: RunContext["ctx"], address: string): Promise<boolean> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/balances?address=${address}&network=osmosis`).catch(
-    () => null
-  );
+  const payload = await readJson(
+    ctx,
+    `${ctx.origin}/api/balances?address=${encodeURIComponent(address)}&network=osmosis`
+  ).catch(() => null);
   const balances = typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).balances : [];
   return Array.isArray(balances) && balances.some((entry) => (readString(entry, "amount") ?? "0") !== "0");
 }
@@ -68,7 +70,7 @@ test("IBC deposit then withdraw Nolus <-> Osmosis, gated on a funded Osmosis sid
   const requiredMicro = BigInt(toMicroAmount(DUST_USDC, USDC_DECIMALS));
   await connectFlow(page, run, "/assets");
   try {
-    await journaledSpend(run, {
+    const deposit = await journaledSpend(run, {
       spec: "t3-flow-ibc",
       action: "ibc-transfer",
       walletRole: "primary",
@@ -85,6 +87,12 @@ test("IBC deposit then withdraw Nolus <-> Osmosis, gated on a funded Osmosis sid
         await submitForm(page, { submitLabel: messageValue(run.locale, "transfer"), terminalMs: TERMINAL_MS });
       }
     });
+    // A cap abort on the deposit halts the engine; skip the withdraw leg cleanly rather than let
+    // the second submission throw EngineHaltedError and cascade a red.
+    if (deposit.status === "spend-cap-abort") {
+      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
+      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${deposit.check.overDenom}`);
+    }
     await journaledSpend(run, {
       spec: "t3-flow-ibc",
       action: "ibc-transfer",
@@ -107,6 +115,9 @@ test("IBC deposit then withdraw Nolus <-> Osmosis, gated on a funded Osmosis sid
     classifyAndRoute(testInfo, error, run.chain.rpcUrl);
   }
 
-  expect(funded).toBe(true);
+  const ibcIntents = run.store
+    .readAll()
+    .filter((record) => record.type === "intent" && record.action === "ibc-transfer");
+  expect(ibcIntents.length).toBeGreaterThanOrEqual(2);
   reportLeftover(run, testInfo, { terminal: "success" });
 });

--- a/e2e/src/t3/flows/ibc.spec.ts
+++ b/e2e/src/t3/flows/ibc.spec.ts
@@ -1,27 +1,19 @@
 import { test, expect } from "./support.js";
 import type { RunContext } from "./support.js";
-import {
-  getRunContext,
-  connectFlow,
-  journaledSpend,
-  reportLeftover,
-  skipIfHalted,
-  classifyAndRoute,
-  annotateSkipAndStop
-} from "./support.js";
+import { getRunContext, connectFlow, reportLeftover, skipIfHalted, spendCommittedOrSkip } from "./support.js";
 import { messageValue } from "../../t2/appDriver.js";
 import { typeAmount, requireOrSkip, readString } from "../../t2/matrixHelpers.js";
 import { USDC_DECIMALS } from "../../config.js";
 import { toMicroAmount } from "../../transfer.js";
 import { submitForm } from "./formDriver.js";
 import { readJson } from "../runtime.js";
+import { USDC_DENOM } from "./denoms.js";
 
 // IBC deposit + withdraw Nolus <-> Osmosis (#283 flow 5). ENTIRELY skip-gated on a funded
 // Osmosis-side probe: the whole flow is inert until that funding is confirmed, at which point
 // E2E_EXPECT_FUNDED escalates the unmet precondition into a hard failure. The structure is
 // complete so a funded run exercises deposit and withdraw end to end. No matrix cell.
 
-const USDC_DENOM = "ibc/usdc";
 const DUST_USDC = "0.05";
 const TERMINAL_MS = 150000;
 
@@ -69,51 +61,42 @@ test("IBC deposit then withdraw Nolus <-> Osmosis, gated on a funded Osmosis sid
 
   const requiredMicro = BigInt(toMicroAmount(DUST_USDC, USDC_DECIMALS));
   await connectFlow(page, run, "/assets");
-  try {
-    const deposit = await journaledSpend(run, {
-      spec: "t3-flow-ibc",
-      action: "ibc-transfer",
-      walletRole: "primary",
-      walletKey: run.primary.key,
-      items: [{ denom: "usdc", micro: requiredMicro }],
-      denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
-      memo: "ibc deposit nolus<-osmosis",
-      execute: async () => {
-        await page
-          .getByRole("button", { name: /deposit/i })
-          .first()
-          .click({ timeout: TERMINAL_MS });
-        await typeAmount(page, "receive-send", DUST_USDC);
-        await submitForm(page, { submitLabel: messageValue(run.locale, "transfer"), terminalMs: TERMINAL_MS });
-      }
-    });
-    // A cap abort on the deposit halts the engine; skip the withdraw leg cleanly rather than let
-    // the second submission throw EngineHaltedError and cascade a red.
-    if (deposit.status === "spend-cap-abort") {
-      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
-      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${deposit.check.overDenom}`);
+  // The deposit leg's own cap abort skips the whole test (spendCommittedOrSkip), so the withdraw
+  // leg never runs on a halted engine — no EngineHaltedError cascade.
+  await spendCommittedOrSkip(testInfo, run, {
+    spec: "t3-flow-ibc",
+    action: "ibc-transfer",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "usdc", micro: requiredMicro }],
+    denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
+    memo: "ibc deposit nolus<-osmosis",
+    execute: async () => {
+      await page
+        .getByRole("button", { name: /deposit/i })
+        .first()
+        .click({ timeout: TERMINAL_MS });
+      await typeAmount(page, "receive-send", DUST_USDC);
+      await submitForm(page, { submitLabel: messageValue(run.locale, "transfer"), terminalMs: TERMINAL_MS });
     }
-    await journaledSpend(run, {
-      spec: "t3-flow-ibc",
-      action: "ibc-transfer",
-      walletRole: "primary",
-      walletKey: run.primary.key,
-      items: [{ denom: "usdc", micro: requiredMicro }],
-      denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
-      memo: "ibc withdraw nolus->osmosis",
-      execute: async () => {
-        await page
-          .getByRole("button", { name: /withdraw/i })
-          .first()
-          .click({ timeout: TERMINAL_MS });
-        await typeAmount(page, "receive-send", DUST_USDC);
-        await submitForm(page, { submitLabel: messageValue(run.locale, "transfer"), terminalMs: TERMINAL_MS });
-      }
-    });
-  } catch (error) {
-    reportLeftover(run, testInfo, { terminal: "app-failure" });
-    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
-  }
+  });
+  await spendCommittedOrSkip(testInfo, run, {
+    spec: "t3-flow-ibc",
+    action: "ibc-transfer",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "usdc", micro: requiredMicro }],
+    denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
+    memo: "ibc withdraw nolus->osmosis",
+    execute: async () => {
+      await page
+        .getByRole("button", { name: /withdraw/i })
+        .first()
+        .click({ timeout: TERMINAL_MS });
+      await typeAmount(page, "receive-send", DUST_USDC);
+      await submitForm(page, { submitLabel: messageValue(run.locale, "transfer"), terminalMs: TERMINAL_MS });
+    }
+  });
 
   const ibcIntents = run.store
     .readAll()

--- a/e2e/src/t3/flows/ibc.spec.ts
+++ b/e2e/src/t3/flows/ibc.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "./support.js";
+import type { RunContext } from "./support.js";
+import {
+  getRunContext,
+  connectFlow,
+  journaledSpend,
+  reportLeftover,
+  skipIfHalted,
+  classifyAndRoute
+} from "./support.js";
+import { messageValue } from "../../t2/appDriver.js";
+import { typeAmount, requireOrSkip, readString } from "../../t2/matrixHelpers.js";
+import { USDC_DECIMALS } from "../../config.js";
+import { toMicroAmount } from "../../transfer.js";
+import { submitForm } from "./formDriver.js";
+import { readJson } from "../runtime.js";
+
+// IBC deposit + withdraw Nolus <-> Osmosis (#283 flow 5). ENTIRELY skip-gated on a funded
+// Osmosis-side probe: the whole flow is inert until that funding is confirmed, at which point
+// E2E_EXPECT_FUNDED escalates the unmet precondition into a hard failure. The structure is
+// complete so a funded run exercises deposit and withdraw end to end. No matrix cell.
+
+const USDC_DENOM = "ibc/usdc";
+const DUST_USDC = "0.05";
+const TERMINAL_MS = 150000;
+
+let run: RunContext;
+
+/**
+ * Probe whether the Osmosis counterparty side holds funds to relay back. There is no committed
+ * Osmosis balance endpoint in this suite, so the probe reports funded only when the operator
+ * asserts it via E2E_EXPECT_FUNDED — otherwise the flow skips, never broadcasting an IBC transfer
+ * that would strand value with no return leg.
+ */
+async function osmosisFunded(ctx: RunContext["ctx"], address: string): Promise<boolean> {
+  const payload = await readJson(ctx, `${ctx.origin}/api/balances?address=${address}&network=osmosis`).catch(
+    () => null
+  );
+  const balances = typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).balances : [];
+  return Array.isArray(balances) && balances.some((entry) => (readString(entry, "amount") ?? "0") !== "0");
+}
+
+test.beforeAll(async () => {
+  run = await getRunContext(test.info());
+});
+
+test.afterAll(async () => {
+  if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
+});
+
+test("IBC deposit then withdraw Nolus <-> Osmosis, gated on a funded Osmosis side", async ({
+  page,
+  budget,
+  wallet
+}, testInfo) => {
+  skipIfHalted(testInfo, run);
+  test.setTimeout(TERMINAL_MS * 3);
+  budget.route = "/assets";
+
+  const funded = await osmosisFunded(run.ctx, wallet.address);
+  requireOrSkip(
+    testInfo,
+    run.matrix.expectFunded,
+    funded,
+    "Osmosis counterparty side is not funded for an IBC round trip"
+  );
+
+  const requiredMicro = BigInt(toMicroAmount(DUST_USDC, USDC_DECIMALS));
+  await connectFlow(page, run, "/assets");
+  try {
+    await journaledSpend(run, {
+      spec: "t3-flow-ibc",
+      action: "ibc-transfer",
+      walletRole: "primary",
+      walletKey: run.primary.key,
+      items: [{ denom: "usdc", micro: requiredMicro }],
+      denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
+      memo: "ibc deposit nolus<-osmosis",
+      execute: async () => {
+        await page
+          .getByRole("button", { name: /deposit/i })
+          .first()
+          .click({ timeout: TERMINAL_MS });
+        await typeAmount(page, "receive-send", DUST_USDC);
+        await submitForm(page, { submitLabel: messageValue(run.locale, "transfer"), terminalMs: TERMINAL_MS });
+      }
+    });
+    await journaledSpend(run, {
+      spec: "t3-flow-ibc",
+      action: "ibc-transfer",
+      walletRole: "primary",
+      walletKey: run.primary.key,
+      items: [{ denom: "usdc", micro: requiredMicro }],
+      denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
+      memo: "ibc withdraw nolus->osmosis",
+      execute: async () => {
+        await page
+          .getByRole("button", { name: /withdraw/i })
+          .first()
+          .click({ timeout: TERMINAL_MS });
+        await typeAmount(page, "receive-send", DUST_USDC);
+        await submitForm(page, { submitLabel: messageValue(run.locale, "transfer"), terminalMs: TERMINAL_MS });
+      }
+    });
+  } catch (error) {
+    reportLeftover(run, testInfo, { terminal: "app-failure" });
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
+
+  expect(funded).toBe(true);
+  reportLeftover(run, testInfo, { terminal: "success" });
+});

--- a/e2e/src/t3/flows/lease.spec.ts
+++ b/e2e/src/t3/flows/lease.spec.ts
@@ -1,27 +1,20 @@
 import { test, expect } from "./support.js";
 import type { Page, TestInfo } from "@playwright/test";
 import type { RunContext } from "./support.js";
-import {
-  getRunContext,
-  connectFlow,
-  journaledSpend,
-  reportLeftover,
-  skipIfHalted,
-  classifyAndRoute,
-  annotateSkipAndStop
-} from "./support.js";
-import type { JournaledSpendParams } from "./support.js";
+import { getRunContext, connectFlow, reportLeftover, skipIfHalted, spendCommittedOrSkip } from "./support.js";
 import { messageValue } from "../../t2/appDriver.js";
 import { typeAmount, requireOrSkip, readString } from "../../t2/matrixHelpers.js";
 import { USDC_DECIMALS } from "../../config.js";
 import { toMicroAmount } from "../../transfer.js";
 import { Decimal } from "../../oracle/decimal.js";
 import { computeLiquidation, leaseSizeCell } from "../../oracle/lease.js";
-import { microBalanceByDenom, openedLease, leaseConfig, firstProtocol } from "./apiReads.js";
+import { microBalanceByDenom, openedLease, leaseConfig, firstProtocol, currencies } from "./apiReads.js";
 import { submitForm, openDetailDialog } from "./formDriver.js";
 import { resolveDownpaymentFloorUsd, remainsAboveMin } from "./preconditions.js";
+import { resolveShortLeaseStable } from "./sideSelection.js";
 import type { LeaseSide } from "./sideSelection.js";
-import { assertNonZeroBasis } from "./tolerance.js";
+import { assertNonZeroBasis, assertWithinTolerance } from "./tolerance.js";
+import { USDC_DENOM } from "./denoms.js";
 
 // The alternating-side single-lease lifecycle (#283 flow 1), run same-run on ONE opened lease so
 // the pre-run sweep never sees a cross-run orphan: open → TP/SL create + edit → dust repay
@@ -32,7 +25,6 @@ import { assertNonZeroBasis } from "./tolerance.js";
 // against chain-enumerated state. Matrix labels: flow-lease-row, flow-lease-detail,
 // flow-lease-crossfield.
 
-const USDC_DENOM = "ibc/usdc";
 const TERMINAL_MS = 150000;
 const MIN_ASSET_USDC = "15";
 const MIN_TRANSACTION_USDC = "0.01";
@@ -56,18 +48,11 @@ function oracleSize(lease: Record<string, unknown>, side: LeaseSide): string {
   }).value;
 }
 
-/** Run a governed lease spend through the engine; skip on cap-abort, classify-and-route on error. */
-async function spendOrRoute(testInfo: TestInfo, params: JournaledSpendParams<void>): Promise<void> {
-  try {
-    const outcome = await journaledSpend(run, params);
-    if (outcome.status === "spend-cap-abort") {
-      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
-      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
-    }
-  } catch (error) {
-    reportLeftover(run, testInfo, { terminal: "app-failure" });
-    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
-  }
+/** The first `$`-prefixed amount rendered in a dialog, digits only, or undefined. */
+function firstUsdAmount(text: string): string | undefined {
+  const match = text.match(/\$\s?([0-9][0-9,]*(?:\.[0-9]+)?)/);
+  const raw = match?.[1];
+  return raw === undefined ? undefined : raw.replace(/,/g, "");
 }
 
 /** Set the take-profit / stop-loss trigger in the open lease detail dialog (config-only, no spend). */
@@ -113,11 +98,16 @@ async function assertOpenedLeaseOracle(
 
   testInfo.annotations.push({ type: "matrix", description: "flow-lease-detail" });
   const dialogText = await openDetailDialog(page, address, TERMINAL_MS);
-  assertNonZeroBasis({
-    value: dec(readString(opened, "asset_value_usd")).toString(2),
-    description: `${side} lease value`
-  });
+  const expectedUsd = dec(readString(opened, "asset_value_usd")).toString(2);
+  assertNonZeroBasis({ value: expectedUsd, description: `${side} lease value` });
   expect(dialogText).toContain(oracleSize(opened, side));
+  const renderedUsd = firstUsdAmount(dialogText);
+  if (renderedUsd !== undefined) {
+    assertWithinTolerance(
+      { actual: renderedUsd, expected: expectedUsd, tolerance: run.usdTolerance },
+      `${side} lease rendered value vs oracle`
+    );
+  }
 
   testInfo.annotations.push({ type: "matrix", description: "flow-lease-crossfield" });
   const spot = dec(readString(opened, "price"));
@@ -164,10 +154,9 @@ test("a single alternating-side lease runs its full lifecycle through the engine
     `primary holds ${balance.toString()} micro-USDC, below the ${requiredMicro.toString()} a ${side} lease needs`
   );
 
-  // Open.
   await connectFlow(page, run, `/positions/open/${side}`);
   await typeAmount(page, "receive-send", downpayment);
-  await spendOrRoute(testInfo, {
+  await spendCommittedOrSkip(testInfo, run, {
     spec: "t3-flow-lease",
     action: "lease-open",
     walletRole: "primary",
@@ -182,6 +171,13 @@ test("a single alternating-side lease runs its full lifecycle through the engine
   requireOrSkip(testInfo, run.matrix.expectFunded, lease !== undefined, "no opened lease enumerated after open");
   const opened = lease ?? {};
   const address = readString(opened, "address") ?? "";
+
+  // #283 acceptance: a short position is denominated in the lease-group stable, never the LPN.
+  if (side === "short") {
+    const stableTicker = resolveShortLeaseStable(await currencies(run.ctx));
+    expect(readString(opened, "ticker")).toBe(stableTicker);
+  }
+
   await assertOpenedLeaseOracle(page, testInfo, opened, side);
 
   // TP/SL create + edit (config-only; the app does not attach funds, so it bypasses the engine).
@@ -192,7 +188,7 @@ test("a single alternating-side lease runs its full lifecycle through the engine
   // Dust repay (min_transaction): debt must fall.
   const debtBefore = dec(readString(opened, "total_debt_usd") ?? readString(opened, "debt"));
   const repayMicro = BigInt(toMicroAmount(MIN_TRANSACTION_USDC, USDC_DECIMALS));
-  await spendOrRoute(testInfo, {
+  await spendCommittedOrSkip(testInfo, run, {
     spec: "t3-flow-lease",
     action: "lease-repay",
     walletRole: "primary",
@@ -222,19 +218,19 @@ test("a single alternating-side lease runs its full lifecycle through the engine
     remainsAboveMin(positionMicro - repayMicro, minAssetMicro),
     `position ${positionMicro.toString()} micro-USDC cannot leave ${MIN_ASSET_USDC} USDC after a dust partial close`
   );
-  await spendOrRoute(testInfo, {
+  await spendCommittedOrSkip(testInfo, run, {
     spec: "t3-flow-lease",
     action: "lease-close",
     walletRole: "primary",
     walletKey: run.primary.key,
     items: [{ denom: "nls", micro: 0n }],
-    denoms: [{ denom: USDC_DENOM, micro: MIN_TRANSACTION_USDC }],
+    denoms: [{ denom: USDC_DENOM, micro: repayMicro.toString() }],
     memo: "partial close",
     execute: () => driveClose(page, "partial", MIN_TRANSACTION_USDC)
   });
 
   // Market close (full): the lease must no longer enumerate as opened.
-  await spendOrRoute(testInfo, {
+  await spendCommittedOrSkip(testInfo, run, {
     spec: "t3-flow-lease",
     action: "lease-close",
     walletRole: "primary",

--- a/e2e/src/t3/flows/lease.spec.ts
+++ b/e2e/src/t3/flows/lease.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./support.js";
+import type { Page, TestInfo } from "@playwright/test";
 import type { RunContext } from "./support.js";
 import {
   getRunContext,
@@ -9,6 +10,7 @@ import {
   classifyAndRoute,
   annotateSkipAndStop
 } from "./support.js";
+import type { JournaledSpendParams } from "./support.js";
 import { messageValue } from "../../t2/appDriver.js";
 import { typeAmount, requireOrSkip, readString } from "../../t2/matrixHelpers.js";
 import { USDC_DECIMALS } from "../../config.js";
@@ -17,20 +19,25 @@ import { Decimal } from "../../oracle/decimal.js";
 import { computeLiquidation, leaseSizeCell } from "../../oracle/lease.js";
 import { microBalanceByDenom, openedLease, leaseConfig, firstProtocol } from "./apiReads.js";
 import { submitForm, openDetailDialog } from "./formDriver.js";
-import { resolveDownpaymentFloorUsd } from "./preconditions.js";
+import { resolveDownpaymentFloorUsd, remainsAboveMin } from "./preconditions.js";
 import type { LeaseSide } from "./sideSelection.js";
 import { assertNonZeroBasis } from "./tolerance.js";
 
-// The alternating-side single-lease lifecycle (#283 flow 1). The side is chosen by UTC
-// day-of-year parity unless E2E_LEASE_SIDE pins it. USDC is the only viable downpayment denom
-// (NLS is priced ~$0 on staging, so its USD figures are vacuous). The whole cycle — open, then
-// the leftover-safe teardown — runs on ONE lease within this run so the pre-run sweep never sees
-// a cross-run orphan. Post-flow math is asserted against the EXISTING render oracle on the
-// non-zero-priced collateral leg. Matrix labels: flow-lease-row, flow-lease-detail,
+// The alternating-side single-lease lifecycle (#283 flow 1), run same-run on ONE opened lease so
+// the pre-run sweep never sees a cross-run orphan: open → TP/SL create + edit → dust repay
+// (min_transaction) → partial close (leaving ≥ min_asset) → market close. The side is chosen by
+// UTC day-of-year parity unless E2E_LEASE_SIDE pins it; USDC is the only viable downpayment denom
+// (NLS is priced ~$0, so its USD figures are vacuous). Post-flow math is asserted against the
+// EXISTING render oracle on the non-zero-priced collateral leg, and each teardown step is checked
+// against chain-enumerated state. Matrix labels: flow-lease-row, flow-lease-detail,
 // flow-lease-crossfield.
 
 const USDC_DENOM = "ibc/usdc";
 const TERMINAL_MS = 150000;
+const MIN_ASSET_USDC = "15";
+const MIN_TRANSACTION_USDC = "0.01";
+const TP_TRIGGER_PERCENT = "5";
+const TP_EDIT_PERCENT = "8";
 
 let run: RunContext;
 
@@ -49,6 +56,84 @@ function oracleSize(lease: Record<string, unknown>, side: LeaseSide): string {
   }).value;
 }
 
+/** Run a governed lease spend through the engine; skip on cap-abort, classify-and-route on error. */
+async function spendOrRoute(testInfo: TestInfo, params: JournaledSpendParams<void>): Promise<void> {
+  try {
+    const outcome = await journaledSpend(run, params);
+    if (outcome.status === "spend-cap-abort") {
+      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
+      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+    }
+  } catch (error) {
+    reportLeftover(run, testInfo, { terminal: "app-failure" });
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
+}
+
+/** Set the take-profit / stop-loss trigger in the open lease detail dialog (config-only, no spend). */
+async function setTakeProfitStopLoss(page: Page, triggerPercent: string): Promise<void> {
+  await page
+    .getByRole("button", { name: /take.?profit|stop.?loss|tp\s?\/?\s?sl/i })
+    .first()
+    .click({ timeout: TERMINAL_MS });
+  await typeAmount(page, "receive-send", triggerPercent);
+  await page
+    .getByRole("button", { name: /save|set|apply|confirm/i })
+    .first()
+    .click({ timeout: TERMINAL_MS });
+}
+
+/** Drive the detail-dialog close flow — market (full) or partial with an amount. */
+async function driveClose(page: Page, mode: "market" | "partial", amount?: string): Promise<void> {
+  await page.getByRole("button", { name: /close/i }).first().click({ timeout: TERMINAL_MS });
+  await page
+    .getByRole("button", { name: mode === "market" ? /market/i : /partial/i })
+    .first()
+    .click({ timeout: TERMINAL_MS });
+  if (mode === "partial" && amount !== undefined) {
+    await typeAmount(page, "receive-send", amount);
+  }
+  await page
+    .getByRole("button", { name: /confirm|submit|send/i })
+    .first()
+    .click({ timeout: TERMINAL_MS });
+  await expect(page.locator("div.toast")).toBeVisible({ timeout: TERMINAL_MS });
+}
+
+/** Assert the opened lease's rendered row, detail size, and liquidation ordering against the oracle. */
+async function assertOpenedLeaseOracle(
+  page: Page,
+  testInfo: TestInfo,
+  opened: Record<string, unknown>,
+  side: LeaseSide
+): Promise<void> {
+  const address = readString(opened, "address") ?? "";
+  testInfo.annotations.push({ type: "matrix", description: "flow-lease-row" });
+  await expect(page.getByText(address, { exact: false }).first()).toBeVisible({ timeout: TERMINAL_MS });
+
+  testInfo.annotations.push({ type: "matrix", description: "flow-lease-detail" });
+  const dialogText = await openDetailDialog(page, address, TERMINAL_MS);
+  assertNonZeroBasis({
+    value: dec(readString(opened, "asset_value_usd")).toString(2),
+    description: `${side} lease value`
+  });
+  expect(dialogText).toContain(oracleSize(opened, side));
+
+  testInfo.annotations.push({ type: "matrix", description: "flow-lease-crossfield" });
+  const spot = dec(readString(opened, "price"));
+  const liquidation = computeLiquidation({
+    serverPrice: readString(opened, "liquidation_price") ?? null,
+    positionType: side === "short" ? "Short" : "Long",
+    debt: dec(readString(opened, "debt")),
+    collateral: dec(readString(opened, "collateral"))
+  });
+  if (spot.isPositive() && liquidation.isPositive()) {
+    expect(side === "short" ? liquidation.gt(spot) : spot.gt(liquidation)).toBe(true);
+  } else {
+    expect(liquidation.isNegative()).toBe(false);
+  }
+}
+
 test.beforeAll(async () => {
   run = await getRunContext(test.info());
 });
@@ -57,13 +142,13 @@ test.afterAll(async () => {
   if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
 });
 
-test("a single alternating-side lease opens and its rendered figures match the oracle", async ({
+test("a single alternating-side lease runs its full lifecycle through the engine", async ({
   page,
   budget,
   wallet
 }, testInfo) => {
   skipIfHalted(testInfo, run);
-  test.setTimeout(TERMINAL_MS * 3);
+  test.setTimeout(TERMINAL_MS * 6);
   const side: LeaseSide = run.leaseSides[0] ?? "long";
   budget.route = `/positions/open/${side}`;
 
@@ -79,62 +164,91 @@ test("a single alternating-side lease opens and its rendered figures match the o
     `primary holds ${balance.toString()} micro-USDC, below the ${requiredMicro.toString()} a ${side} lease needs`
   );
 
+  // Open.
   await connectFlow(page, run, `/positions/open/${side}`);
   await typeAmount(page, "receive-send", downpayment);
-  try {
-    const outcome = await journaledSpend(run, {
-      spec: "t3-flow-lease",
-      action: "lease-open",
-      walletRole: "primary",
-      walletKey: run.primary.key,
-      items: [{ denom: "usdc", micro: requiredMicro }],
-      denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
-      execute: () =>
-        submitForm(page, { submitLabel: messageValue(run.locale, "open-position"), terminalMs: TERMINAL_MS })
-    });
-    if (outcome.status === "spend-cap-abort") {
-      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
-      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
-    }
-  } catch (error) {
-    reportLeftover(run, testInfo, { terminal: "app-failure" });
-    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
-  }
+  await spendOrRoute(testInfo, {
+    spec: "t3-flow-lease",
+    action: "lease-open",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "usdc", micro: requiredMicro }],
+    denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
+    execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "open-position"), terminalMs: TERMINAL_MS })
+  });
 
   await page.goto("/positions", { waitUntil: "domcontentloaded" });
   const lease = await openedLease(run.ctx, wallet.address);
   requireOrSkip(testInfo, run.matrix.expectFunded, lease !== undefined, "no opened lease enumerated after open");
   const opened = lease ?? {};
   const address = readString(opened, "address") ?? "";
+  await assertOpenedLeaseOracle(page, testInfo, opened, side);
 
-  testInfo.annotations.push({ type: "matrix", description: "flow-lease-row" });
-  await expect(page.getByText(address, { exact: false }).first()).toBeVisible({ timeout: TERMINAL_MS });
+  // TP/SL create + edit (config-only; the app does not attach funds, so it bypasses the engine).
+  await setTakeProfitStopLoss(page, TP_TRIGGER_PERCENT);
+  await setTakeProfitStopLoss(page, TP_EDIT_PERCENT);
+  await expect(page.locator("#dialog-scroll").first()).toBeVisible({ timeout: TERMINAL_MS });
 
-  testInfo.annotations.push({ type: "matrix", description: "flow-lease-detail" });
-  const dialogText = await openDetailDialog(page, address, TERMINAL_MS);
-  const size = oracleSize(opened, side);
-  assertNonZeroBasis({
-    value: dec(readString(opened, "asset_value_usd")).toString(2),
-    description: `${side} lease value`
+  // Dust repay (min_transaction): debt must fall.
+  const debtBefore = dec(readString(opened, "total_debt_usd") ?? readString(opened, "debt"));
+  const repayMicro = BigInt(toMicroAmount(MIN_TRANSACTION_USDC, USDC_DECIMALS));
+  await spendOrRoute(testInfo, {
+    spec: "t3-flow-lease",
+    action: "lease-repay",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "usdc", micro: repayMicro }],
+    denoms: [{ denom: USDC_DENOM, micro: repayMicro.toString() }],
+    execute: async () => {
+      await page.getByRole("button", { name: /repay/i }).first().click({ timeout: TERMINAL_MS });
+      await typeAmount(page, "receive-send", MIN_TRANSACTION_USDC);
+      await submitForm(page, { submitLabel: messageValue(run.locale, "repay"), terminalMs: TERMINAL_MS });
+    }
   });
-  expect(dialogText).toContain(size);
-
-  testInfo.annotations.push({ type: "matrix", description: "flow-lease-crossfield" });
-  const spot = dec(readString(opened, "price"));
-  const liquidation = computeLiquidation({
-    serverPrice: readString(opened, "liquidation_price") ?? null,
-    positionType: side === "short" ? "Short" : "Long",
-    debt: dec(readString(opened, "debt")),
-    collateral: dec(readString(opened, "collateral"))
-  });
-  if (spot.isPositive() && liquidation.isPositive()) {
-    expect(side === "short" ? liquidation.gt(spot) : spot.gt(liquidation)).toBe(true);
-  } else {
-    expect(liquidation.isNegative()).toBe(false);
+  const afterRepay = (await openedLease(run.ctx, wallet.address)) ?? {};
+  const debtAfter = dec(readString(afterRepay, "total_debt_usd") ?? readString(afterRepay, "debt"));
+  if (debtBefore.isPositive()) {
+    expect(debtAfter.gt(debtBefore)).toBe(false);
   }
 
-  reportLeftover(run, testInfo, {
-    terminal: "success",
-    openLeases: [{ address, protocol: readString(opened, "protocol") ?? protocol, status: "opened" }]
+  // Partial close leaving ≥ min_asset (wires the remainsAboveMin guard).
+  const positionMicro = BigInt(
+    toMicroAmount(dec(readString(afterRepay, "asset_value_usd")).toString(USDC_DECIMALS), USDC_DECIMALS)
+  );
+  const minAssetMicro = BigInt(toMicroAmount(MIN_ASSET_USDC, USDC_DECIMALS));
+  requireOrSkip(
+    testInfo,
+    run.matrix.expectFunded,
+    remainsAboveMin(positionMicro - repayMicro, minAssetMicro),
+    `position ${positionMicro.toString()} micro-USDC cannot leave ${MIN_ASSET_USDC} USDC after a dust partial close`
+  );
+  await spendOrRoute(testInfo, {
+    spec: "t3-flow-lease",
+    action: "lease-close",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "nls", micro: 0n }],
+    denoms: [{ denom: USDC_DENOM, micro: MIN_TRANSACTION_USDC }],
+    memo: "partial close",
+    execute: () => driveClose(page, "partial", MIN_TRANSACTION_USDC)
   });
+
+  // Market close (full): the lease must no longer enumerate as opened.
+  await spendOrRoute(testInfo, {
+    spec: "t3-flow-lease",
+    action: "lease-close",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "nls", micro: 0n }],
+    denoms: [{ denom: USDC_DENOM, micro: "0" }],
+    memo: "market close",
+    execute: () => driveClose(page, "market")
+  });
+  const stillOpen = await openedLease(run.ctx, wallet.address);
+  const leftoverOpen =
+    stillOpen === undefined
+      ? []
+      : [{ address, protocol: readString(opened, "protocol") ?? protocol, status: "opened" }];
+
+  reportLeftover(run, testInfo, { terminal: "success", openLeases: leftoverOpen });
 });

--- a/e2e/src/t3/flows/lease.spec.ts
+++ b/e2e/src/t3/flows/lease.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from "./support.js";
+import type { RunContext } from "./support.js";
+import {
+  getRunContext,
+  connectFlow,
+  journaledSpend,
+  reportLeftover,
+  skipIfHalted,
+  classifyAndRoute,
+  annotateSkipAndStop
+} from "./support.js";
+import { messageValue } from "../../t2/appDriver.js";
+import { typeAmount, requireOrSkip, readString } from "../../t2/matrixHelpers.js";
+import { USDC_DECIMALS } from "../../config.js";
+import { toMicroAmount } from "../../transfer.js";
+import { Decimal } from "../../oracle/decimal.js";
+import { computeLiquidation, leaseSizeCell } from "../../oracle/lease.js";
+import { microBalanceByDenom, openedLease, leaseConfig, firstProtocol } from "./apiReads.js";
+import { submitForm, openDetailDialog } from "./formDriver.js";
+import { resolveDownpaymentFloorUsd } from "./preconditions.js";
+import type { LeaseSide } from "./sideSelection.js";
+import { assertNonZeroBasis } from "./tolerance.js";
+
+// The alternating-side single-lease lifecycle (#283 flow 1). The side is chosen by UTC
+// day-of-year parity unless E2E_LEASE_SIDE pins it. USDC is the only viable downpayment denom
+// (NLS is priced ~$0 on staging, so its USD figures are vacuous). The whole cycle — open, then
+// the leftover-safe teardown — runs on ONE lease within this run so the pre-run sweep never sees
+// a cross-run orphan. Post-flow math is asserted against the EXISTING render oracle on the
+// non-zero-priced collateral leg. Matrix labels: flow-lease-row, flow-lease-detail,
+// flow-lease-crossfield.
+
+const USDC_DENOM = "ibc/usdc";
+const TERMINAL_MS = 150000;
+
+let run: RunContext;
+
+function dec(value: string | undefined): Decimal {
+  return Decimal.fromString(value !== undefined && /^-?\d+(\.\d+)?$/.test(value) ? value : "0");
+}
+
+function oracleSize(lease: Record<string, unknown>, side: LeaseSide): string {
+  const ticker = readString(lease, "ticker");
+  return leaseSizeCell({
+    positionType: side === "short" ? "Short" : "Long",
+    unitAsset: dec(readString(lease, "unit_asset")),
+    assetValueUsd: dec(readString(lease, "asset_value_usd")),
+    ...(ticker !== undefined ? { cryptoShortName: ticker } : {}),
+    cryptoPriceUsd: dec(readString(lease, "price"))
+  }).value;
+}
+
+test.beforeAll(async () => {
+  run = await getRunContext(test.info());
+});
+
+test.afterAll(async () => {
+  if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
+});
+
+test("a single alternating-side lease opens and its rendered figures match the oracle", async ({
+  page,
+  budget,
+  wallet
+}, testInfo) => {
+  skipIfHalted(testInfo, run);
+  test.setTimeout(TERMINAL_MS * 3);
+  const side: LeaseSide = run.leaseSides[0] ?? "long";
+  budget.route = `/positions/open/${side}`;
+
+  const protocol = await firstProtocol(run.ctx);
+  const floorUsd = resolveDownpaymentFloorUsd(await leaseConfig(run.ctx, protocol));
+  const downpayment = floorUsd.add(Decimal.fromString("2")).toString(2);
+  const requiredMicro = BigInt(toMicroAmount(downpayment, USDC_DECIMALS));
+  const balance = await microBalanceByDenom(run.ctx, wallet.address, "usdc");
+  requireOrSkip(
+    testInfo,
+    run.matrix.expectFunded,
+    balance > requiredMicro,
+    `primary holds ${balance.toString()} micro-USDC, below the ${requiredMicro.toString()} a ${side} lease needs`
+  );
+
+  await connectFlow(page, run, `/positions/open/${side}`);
+  await typeAmount(page, "receive-send", downpayment);
+  try {
+    const outcome = await journaledSpend(run, {
+      spec: "t3-flow-lease",
+      action: "lease-open",
+      walletRole: "primary",
+      walletKey: run.primary.key,
+      items: [{ denom: "usdc", micro: requiredMicro }],
+      denoms: [{ denom: USDC_DENOM, micro: requiredMicro.toString() }],
+      execute: () =>
+        submitForm(page, { submitLabel: messageValue(run.locale, "open-position"), terminalMs: TERMINAL_MS })
+    });
+    if (outcome.status === "spend-cap-abort") {
+      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
+      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+    }
+  } catch (error) {
+    reportLeftover(run, testInfo, { terminal: "app-failure" });
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
+
+  await page.goto("/positions", { waitUntil: "domcontentloaded" });
+  const lease = await openedLease(run.ctx, wallet.address);
+  requireOrSkip(testInfo, run.matrix.expectFunded, lease !== undefined, "no opened lease enumerated after open");
+  const opened = lease ?? {};
+  const address = readString(opened, "address") ?? "";
+
+  testInfo.annotations.push({ type: "matrix", description: "flow-lease-row" });
+  await expect(page.getByText(address, { exact: false }).first()).toBeVisible({ timeout: TERMINAL_MS });
+
+  testInfo.annotations.push({ type: "matrix", description: "flow-lease-detail" });
+  const dialogText = await openDetailDialog(page, address, TERMINAL_MS);
+  const size = oracleSize(opened, side);
+  assertNonZeroBasis({
+    value: dec(readString(opened, "asset_value_usd")).toString(2),
+    description: `${side} lease value`
+  });
+  expect(dialogText).toContain(size);
+
+  testInfo.annotations.push({ type: "matrix", description: "flow-lease-crossfield" });
+  const spot = dec(readString(opened, "price"));
+  const liquidation = computeLiquidation({
+    serverPrice: readString(opened, "liquidation_price") ?? null,
+    positionType: side === "short" ? "Short" : "Long",
+    debt: dec(readString(opened, "debt")),
+    collateral: dec(readString(opened, "collateral"))
+  });
+  if (spot.isPositive() && liquidation.isPositive()) {
+    expect(side === "short" ? liquidation.gt(spot) : spot.gt(liquidation)).toBe(true);
+  } else {
+    expect(liquidation.isNegative()).toBe(false);
+  }
+
+  reportLeftover(run, testInfo, {
+    terminal: "success",
+    openLeases: [{ address, protocol: readString(opened, "protocol") ?? protocol, status: "opened" }]
+  });
+});

--- a/e2e/src/t3/flows/preconditions.test.ts
+++ b/e2e/src/t3/flows/preconditions.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  UNBONDING_ENTRY_CAP,
+  hasSwapRoute,
+  pickUnbondingValidator,
+  remainsAboveMin,
+  resolveDownpaymentFloorUsd,
+  unbondingEntryGate
+} from "./preconditions.js";
+
+describe("unbondingEntryGate", () => {
+  it("has room below the cap and none at or above it", () => {
+    expect(unbondingEntryGate(6)).toEqual({ ok: true, entries: 6, cap: UNBONDING_ENTRY_CAP });
+    expect(unbondingEntryGate(7).ok).toBe(false);
+    expect(unbondingEntryGate(8).ok).toBe(false);
+  });
+});
+
+describe("pickUnbondingValidator", () => {
+  it("rotates to the first validator with entry headroom", () => {
+    const target = pickUnbondingValidator([
+      { validatorAddress: "nolusvaloper1full", entries: 7 },
+      { validatorAddress: "nolusvaloper2open", entries: 2 }
+    ]);
+    expect(target).toBe("nolusvaloper2open");
+  });
+
+  it("returns undefined when every validator is saturated", () => {
+    expect(
+      pickUnbondingValidator([
+        { validatorAddress: "a", entries: 7 },
+        { validatorAddress: "b", entries: 9 }
+      ])
+    ).toBeUndefined();
+  });
+});
+
+describe("hasSwapRoute", () => {
+  it("accepts a positive amount-out at the top level or under a wrapper", () => {
+    expect(hasSwapRoute({ amount_out: "1000" })).toBe(true);
+    expect(hasSwapRoute({ route: { amount_out: "5" } })).toBe(true);
+    expect(hasSwapRoute({ quote: { amount_out: "42" } })).toBe(true);
+  });
+
+  it("rejects a missing, zero, or non-numeric amount-out", () => {
+    expect(hasSwapRoute({})).toBe(false);
+    expect(hasSwapRoute({ amount_out: "0" })).toBe(false);
+    expect(hasSwapRoute({ amount_out: "none" })).toBe(false);
+    expect(hasSwapRoute(null)).toBe(false);
+  });
+});
+
+describe("resolveDownpaymentFloorUsd", () => {
+  it("returns the floor for a named currency from an object map", () => {
+    const payload = { downpayment_ranges: { USDC: { min: "40.0" }, ATOM: { min: "45.0" } } };
+    expect(resolveDownpaymentFloorUsd(payload, "USDC").toString(2)).toBe("40.00");
+  });
+
+  it("returns the highest floor across currencies when none is named", () => {
+    const payload = {
+      downpayment_ranges: [
+        { ticker: "USDC", min: "40.0" },
+        { ticker: "ATOM", min: "45.0" }
+      ]
+    };
+    expect(resolveDownpaymentFloorUsd(payload).toString(2)).toBe("45.00");
+  });
+
+  it("throws when no ranges parse so a drifted shape is a red", () => {
+    expect(() => resolveDownpaymentFloorUsd({})).toThrow(/no downpayment ranges/);
+  });
+});
+
+describe("remainsAboveMin", () => {
+  it("holds when the residual meets the minimum and fails below it", () => {
+    expect(remainsAboveMin(15_000_000n, 15_000_000n)).toBe(true);
+    expect(remainsAboveMin(14_999_999n, 15_000_000n)).toBe(false);
+  });
+});

--- a/e2e/src/t3/flows/preconditions.ts
+++ b/e2e/src/t3/flows/preconditions.ts
@@ -1,0 +1,113 @@
+import { Decimal } from "../../oracle/decimal.js";
+import { readString } from "../../t2/matrixHelpers.js";
+
+/**
+ * Cosmos caps concurrent unbonding entries per delegator/validator pair at 7; a run that would
+ * add the 8th is a precondition to fix (rotate validator or wait), never an app red.
+ */
+export const UNBONDING_ENTRY_CAP = 7;
+
+export interface UnbondingGate {
+  ok: boolean;
+  entries: number;
+  cap: number;
+}
+
+/** True while the target validator has room for one more unbonding entry. */
+export function unbondingEntryGate(entries: number, cap: number = UNBONDING_ENTRY_CAP): UnbondingGate {
+  return { ok: entries < cap, entries, cap };
+}
+
+export interface ValidatorEntryCount {
+  validatorAddress: string;
+  entries: number;
+}
+
+/**
+ * Pick a target validator that still has unbonding-entry headroom, rotating away from any that
+ * is at or near the cap. Returns the address of the first candidate under the cap, or undefined
+ * when every candidate is saturated (the spec then precondition-skips).
+ */
+export function pickUnbondingValidator(
+  candidates: ValidatorEntryCount[],
+  cap: number = UNBONDING_ENTRY_CAP
+): string | undefined {
+  for (const candidate of candidates) {
+    if (unbondingEntryGate(candidate.entries, cap).ok) {
+      return candidate.validatorAddress;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Whether a Skip quote payload carries a usable route for the requested amount. A dust amount
+ * routinely has no route on staging, which is a precondition skip rather than a failure — so the
+ * spec pre-probes the quote and only executes when this returns true. Accepts the amount-out
+ * either at the top level or under a `route`/`quote` wrapper and requires it to be positive.
+ */
+export function hasSwapRoute(payload: unknown): boolean {
+  const amountOut =
+    readString(payload, "amount_out") ??
+    readString(payload, "route", "amount_out") ??
+    readString(payload, "quote", "amount_out");
+  if (amountOut === undefined || !/^\d+$/.test(amountOut)) {
+    return false;
+  }
+  return BigInt(amountOut) > 0n;
+}
+
+interface DownpaymentRange {
+  currency: string;
+  min: Decimal;
+}
+
+function extractRanges(payload: unknown): DownpaymentRange[] {
+  const root =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>).downpayment_ranges
+      : undefined;
+  const ranges: DownpaymentRange[] = [];
+  if (Array.isArray(root)) {
+    for (const entry of root) {
+      const currency = readString(entry, "ticker") ?? readString(entry, "currency");
+      const min = readString(entry, "min");
+      if (currency !== undefined && min !== undefined) {
+        ranges.push({ currency, min: Decimal.fromString(min) });
+      }
+    }
+  } else if (typeof root === "object" && root !== null) {
+    for (const [currency, value] of Object.entries(root as Record<string, unknown>)) {
+      const min = readString(value, "min");
+      if (min !== undefined) {
+        ranges.push({ currency, min: Decimal.fromString(min) });
+      }
+    }
+  }
+  return ranges;
+}
+
+/**
+ * Resolve the minimum USD-equivalent downpayment required to open a lease from the live
+ * `/api/leases/config/<protocol>` payload. Returns the range floor for `currency` when present,
+ * else the highest floor across all currencies (the safe amount that clears any range). Throws
+ * when no ranges parse so a drifted config shape is a red rather than a silent zero minimum.
+ */
+export function resolveDownpaymentFloorUsd(payload: unknown, currency?: string): Decimal {
+  const ranges = extractRanges(payload);
+  if (ranges.length === 0) {
+    throw new Error("no downpayment ranges found in the lease config");
+  }
+  if (currency !== undefined) {
+    const match = ranges.find((range) => range.currency === currency);
+    if (match !== undefined) {
+      return match.min;
+    }
+  }
+  return ranges.reduce((max, range) => (range.min.gt(max) ? range.min : max), Decimal.zero());
+}
+
+/** True when a partial repay/close leaves at least the protocol's `min_asset` residual. */
+export function remainsAboveMin(remainingMicro: bigint, minMicro: bigint): boolean {
+  return remainingMicro >= minMicro;
+}

--- a/e2e/src/t3/flows/send.spec.ts
+++ b/e2e/src/t3/flows/send.spec.ts
@@ -1,14 +1,7 @@
 import { test, expect } from "./support.js";
 import type { Page } from "@playwright/test";
 import type { RunContext } from "./support.js";
-import {
-  getRunContext,
-  journaledSpend,
-  reportLeftover,
-  skipIfHalted,
-  classifyAndRoute,
-  annotateSkipAndStop
-} from "./support.js";
+import { getRunContext, reportLeftover, skipIfHalted, spendCommittedOrSkip } from "./support.js";
 import { connectKeplr, waitForAppShell, assertConnected } from "../../t2/appDriver.js";
 import {
   requireOrSkip,
@@ -77,38 +70,27 @@ test("a native send debits the sender and credits wallet-2 through the engine", 
   const renderedBefore = await readSwapFromNls(page);
   const receiverBefore = await probeNativeMicroBalance(run.ctx, run.secondary.address);
 
-  let result: BroadcastResult | undefined;
-  try {
-    const outcome = await journaledSpend(run, {
-      spec: "t3-flow-send",
-      action: "native-send",
-      walletRole: "primary",
-      walletKey: run.primary.key,
-      items: [{ denom: "nls", micro: grossMicro }],
-      denoms: [{ denom: NATIVE_DENOM, micro: grossMicro.toString() }],
-      memo: "nolus-e2e-t3-flow",
-      outcomeFrom: (value: BroadcastResult) => ({ txHash: value.txHash, height: value.height }),
-      execute: () =>
-        broadcastSend({
-          rpcUrl: run.chain.rpcUrl,
-          senderMnemonic: run.primaryMnemonic,
-          prefix: "nolus",
-          recipient: run.secondary.address,
-          amount: coin,
-          fee,
-          memo: "nolus-e2e-t3-flow"
-        })
-    });
-    if (outcome.status === "spend-cap-abort") {
-      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
-      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
-    }
-    result = outcome.status === "committed" ? outcome.value : undefined;
-  } catch (error) {
-    reportLeftover(run, testInfo, { terminal: "app-failure" });
-    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
-  }
-  testInfo.annotations.push({ type: "t3-send", description: `broadcast at height ${result?.height ?? 0}` });
+  const result = await spendCommittedOrSkip<BroadcastResult>(testInfo, run, {
+    spec: "t3-flow-send",
+    action: "native-send",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "nls", micro: grossMicro }],
+    denoms: [{ denom: NATIVE_DENOM, micro: grossMicro.toString() }],
+    memo: "nolus-e2e-t3-flow",
+    outcomeFrom: (value: BroadcastResult) => ({ txHash: value.txHash, height: value.height }),
+    execute: () =>
+      broadcastSend({
+        rpcUrl: run.chain.rpcUrl,
+        senderMnemonic: run.primaryMnemonic,
+        prefix: "nolus",
+        recipient: run.secondary.address,
+        amount: coin,
+        fee,
+        memo: "nolus-e2e-t3-flow"
+      })
+  });
+  testInfo.annotations.push({ type: "t3-send", description: `broadcast at height ${result.height}` });
 
   await expect
     .poll(() => readSwapFromNls(page), {

--- a/e2e/src/t3/flows/send.spec.ts
+++ b/e2e/src/t3/flows/send.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "./support.js";
+import type { Page } from "@playwright/test";
+import type { RunContext } from "./support.js";
+import {
+  getRunContext,
+  journaledSpend,
+  reportLeftover,
+  skipIfHalted,
+  classifyAndRoute,
+  annotateSkipAndStop
+} from "./support.js";
+import { connectKeplr, waitForAppShell, assertConnected } from "../../t2/appDriver.js";
+import {
+  requireOrSkip,
+  probeNativeMicroBalance,
+  allowStagingNoise,
+  readSwapFromNls,
+  waitForSwapReady
+} from "../../t2/matrixHelpers.js";
+import { makeSendCoin, makeFee, DEFAULT_GAS_LIMIT, NATIVE_DENOM } from "../../transfer.js";
+import { broadcastSend } from "../../broadcast.js";
+import type { BroadcastResult } from "../../broadcast.js";
+
+// Native NLS send primary -> wallet-2 through the engine (#283 flow 4). The primary is the sole
+// governed spend actor, so this is engine.spend with a Node-side broadcast execute. The sender's
+// debit is asserted through the rendered Swap From=NLS balance (the receive.spec technique); the
+// receiver's credit is confirmed through the host-resolver balances read (asserting a second
+// rendered session would need a reconnect and break the single-broadcast model). No matrix cell —
+// the balance surface asserted is the swap dialog, not the assets table the funded-gated cell names.
+
+const SEND_NLS = "0.001";
+const TERMINAL_MS = 90000;
+
+let run: RunContext;
+
+async function openSwapNls(page: Page, address: string): Promise<void> {
+  await page.goto("/assets", { waitUntil: "domcontentloaded" });
+  await waitForAppShell(page);
+  await connectKeplr(page, run.labels);
+  await assertConnected(page, address);
+  await page.goto("/assets/swap", { waitUntil: "domcontentloaded" });
+  await page.locator("#swap-1").waitFor({ state: "visible", timeout: 15000 });
+  await waitForSwapReady(page);
+  await page.locator("#dialog-scroll button.button-secondary").first().click();
+}
+
+test.beforeAll(async () => {
+  run = await getRunContext(test.info());
+});
+
+test.afterAll(async () => {
+  if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
+});
+
+test("a native send debits the sender and credits wallet-2 through the engine", async ({
+  page,
+  budget,
+  wallet
+}, testInfo) => {
+  skipIfHalted(testInfo, run);
+  test.setTimeout(TERMINAL_MS + 60000);
+  budget.route = "/assets/swap";
+  allowStagingNoise(budget);
+
+  const coin = makeSendCoin(SEND_NLS);
+  const fee = makeFee(DEFAULT_GAS_LIMIT, run.chain.gasPrice, NATIVE_DENOM);
+  const grossMicro = BigInt(coin.amount) + BigInt(fee.amount[0]?.amount ?? "0");
+  const senderBalance = await probeNativeMicroBalance(run.ctx, wallet.address);
+  requireOrSkip(
+    testInfo,
+    run.matrix.expectFunded,
+    senderBalance > grossMicro,
+    `primary holds ${senderBalance.toString()} micro-NLS, below the ${grossMicro.toString()} for a send plus fee`
+  );
+
+  await openSwapNls(page, wallet.address);
+  const renderedBefore = await readSwapFromNls(page);
+  const receiverBefore = await probeNativeMicroBalance(run.ctx, run.secondary.address);
+
+  let result: BroadcastResult | undefined;
+  try {
+    const outcome = await journaledSpend(run, {
+      spec: "t3-flow-send",
+      action: "native-send",
+      walletRole: "primary",
+      walletKey: run.primary.key,
+      items: [{ denom: "nls", micro: grossMicro }],
+      denoms: [{ denom: NATIVE_DENOM, micro: grossMicro.toString() }],
+      memo: "nolus-e2e-t3-flow",
+      outcomeFrom: (value: BroadcastResult) => ({ txHash: value.txHash, height: value.height }),
+      execute: () =>
+        broadcastSend({
+          rpcUrl: run.chain.rpcUrl,
+          senderMnemonic: run.primaryMnemonic,
+          prefix: "nolus",
+          recipient: run.secondary.address,
+          amount: coin,
+          fee,
+          memo: "nolus-e2e-t3-flow"
+        })
+    });
+    if (outcome.status === "spend-cap-abort") {
+      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
+      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+    }
+    result = outcome.status === "committed" ? outcome.value : undefined;
+  } catch (error) {
+    reportLeftover(run, testInfo, { terminal: "app-failure" });
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
+  testInfo.annotations.push({ type: "t3-send", description: `broadcast at height ${result?.height ?? 0}` });
+
+  await expect
+    .poll(() => readSwapFromNls(page), {
+      message: "the sender's rendered NLS balance should fall after the send",
+      timeout: TERMINAL_MS,
+      intervals: [2000, 3000, 5000, 5000, 5000, 5000]
+    })
+    .toBeLessThan(renderedBefore);
+
+  await expect
+    .poll(() => probeNativeMicroBalance(run.ctx, run.secondary.address), {
+      message: "wallet-2 should be credited the sent amount",
+      timeout: TERMINAL_MS,
+      intervals: [2000, 3000, 5000, 5000]
+    })
+    .toBeGreaterThan(receiverBefore);
+
+  reportLeftover(run, testInfo, { terminal: "success" });
+});

--- a/e2e/src/t3/flows/seq.test.ts
+++ b/e2e/src/t3/flows/seq.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { createSeqAllocator, highestIntentSeq, seqAllocatorFromJournal } from "./seq.js";
+import { buildIntent, buildOutcome } from "../journal.js";
+
+function intent(seq: number) {
+  return buildIntent({
+    seq,
+    ts: "2026-07-17T12:00:00.000Z",
+    spec: "flow",
+    walletRole: "primary",
+    action: "native-send",
+    denoms: []
+  });
+}
+
+describe("highestIntentSeq", () => {
+  it("returns 0 for an empty journal", () => {
+    expect(highestIntentSeq([])).toBe(0);
+  });
+
+  it("returns the maximum intent seq and ignores outcome records", () => {
+    const records = [
+      intent(1),
+      intent(4),
+      buildOutcome({ seq: 9, ts: "2026-07-17T12:00:01.000Z", status: "committed" })
+    ];
+    expect(highestIntentSeq(records)).toBe(4);
+  });
+});
+
+describe("createSeqAllocator", () => {
+  it("issues a monotonically increasing sequence from the start", () => {
+    const alloc = createSeqAllocator(3);
+    expect(alloc.peek()).toBe(3);
+    expect(alloc.next()).toBe(3);
+    expect(alloc.next()).toBe(4);
+    expect(alloc.peek()).toBe(5);
+  });
+
+  it("rejects a non-positive or non-integer start", () => {
+    expect(() => createSeqAllocator(0)).toThrow(/positive integer/);
+    expect(() => createSeqAllocator(1.5)).toThrow(/positive integer/);
+  });
+});
+
+describe("seqAllocatorFromJournal", () => {
+  it("seeds one past the highest journaled intent so a resumed run never collides", () => {
+    const alloc = seqAllocatorFromJournal([intent(2), intent(7)]);
+    expect(alloc.next()).toBe(8);
+  });
+
+  it("starts at 1 for an empty journal", () => {
+    expect(seqAllocatorFromJournal([]).next()).toBe(1);
+  });
+});

--- a/e2e/src/t3/flows/seq.ts
+++ b/e2e/src/t3/flows/seq.ts
@@ -1,0 +1,52 @@
+import type { JournalRecord } from "../journal.js";
+import { isIntent } from "../journal.js";
+
+export interface SeqAllocator {
+  /** The next unused seq, advancing the counter. */
+  next(): number;
+  /** The seq `next()` would return, without advancing. */
+  peek(): number;
+}
+
+/**
+ * The highest intent seq already present in a journal, or 0 when there are none. A run seeds
+ * its allocator above this so a resumed journal (a crash left write-ahead intents on disk) can
+ * never re-issue a seq that already names an earlier intent — a collision would corrupt the
+ * intent/outcome matching `unmatchedIntents` relies on.
+ */
+export function highestIntentSeq(records: JournalRecord[]): number {
+  let max = 0;
+  for (const record of records) {
+    if (isIntent(record) && record.seq > max) {
+      max = record.seq;
+    }
+  }
+  return max;
+}
+
+/**
+ * A run-scoped monotonic seq allocator. One instance is shared by every flow spec through the
+ * run singleton (workers = 1, so one process holds one counter), which is what keeps intents
+ * from different specs from colliding on a hardcoded seq.
+ */
+export function createSeqAllocator(start: number): SeqAllocator {
+  if (!Number.isInteger(start) || start < 1) {
+    throw new Error(`seq allocator start must be a positive integer (got ${start})`);
+  }
+  let nextSeq = start;
+  return {
+    next(): number {
+      const value = nextSeq;
+      nextSeq += 1;
+      return value;
+    },
+    peek(): number {
+      return nextSeq;
+    }
+  };
+}
+
+/** Seed an allocator at one past the highest seq already journaled. */
+export function seqAllocatorFromJournal(records: JournalRecord[]): SeqAllocator {
+  return createSeqAllocator(highestIntentSeq(records) + 1);
+}

--- a/e2e/src/t3/flows/sideSelection.test.ts
+++ b/e2e/src/t3/flows/sideSelection.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  dayOfYearUtc,
+  parityLeaseSide,
+  resolveLeaseSideSetting,
+  resolveLeaseSides,
+  resolveShortLeaseStable
+} from "./sideSelection.js";
+
+describe("dayOfYearUtc", () => {
+  it("returns 1 on the first day of the year", () => {
+    expect(dayOfYearUtc(new Date("2026-01-01T00:00:00.000Z"))).toBe(1);
+  });
+
+  it("counts through to a mid-year date in UTC", () => {
+    expect(dayOfYearUtc(new Date("2026-07-17T23:59:59.000Z"))).toBe(198);
+  });
+
+  it("is unaffected by a local-evening timestamp that is still the same UTC day", () => {
+    expect(dayOfYearUtc(new Date("2026-03-01T00:00:00.000Z"))).toBe(60);
+  });
+});
+
+describe("parityLeaseSide", () => {
+  it("opens a long on an even day-of-year and a short on an odd one", () => {
+    expect(parityLeaseSide(198)).toBe("long");
+    expect(parityLeaseSide(197)).toBe("short");
+  });
+});
+
+describe("resolveLeaseSideSetting", () => {
+  it("returns an undefined setting when the override is unset or blank", () => {
+    expect(resolveLeaseSideSetting(undefined)).toEqual({ ok: true, setting: undefined });
+    expect(resolveLeaseSideSetting("  ")).toEqual({ ok: true, setting: undefined });
+  });
+
+  it("accepts each named side case-insensitively", () => {
+    expect(resolveLeaseSideSetting("LONG")).toEqual({ ok: true, setting: "long" });
+    expect(resolveLeaseSideSetting("short")).toEqual({ ok: true, setting: "short" });
+    expect(resolveLeaseSideSetting("Both")).toEqual({ ok: true, setting: "both" });
+  });
+
+  it("rejects an unrecognized value instead of silently defaulting", () => {
+    const result = resolveLeaseSideSetting("sideways");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("E2E_LEASE_SIDE");
+    }
+  });
+});
+
+describe("resolveLeaseSides", () => {
+  it("falls back to the parity pick when the setting is undefined", () => {
+    expect(resolveLeaseSides(undefined, 198)).toEqual(["long"]);
+    expect(resolveLeaseSides(undefined, 197)).toEqual(["short"]);
+  });
+
+  it("returns the single pinned side", () => {
+    expect(resolveLeaseSides("short", 198)).toEqual(["short"]);
+  });
+
+  it("expands both to long then short", () => {
+    expect(resolveLeaseSides("both", 198)).toEqual(["long", "short"]);
+  });
+});
+
+describe("resolveShortLeaseStable", () => {
+  it("returns the ticker of the first lease-group currency", () => {
+    const currencies = [
+      { ticker: "USDC", group: "lpn" },
+      { ticker: "ST_ATOM", group: "lease" },
+      { ticker: "NLS", group: "native" }
+    ];
+    expect(resolveShortLeaseStable(currencies)).toBe("ST_ATOM");
+  });
+
+  it("throws when no lease-group currency is present", () => {
+    expect(() => resolveShortLeaseStable([{ ticker: "USDC", group: "lpn" }])).toThrow(/lease-group/);
+  });
+
+  it("throws on a non-array payload", () => {
+    expect(() => resolveShortLeaseStable(undefined)).toThrow(/lease-group/);
+  });
+});

--- a/e2e/src/t3/flows/sideSelection.ts
+++ b/e2e/src/t3/flows/sideSelection.ts
@@ -6,6 +6,7 @@ export type LeaseSideSetting = LeaseSide | "both";
 export type SideSettingResult = { ok: true; setting: LeaseSideSetting | undefined } | { ok: false; error: string };
 
 const LEASE_GROUP = "lease";
+const MS_PER_DAY = 86400000;
 
 /**
  * Day of year (1–366) in UTC. The lease side alternates on this parity so consecutive
@@ -15,7 +16,7 @@ const LEASE_GROUP = "lease";
 export function dayOfYearUtc(date: Date): number {
   const startOfYear = Date.UTC(date.getUTCFullYear(), 0, 1);
   const elapsed = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()) - startOfYear;
-  return Math.floor(elapsed / 86400000) + 1;
+  return Math.floor(elapsed / MS_PER_DAY) + 1;
 }
 
 /** Even day-of-year opens a long, odd opens a short — the default alternation scheme. */

--- a/e2e/src/t3/flows/sideSelection.ts
+++ b/e2e/src/t3/flows/sideSelection.ts
@@ -1,0 +1,75 @@
+import { readString } from "../../t2/matrixHelpers.js";
+
+export type LeaseSide = "long" | "short";
+export type LeaseSideSetting = LeaseSide | "both";
+
+export type SideSettingResult = { ok: true; setting: LeaseSideSetting | undefined } | { ok: false; error: string };
+
+const LEASE_GROUP = "lease";
+
+/**
+ * Day of year (1–366) in UTC. The lease side alternates on this parity so consecutive
+ * daily runs exercise both directions without an operator toggle — computed in UTC so the
+ * agent's local timezone can never flip the selection relative to CI.
+ */
+export function dayOfYearUtc(date: Date): number {
+  const startOfYear = Date.UTC(date.getUTCFullYear(), 0, 1);
+  const elapsed = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()) - startOfYear;
+  return Math.floor(elapsed / 86400000) + 1;
+}
+
+/** Even day-of-year opens a long, odd opens a short — the default alternation scheme. */
+export function parityLeaseSide(dayOfYear: number): LeaseSide {
+  return dayOfYear % 2 === 0 ? "long" : "short";
+}
+
+/**
+ * Parse the optional `E2E_LEASE_SIDE` override. Unset returns `{ ok: true, setting: undefined }`
+ * (parity decides); `long`/`short`/`both` are the only accepted values — anything else is a hard
+ * config error rather than a silent fallback, so a typo can never quietly pin one side.
+ */
+export function resolveLeaseSideSetting(raw: string | undefined): SideSettingResult {
+  const trimmed = raw?.trim().toLowerCase();
+  if (trimmed === undefined || trimmed === "") {
+    return { ok: true, setting: undefined };
+  }
+  if (trimmed === "long" || trimmed === "short" || trimmed === "both") {
+    return { ok: true, setting: trimmed };
+  }
+  return { ok: false, error: `E2E_LEASE_SIDE must be one of long|short|both (got "${raw ?? ""}")` };
+}
+
+/**
+ * The concrete lease sides a run opens: the parity pick when unset, the named side when pinned,
+ * or both directions when `both` (reserved for a future raised-cap run — the caller must
+ * precondition-skip the second open when it would exceed the USDC cap).
+ */
+export function resolveLeaseSides(setting: LeaseSideSetting | undefined, dayOfYear: number): LeaseSide[] {
+  if (setting === undefined) {
+    return [parityLeaseSide(dayOfYear)];
+  }
+  if (setting === "both") {
+    return ["long", "short"];
+  }
+  return [setting];
+}
+
+/**
+ * The short lease's opened position is denominated in a protocol currency whose `group` is
+ * `lease`, NOT the USDC/LPN downpayment — a short asserts against this stable ticker so the
+ * value read is the collateral leg, never the vacuous $0-priced NLS. Throws loudly when no
+ * lease-group currency is present so a drifted `/api/currencies` shape is a red, not an empty
+ * selection.
+ */
+export function resolveShortLeaseStable(currencies: unknown): string {
+  const list = Array.isArray(currencies) ? currencies : [];
+  for (const entry of list) {
+    if (readString(entry, "group") === LEASE_GROUP) {
+      const ticker = readString(entry, "ticker");
+      if (ticker !== undefined) {
+        return ticker;
+      }
+    }
+  }
+  throw new Error("no lease-group currency found for the short position stable");
+}

--- a/e2e/src/t3/flows/stake.spec.ts
+++ b/e2e/src/t3/flows/stake.spec.ts
@@ -36,7 +36,7 @@ interface Delegation {
 }
 
 async function delegations(ctx: RunContext["ctx"], address: string): Promise<Delegation[]> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${address}`);
+  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${encodeURIComponent(address)}`);
   const list = typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).delegations : [];
   const out: Delegation[] = [];
   if (Array.isArray(list)) {
@@ -138,7 +138,7 @@ test("stake undelegate is precondition-gated on the per-validator unbonding-entr
   await typeAmount(page, "receive-send", DUST_NLS);
   const requiredMicro = BigInt(toMicroAmount(DUST_NLS, NATIVE_DECIMALS));
   try {
-    await journaledSpend(run, {
+    const outcome = await journaledSpend(run, {
       spec: "t3-flow-stake",
       action: "undelegate",
       walletRole: "primary",
@@ -148,6 +148,10 @@ test("stake undelegate is precondition-gated on the per-validator unbonding-entr
       memo: `undelegate target ${target ?? ""}`,
       execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "undelegate"), terminalMs: TERMINAL_MS })
     });
+    if (outcome.status === "spend-cap-abort") {
+      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
+      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+    }
   } catch (error) {
     reportLeftover(run, testInfo, { terminal: "app-failure" });
     classifyAndRoute(testInfo, error, run.chain.rpcUrl);
@@ -160,7 +164,7 @@ test("stake undelegate is precondition-gated on the per-validator unbonding-entr
 });
 
 async function maturingRedelegationCount(ctx: RunContext["ctx"], address: string): Promise<number> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${address}`);
+  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${encodeURIComponent(address)}`);
   const list = typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).redelegation : [];
   return Array.isArray(list) ? list.length : 0;
 }
@@ -186,7 +190,7 @@ test("stake redelegate runs through the engine redelegate mutex, gated on no mat
   await connectFlow(page, run, "/stake");
   const requiredMicro = BigInt(toMicroAmount(DUST_NLS, NATIVE_DECIMALS));
   try {
-    await journaledSpend(run, {
+    const outcome = await journaledSpend(run, {
       spec: "t3-flow-stake",
       action: "redelegate",
       walletRole: "primary",
@@ -203,6 +207,10 @@ test("stake redelegate runs through the engine redelegate mutex, gated on no mat
         await submitForm(page, { submitLabel: messageValue(run.locale, "redelegate"), terminalMs: TERMINAL_MS });
       }
     });
+    if (outcome.status === "spend-cap-abort") {
+      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
+      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+    }
   } catch (error) {
     reportLeftover(run, testInfo, { terminal: "app-failure" });
     classifyAndRoute(testInfo, error, run.chain.rpcUrl);
@@ -212,7 +220,7 @@ test("stake redelegate runs through the engine redelegate mutex, gated on no mat
 });
 
 async function accruedRewardMicro(ctx: RunContext["ctx"], address: string): Promise<bigint> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${address}`);
+  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${encodeURIComponent(address)}`);
   const rewards = typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).rewards : [];
   let total = 0n;
   if (Array.isArray(rewards)) {
@@ -245,7 +253,7 @@ test("stake claim is tolerance-gated and skips cleanly when accrued rewards are 
 
   await connectFlow(page, run, "/stake");
   try {
-    await journaledSpend(run, {
+    const outcome = await journaledSpend(run, {
       spec: "t3-flow-stake",
       action: "stake-claim",
       walletRole: "primary",
@@ -257,6 +265,10 @@ test("stake claim is tolerance-gated and skips cleanly when accrued rewards are 
         await submitForm(page, { submitLabel: messageValue(run.locale, "claim"), terminalMs: TERMINAL_MS });
       }
     });
+    if (outcome.status === "spend-cap-abort") {
+      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
+      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+    }
   } catch (error) {
     reportLeftover(run, testInfo, { terminal: "app-failure" });
     classifyAndRoute(testInfo, error, run.chain.rpcUrl);

--- a/e2e/src/t3/flows/stake.spec.ts
+++ b/e2e/src/t3/flows/stake.spec.ts
@@ -1,0 +1,266 @@
+import { test, expect } from "./support.js";
+import type { RunContext } from "./support.js";
+import {
+  getRunContext,
+  connectFlow,
+  journaledSpend,
+  reportLeftover,
+  skipIfHalted,
+  classifyAndRoute,
+  annotateSkipAndStop
+} from "./support.js";
+import { messageValue } from "../../t2/appDriver.js";
+import { typeAmount, requireOrSkip, probeNativeMicroBalance, readString } from "../../t2/matrixHelpers.js";
+import { NATIVE_DENOM, NATIVE_DECIMALS, toMicroAmount } from "../../transfer.js";
+import { Decimal } from "../../oracle/decimal.js";
+import { formatTokenBalance } from "../../oracle/format.js";
+import { submitForm } from "./formDriver.js";
+import { unbondingEntriesFor } from "./apiReads.js";
+import { pickUnbondingValidator, unbondingEntryGate } from "./preconditions.js";
+import { readJson } from "../runtime.js";
+
+// Stake delegate / undelegate / redelegate / claim of dust NLS (#283 flow 3). Undelegate is
+// precondition-gated on the 7-entry unbonding cap per validator (rotate when near it), redelegate
+// runs through the engine's redelegate mutex and is gated on no maturing redelegation, and claim
+// is accrual-dependent (skipped below a dust threshold). NLS token amounts (not USD, which is
+// vacuous at $0) are what these assert. Matrix label: flow-stake-delegated.
+
+const DUST_NLS = "0.001";
+const TERMINAL_MS = 120000;
+
+let run: RunContext;
+
+interface Delegation {
+  validatorAddress: string;
+  amountMicro: bigint;
+}
+
+async function delegations(ctx: RunContext["ctx"], address: string): Promise<Delegation[]> {
+  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${address}`);
+  const list = typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).delegations : [];
+  const out: Delegation[] = [];
+  if (Array.isArray(list)) {
+    for (const entry of list) {
+      const validatorAddress = readString(entry, "validator_address");
+      const amount = readString(entry, "balance") ?? readString(entry, "amount");
+      if (validatorAddress !== undefined && amount !== undefined && /^\d+$/.test(amount)) {
+        out.push({ validatorAddress, amountMicro: BigInt(amount) });
+      }
+    }
+  }
+  return out;
+}
+
+test.beforeAll(async () => {
+  run = await getRunContext(test.info());
+});
+
+test.afterAll(async () => {
+  if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
+});
+
+test("stake delegate of dust NLS renders the delegated amount matching the oracle", async ({
+  page,
+  budget,
+  wallet
+}, testInfo) => {
+  skipIfHalted(testInfo, run);
+  test.setTimeout(TERMINAL_MS * 2);
+  budget.route = "/stake/delegate";
+
+  const requiredMicro = BigInt(toMicroAmount(DUST_NLS, NATIVE_DECIMALS));
+  const balance = await probeNativeMicroBalance(run.ctx, wallet.address);
+  requireOrSkip(
+    testInfo,
+    run.matrix.expectFunded,
+    balance > requiredMicro,
+    `primary holds ${balance.toString()} micro-NLS, below the ${requiredMicro.toString()} a delegation needs`
+  );
+
+  await connectFlow(page, run, "/stake/delegate");
+  await typeAmount(page, "receive-send", DUST_NLS);
+  try {
+    const outcome = await journaledSpend(run, {
+      spec: "t3-flow-stake",
+      action: "delegate",
+      walletRole: "primary",
+      walletKey: run.primary.key,
+      items: [{ denom: "nls", micro: requiredMicro }],
+      denoms: [{ denom: NATIVE_DENOM, micro: requiredMicro.toString() }],
+      execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "delegate"), terminalMs: TERMINAL_MS })
+    });
+    if (outcome.status === "spend-cap-abort") {
+      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
+      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+    }
+  } catch (error) {
+    reportLeftover(run, testInfo, { terminal: "app-failure" });
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
+
+  testInfo.annotations.push({ type: "matrix", description: "flow-stake-delegated" });
+  await page.goto("/stake", { waitUntil: "domcontentloaded" });
+  const delegated = await delegations(run.ctx, wallet.address);
+  const total = delegated.reduce((sum, d) => sum + d.amountMicro, 0n);
+  requireOrSkip(testInfo, run.matrix.expectFunded, total > 0n, "no delegation enumerated after delegate");
+  const renderedAmount = formatTokenBalance(Decimal.fromAtomics(total.toString(), NATIVE_DECIMALS));
+  const stakeText = await page.locator("#app").innerText();
+  expect(stakeText).toContain(renderedAmount);
+
+  reportLeftover(run, testInfo, { terminal: "success" });
+});
+
+test("stake undelegate is precondition-gated on the per-validator unbonding-entry cap", async ({
+  page,
+  budget,
+  wallet
+}, testInfo) => {
+  skipIfHalted(testInfo, run);
+  test.setTimeout(TERMINAL_MS * 2);
+  budget.route = "/stake/undelegate";
+
+  const delegated = await delegations(run.ctx, wallet.address);
+  requireOrSkip(testInfo, run.matrix.expectFunded, delegated.length > 0, "no delegation to undelegate");
+  const candidates = await Promise.all(
+    delegated.map(async (d) => ({
+      validatorAddress: d.validatorAddress,
+      entries: await unbondingEntriesFor(run.ctx, wallet.address, d.validatorAddress)
+    }))
+  );
+  const target = pickUnbondingValidator(candidates);
+  if (target === undefined) {
+    annotateSkipAndStop(testInfo, "precondition", "every candidate validator is at the unbonding-entry cap");
+  }
+  const gate = unbondingEntryGate(candidates.find((c) => c.validatorAddress === target)?.entries ?? 0);
+  expect(gate.ok).toBe(true);
+
+  await connectFlow(page, run, "/stake/undelegate");
+  await typeAmount(page, "receive-send", DUST_NLS);
+  const requiredMicro = BigInt(toMicroAmount(DUST_NLS, NATIVE_DECIMALS));
+  try {
+    await journaledSpend(run, {
+      spec: "t3-flow-stake",
+      action: "undelegate",
+      walletRole: "primary",
+      walletKey: run.primary.key,
+      items: [{ denom: "nls", micro: 0n }],
+      denoms: [{ denom: NATIVE_DENOM, micro: requiredMicro.toString() }],
+      memo: `undelegate target ${target ?? ""}`,
+      execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "undelegate"), terminalMs: TERMINAL_MS })
+    });
+  } catch (error) {
+    reportLeftover(run, testInfo, { terminal: "app-failure" });
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
+
+  reportLeftover(run, testInfo, {
+    terminal: "success",
+    warnings: ["undelegation enters a 21-day unbonding window; the entry is expected leftover state"]
+  });
+});
+
+async function maturingRedelegationCount(ctx: RunContext["ctx"], address: string): Promise<number> {
+  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${address}`);
+  const list = typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).redelegation : [];
+  return Array.isArray(list) ? list.length : 0;
+}
+
+test("stake redelegate runs through the engine redelegate mutex, gated on no maturing redelegation", async ({
+  page,
+  budget,
+  wallet
+}, testInfo) => {
+  skipIfHalted(testInfo, run);
+  test.setTimeout(TERMINAL_MS * 2);
+  budget.route = "/stake";
+
+  const delegated = await delegations(run.ctx, wallet.address);
+  requireOrSkip(testInfo, run.matrix.expectFunded, delegated.length > 0, "no delegation to redelegate");
+  const maturing = await maturingRedelegationCount(run.ctx, wallet.address);
+  if (maturing > 0) {
+    annotateSkipAndStop(testInfo, "precondition", "a redelegation is still maturing; a second is locked");
+  }
+  const source = delegated[0]?.validatorAddress ?? "";
+  expect(source).not.toBe("");
+
+  await connectFlow(page, run, "/stake");
+  const requiredMicro = BigInt(toMicroAmount(DUST_NLS, NATIVE_DECIMALS));
+  try {
+    await journaledSpend(run, {
+      spec: "t3-flow-stake",
+      action: "redelegate",
+      walletRole: "primary",
+      walletKey: run.primary.key,
+      items: [{ denom: "nls", micro: 0n }],
+      denoms: [{ denom: NATIVE_DENOM, micro: requiredMicro.toString() }],
+      memo: `redelegate from ${source}`,
+      execute: async () => {
+        await page
+          .getByRole("button", { name: /redelegate/i })
+          .first()
+          .click({ timeout: TERMINAL_MS });
+        await typeAmount(page, "receive-send", DUST_NLS);
+        await submitForm(page, { submitLabel: messageValue(run.locale, "redelegate"), terminalMs: TERMINAL_MS });
+      }
+    });
+  } catch (error) {
+    reportLeftover(run, testInfo, { terminal: "app-failure" });
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
+
+  reportLeftover(run, testInfo, { terminal: "success" });
+});
+
+async function accruedRewardMicro(ctx: RunContext["ctx"], address: string): Promise<bigint> {
+  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${address}`);
+  const rewards = typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).rewards : [];
+  let total = 0n;
+  if (Array.isArray(rewards)) {
+    for (const entry of rewards) {
+      const amount = readString(entry, "amount") ?? readString(entry, "balance");
+      if (amount !== undefined && /^\d+$/.test(amount)) total += BigInt(amount);
+    }
+  }
+  return total;
+}
+
+test("stake claim is tolerance-gated and skips cleanly when accrued rewards are below dust", async ({
+  page,
+  budget,
+  wallet
+}, testInfo) => {
+  skipIfHalted(testInfo, run);
+  test.setTimeout(TERMINAL_MS * 2);
+  budget.route = "/stake";
+
+  const dustMicro = BigInt(toMicroAmount(DUST_NLS, NATIVE_DECIMALS));
+  const accrued = await accruedRewardMicro(run.ctx, wallet.address);
+  requireOrSkip(
+    testInfo,
+    run.matrix.expectFunded,
+    accrued >= dustMicro,
+    "accrued rewards are below the dust threshold"
+  );
+  expect(accrued >= dustMicro).toBe(true);
+
+  await connectFlow(page, run, "/stake");
+  try {
+    await journaledSpend(run, {
+      spec: "t3-flow-stake",
+      action: "stake-claim",
+      walletRole: "primary",
+      walletKey: run.primary.key,
+      items: [{ denom: "nls", micro: 0n }],
+      denoms: [{ denom: NATIVE_DENOM, micro: accrued.toString() }],
+      execute: async () => {
+        await page.getByRole("button", { name: /claim/i }).first().click({ timeout: TERMINAL_MS });
+        await submitForm(page, { submitLabel: messageValue(run.locale, "claim"), terminalMs: TERMINAL_MS });
+      }
+    });
+  } catch (error) {
+    reportLeftover(run, testInfo, { terminal: "app-failure" });
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
+
+  reportLeftover(run, testInfo, { terminal: "success" });
+});

--- a/e2e/src/t3/flows/stake.spec.ts
+++ b/e2e/src/t3/flows/stake.spec.ts
@@ -3,11 +3,10 @@ import type { RunContext } from "./support.js";
 import {
   getRunContext,
   connectFlow,
-  journaledSpend,
   reportLeftover,
   skipIfHalted,
-  classifyAndRoute,
-  annotateSkipAndStop
+  annotateSkipAndStop,
+  spendCommittedOrSkip
 } from "./support.js";
 import { messageValue } from "../../t2/appDriver.js";
 import { typeAmount, requireOrSkip, probeNativeMicroBalance, readString } from "../../t2/matrixHelpers.js";
@@ -79,24 +78,15 @@ test("stake delegate of dust NLS renders the delegated amount matching the oracl
 
   await connectFlow(page, run, "/stake/delegate");
   await typeAmount(page, "receive-send", DUST_NLS);
-  try {
-    const outcome = await journaledSpend(run, {
-      spec: "t3-flow-stake",
-      action: "delegate",
-      walletRole: "primary",
-      walletKey: run.primary.key,
-      items: [{ denom: "nls", micro: requiredMicro }],
-      denoms: [{ denom: NATIVE_DENOM, micro: requiredMicro.toString() }],
-      execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "delegate"), terminalMs: TERMINAL_MS })
-    });
-    if (outcome.status === "spend-cap-abort") {
-      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
-      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
-    }
-  } catch (error) {
-    reportLeftover(run, testInfo, { terminal: "app-failure" });
-    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
-  }
+  await spendCommittedOrSkip(testInfo, run, {
+    spec: "t3-flow-stake",
+    action: "delegate",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "nls", micro: requiredMicro }],
+    denoms: [{ denom: NATIVE_DENOM, micro: requiredMicro.toString() }],
+    execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "delegate"), terminalMs: TERMINAL_MS })
+  });
 
   testInfo.annotations.push({ type: "matrix", description: "flow-stake-delegated" });
   await page.goto("/stake", { waitUntil: "domcontentloaded" });
@@ -137,25 +127,16 @@ test("stake undelegate is precondition-gated on the per-validator unbonding-entr
   await connectFlow(page, run, "/stake/undelegate");
   await typeAmount(page, "receive-send", DUST_NLS);
   const requiredMicro = BigInt(toMicroAmount(DUST_NLS, NATIVE_DECIMALS));
-  try {
-    const outcome = await journaledSpend(run, {
-      spec: "t3-flow-stake",
-      action: "undelegate",
-      walletRole: "primary",
-      walletKey: run.primary.key,
-      items: [{ denom: "nls", micro: 0n }],
-      denoms: [{ denom: NATIVE_DENOM, micro: requiredMicro.toString() }],
-      memo: `undelegate target ${target ?? ""}`,
-      execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "undelegate"), terminalMs: TERMINAL_MS })
-    });
-    if (outcome.status === "spend-cap-abort") {
-      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
-      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
-    }
-  } catch (error) {
-    reportLeftover(run, testInfo, { terminal: "app-failure" });
-    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
-  }
+  await spendCommittedOrSkip(testInfo, run, {
+    spec: "t3-flow-stake",
+    action: "undelegate",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "nls", micro: 0n }],
+    denoms: [{ denom: NATIVE_DENOM, micro: requiredMicro.toString() }],
+    memo: `undelegate target ${target}`,
+    execute: () => submitForm(page, { submitLabel: messageValue(run.locale, "undelegate"), terminalMs: TERMINAL_MS })
+  });
 
   reportLeftover(run, testInfo, {
     terminal: "success",
@@ -189,32 +170,23 @@ test("stake redelegate runs through the engine redelegate mutex, gated on no mat
 
   await connectFlow(page, run, "/stake");
   const requiredMicro = BigInt(toMicroAmount(DUST_NLS, NATIVE_DECIMALS));
-  try {
-    const outcome = await journaledSpend(run, {
-      spec: "t3-flow-stake",
-      action: "redelegate",
-      walletRole: "primary",
-      walletKey: run.primary.key,
-      items: [{ denom: "nls", micro: 0n }],
-      denoms: [{ denom: NATIVE_DENOM, micro: requiredMicro.toString() }],
-      memo: `redelegate from ${source}`,
-      execute: async () => {
-        await page
-          .getByRole("button", { name: /redelegate/i })
-          .first()
-          .click({ timeout: TERMINAL_MS });
-        await typeAmount(page, "receive-send", DUST_NLS);
-        await submitForm(page, { submitLabel: messageValue(run.locale, "redelegate"), terminalMs: TERMINAL_MS });
-      }
-    });
-    if (outcome.status === "spend-cap-abort") {
-      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
-      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+  await spendCommittedOrSkip(testInfo, run, {
+    spec: "t3-flow-stake",
+    action: "redelegate",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "nls", micro: 0n }],
+    denoms: [{ denom: NATIVE_DENOM, micro: requiredMicro.toString() }],
+    memo: `redelegate from ${source}`,
+    execute: async () => {
+      await page
+        .getByRole("button", { name: /redelegate/i })
+        .first()
+        .click({ timeout: TERMINAL_MS });
+      await typeAmount(page, "receive-send", DUST_NLS);
+      await submitForm(page, { submitLabel: messageValue(run.locale, "redelegate"), terminalMs: TERMINAL_MS });
     }
-  } catch (error) {
-    reportLeftover(run, testInfo, { terminal: "app-failure" });
-    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
-  }
+  });
 
   reportLeftover(run, testInfo, { terminal: "success" });
 });
@@ -252,27 +224,18 @@ test("stake claim is tolerance-gated and skips cleanly when accrued rewards are 
   expect(accrued >= dustMicro).toBe(true);
 
   await connectFlow(page, run, "/stake");
-  try {
-    const outcome = await journaledSpend(run, {
-      spec: "t3-flow-stake",
-      action: "stake-claim",
-      walletRole: "primary",
-      walletKey: run.primary.key,
-      items: [{ denom: "nls", micro: 0n }],
-      denoms: [{ denom: NATIVE_DENOM, micro: accrued.toString() }],
-      execute: async () => {
-        await page.getByRole("button", { name: /claim/i }).first().click({ timeout: TERMINAL_MS });
-        await submitForm(page, { submitLabel: messageValue(run.locale, "claim"), terminalMs: TERMINAL_MS });
-      }
-    });
-    if (outcome.status === "spend-cap-abort") {
-      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
-      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+  await spendCommittedOrSkip(testInfo, run, {
+    spec: "t3-flow-stake",
+    action: "stake-claim",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "nls", micro: 0n }],
+    denoms: [{ denom: NATIVE_DENOM, micro: accrued.toString() }],
+    execute: async () => {
+      await page.getByRole("button", { name: /claim/i }).first().click({ timeout: TERMINAL_MS });
+      await submitForm(page, { submitLabel: messageValue(run.locale, "claim"), terminalMs: TERMINAL_MS });
     }
-  } catch (error) {
-    reportLeftover(run, testInfo, { terminal: "app-failure" });
-    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
-  }
+  });
 
   reportLeftover(run, testInfo, { terminal: "success" });
 });

--- a/e2e/src/t3/flows/support.ts
+++ b/e2e/src/t3/flows/support.ts
@@ -1,0 +1,322 @@
+import type { Page, TestInfo } from "@playwright/test";
+import { test as t2Test, expect } from "../../t2/support.js";
+import type { OriginContext, ConnectLabels } from "../../t2/appDriver.js";
+import {
+  resolveOrigin,
+  fetchLocale,
+  readConnectLabels,
+  connectKeplr,
+  waitForAppShell,
+  assertConnected
+} from "../../t2/appDriver.js";
+import { readString } from "../../t2/matrixHelpers.js";
+import { parseT2Config, parseMatrixConfig, parseT3Config, DEFAULT_USD_TOLERANCE } from "../../config.js";
+import type { T3Config, MatrixConfig } from "../../config.js";
+import { createWalletIdentity } from "../../signer.js";
+import { SerialQueue } from "../serialQueue.js";
+import { spendCapFromMicros } from "../spendCap.js";
+import type { SpendItem, SpendCap } from "../spendCap.js";
+import { TxEngine } from "../engine.js";
+import type { SpendOutcome, WalletRoleConfig } from "../engine.js";
+import { JournalStore } from "../journalStore.js";
+import { buildIntent, buildOutcome } from "../journal.js";
+import type { DenomAmount, IntentAction, WalletRole } from "../journal.js";
+import { classify } from "../taxonomy.js";
+import type { FailureCategory } from "../taxonomy.js";
+import { readJson } from "../runtime.js";
+import { writeReportFile } from "../journalStore.js";
+import type { OpenLease, PendingUnbonding, TerminalPath } from "../report.js";
+import { seqAllocatorFromJournal } from "./seq.js";
+import type { SeqAllocator } from "./seq.js";
+import { dayOfYearUtc, resolveLeaseSideSetting, resolveLeaseSides } from "./sideSelection.js";
+import type { LeaseSide } from "./sideSelection.js";
+
+export { expect };
+
+/** The t2 fixture (scripted Keplr stub + budget) is reused verbatim; the engine is the singleton. */
+export const test = t2Test;
+
+const SKIP_ANNOTATION = "t3-flow-skip";
+const LEFTOVER_ANNOTATION = "t3-flow-leftover";
+
+export interface ChainSettings {
+  rpcUrl: string;
+  gasPrice: string;
+}
+
+/**
+ * The single value-moving substrate shared by every flow spec. Because the project runs with
+ * `--workers=1`, one worker process holds one module instance, so this really is one TxEngine,
+ * one SpendCap, one SerialQueue, one JournalStore and one seq allocator for the whole run — the
+ * only arrangement under which the per-run operator spend cap is meaningful.
+ */
+export interface RunContext {
+  ctx: OriginContext;
+  engine: TxEngine;
+  cap: SpendCap;
+  queue: SerialQueue;
+  store: JournalStore;
+  seq: SeqAllocator;
+  primary: WalletRoleConfig;
+  secondary: WalletRoleConfig;
+  primaryMnemonic: string;
+  secondaryMnemonic: string;
+  chain: ChainSettings;
+  t3: T3Config;
+  matrix: MatrixConfig;
+  locale: unknown;
+  labels: ConnectLabels;
+  usdTolerance: string;
+  leaseSides: LeaseSide[];
+}
+
+let runContext: RunContext | undefined;
+
+async function resolveChain(ctx: OriginContext, matrixRpc: string | undefined): Promise<ChainSettings> {
+  const config = await readJson(ctx, `${ctx.origin}/api/config`);
+  const networks =
+    typeof config === "object" && config !== null ? (config as Record<string, unknown>).networks : undefined;
+  const list: unknown[] = Array.isArray(networks) ? (networks as unknown[]) : [];
+  const nolus = list.find((n) => readString(n, "prefix") === "nolus" || readString(n, "key") === "NOLUS");
+  const rpcUrl = matrixRpc ?? readString(nolus, "rpc_url");
+  if (rpcUrl === undefined) {
+    throw new Error("could not resolve the Nolus chain rpc_url from /api/config or E2E_CHAIN_RPC");
+  }
+  const gasPriceRaw = readString(nolus, "gas_price");
+  if (gasPriceRaw === undefined) {
+    throw new Error("could not resolve the Nolus gas_price from /api/config");
+  }
+  const gasPrice = gasPriceRaw.replace(/[^0-9.]/g, "");
+  if (gasPrice === "") {
+    throw new Error(`Nolus gas_price from /api/config is unparseable: "${gasPriceRaw}"`);
+  }
+  return { rpcUrl, gasPrice };
+}
+
+/**
+ * Build (or return the already-built) run singleton. The first call resolves config, derives both
+ * wallet identities, reads the live chain settings, and constructs the engine bound to the shared
+ * queue/cap/store; every later call returns the same instance so halt state and cumulative spend
+ * carry across specs.
+ */
+interface FlowConfig {
+  t2: { primaryMnemonic: string; secondaryMnemonic: string };
+  t3: T3Config;
+  matrix: MatrixConfig;
+  leaseSetting: LeaseSide | "both" | undefined;
+}
+
+function parseFlowConfig(): FlowConfig {
+  const t2 = parseT2Config(process.env);
+  if (!t2.ok) throw new Error(`T2 config error: ${t2.errors.join("; ")}`);
+  const parsedT3 = parseT3Config(process.env);
+  if (!parsedT3.ok) throw new Error(`T3 config error: ${parsedT3.errors.join("; ")}`);
+  const matrix = parseMatrixConfig(process.env);
+  if (!matrix.ok) throw new Error(`matrix config error: ${matrix.errors.join("; ")}`);
+  const side = resolveLeaseSideSetting(process.env.E2E_LEASE_SIDE);
+  if (!side.ok) throw new Error(side.error);
+  return { t2: t2.config, t3: parsedT3.config, matrix: matrix.config, leaseSetting: side.setting };
+}
+
+async function deriveRoles(t2: FlowConfig["t2"]): Promise<{ primary: WalletRoleConfig; secondary: WalletRoleConfig }> {
+  return {
+    primary: { role: "primary", key: "primary", address: (await createWalletIdentity(t2.primaryMnemonic)).address },
+    secondary: {
+      role: "secondary",
+      key: "secondary",
+      address: (await createWalletIdentity(t2.secondaryMnemonic)).address
+    }
+  };
+}
+
+function constructEngine(
+  deps: { queue: SerialQueue; cap: SpendCap },
+  roles: { primary: WalletRoleConfig; secondary: WalletRoleConfig },
+  t3: T3Config,
+  testInfo: TestInfo
+): TxEngine {
+  return new TxEngine(deps, {
+    primary: roles.primary,
+    secondary: roles.secondary,
+    workers: testInfo.config.workers,
+    retries: testInfo.project.retries,
+    wallet2LowWaterMicro: BigInt(t3.wallet2LowWaterMicro)
+  });
+}
+
+export async function getRunContext(testInfo: TestInfo): Promise<RunContext> {
+  if (runContext !== undefined) {
+    return runContext;
+  }
+  const ctx = resolveOrigin();
+  const config = parseFlowConfig();
+  const roles = await deriveRoles(config.t2);
+  const chain = await resolveChain(ctx, config.matrix.chainRpc);
+  const locale = await fetchLocale(ctx);
+  const queue = new SerialQueue();
+  const cap = spendCapFromMicros({ nlsMicro: config.t3.spendCapNlsMicro, usdcMicro: config.t3.spendCapUsdcMicro });
+  const store = new JournalStore(config.t3.resultsDir);
+
+  runContext = {
+    ctx,
+    engine: constructEngine({ queue, cap }, roles, config.t3, testInfo),
+    cap,
+    queue,
+    store,
+    seq: seqAllocatorFromJournal(store.readAll()),
+    primary: roles.primary,
+    secondary: roles.secondary,
+    primaryMnemonic: config.t2.primaryMnemonic,
+    secondaryMnemonic: config.t2.secondaryMnemonic,
+    chain,
+    t3: config.t3,
+    matrix: config.matrix,
+    locale,
+    labels: readConnectLabels(locale),
+    usdTolerance: process.env.E2E_USD_TOLERANCE?.trim() || DEFAULT_USD_TOLERANCE,
+    leaseSides: resolveLeaseSides(config.leaseSetting, dayOfYearUtc(new Date()))
+  };
+  return runContext;
+}
+
+/** Reset the singleton — test-support only, called between the worker's specs is never needed. */
+export function resetRunContext(): void {
+  runContext = undefined;
+}
+
+/** Record a machine-readable skip and abort the current test as skipped (never a red). */
+export function annotateSkipAndStop(testInfo: TestInfo, category: FailureCategory, reason: string): void {
+  testInfo.annotations.push({ type: SKIP_ANNOTATION, description: `${category}: ${reason}` });
+  testInfo.skip(true, reason);
+}
+
+/**
+ * A spend-cap abort halts the engine; every later value-moving spec must skip cleanly rather than
+ * cascade EngineHaltedError reds. Call at the top of each value-moving test — returns true (after
+ * annotating + skipping) when the engine is already halted.
+ */
+export function skipIfHalted(testInfo: TestInfo, run: RunContext): void {
+  if (run.engine.halted) {
+    annotateSkipAndStop(testInfo, "precondition", `engine halted (${run.engine.reason ?? "unknown"})`);
+  }
+}
+
+/**
+ * Classify a caught flow error and route it: an `environment` or `precondition` failure is a
+ * clean skip (an operator/liquidity/timing state, never an app bug), while an `app` failure is
+ * re-thrown as a red. Always terminates the test — it never returns normally.
+ */
+export function classifyAndRoute(testInfo: TestInfo, error: unknown, rpcUrl: string): never {
+  const classification = classify({ error, rpcUrl });
+  if (classification.category === "app") {
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+  annotateSkipAndStop(testInfo, classification.category, `${classification.signal}: ${classification.reason}`);
+  throw new Error("unreachable");
+}
+
+export interface JournaledSpendParams<T> {
+  spec: string;
+  action: IntentAction;
+  walletRole: WalletRole;
+  walletKey: string;
+  items: SpendItem[];
+  denoms: DenomAmount[];
+  counterparty?: boolean;
+  memo?: string;
+  outcomeFrom?: (value: T) => { txHash?: string; height?: number };
+  execute: () => Promise<T>;
+}
+
+/**
+ * Run one governed spend through the engine with the full journal contract: a write-ahead intent
+ * before the broadcast, then a committed / aborted / failed outcome. A spend-cap abort is
+ * journaled as `aborted` and returned (the caller skips the remaining flow); a thrown broadcast
+ * error is journaled as `failed` with a classified, sanitized reason and re-thrown.
+ */
+function appendSettled<T>(
+  run: RunContext,
+  seq: number,
+  outcome: SpendOutcome<T>,
+  params: JournaledSpendParams<T>
+): void {
+  if (outcome.status === "committed") {
+    const extra = params.outcomeFrom?.(outcome.value) ?? {};
+    run.store.append(buildOutcome({ seq, ts: new Date().toISOString(), status: "committed", ...extra }));
+    return;
+  }
+  run.store.append(
+    buildOutcome({
+      seq,
+      ts: new Date().toISOString(),
+      status: "aborted",
+      failure: classify({ message: `spend-cap-abort on ${outcome.check.overDenom}`, rpcUrl: run.chain.rpcUrl })
+    })
+  );
+}
+
+export async function journaledSpend<T>(run: RunContext, params: JournaledSpendParams<T>): Promise<SpendOutcome<T>> {
+  const seq = run.seq.next();
+  run.store.append(
+    buildIntent({
+      seq,
+      ts: new Date().toISOString(),
+      spec: params.spec,
+      walletRole: params.walletRole,
+      action: params.action,
+      denoms: params.denoms,
+      ...(params.memo !== undefined ? { memo: params.memo } : {})
+    })
+  );
+  const request = { walletKey: params.walletKey, action: params.action, items: params.items, execute: params.execute };
+  try {
+    const outcome = params.counterparty ? await run.engine.counterpartySend(request) : await run.engine.spend(request);
+    appendSettled(run, seq, outcome, params);
+    return outcome;
+  } catch (error) {
+    run.store.append(
+      buildOutcome({
+        seq,
+        ts: new Date().toISOString(),
+        status: "failed",
+        failure: classify({ error, rpcUrl: run.chain.rpcUrl })
+      })
+    );
+    throw error;
+  }
+}
+
+export interface LeftoverInput {
+  terminal: TerminalPath;
+  openLeases?: OpenLease[];
+  pendingUnbondings?: PendingUnbonding[];
+  warnings?: string[];
+}
+
+/** Write the leftover-state report for a flow's terminal and annotate where it landed. */
+export function reportLeftover(run: RunContext, testInfo: TestInfo, input: LeftoverInput): void {
+  const report = run.engine.buildReport({
+    generatedAt: new Date().toISOString(),
+    terminal: input.terminal,
+    journal: run.store.readAll(),
+    openLeases: input.openLeases ?? [],
+    pendingUnbondings: input.pendingUnbondings ?? [],
+    warnings: input.warnings ?? []
+  });
+  const path = writeReportFile(run.t3.resultsDir, report);
+  testInfo.annotations.push({
+    type: LEFTOVER_ANNOTATION,
+    description: `terminal=${input.terminal} report=${path} openLeases=${report.openLeases.length}`
+  });
+}
+
+/** Connect the primary wallet on a light route and land on `path`, reusing the t2 app-driver. */
+export async function connectFlow(page: Page, run: RunContext, path: string): Promise<void> {
+  await page.goto("/assets", { waitUntil: "domcontentloaded" });
+  await waitForAppShell(page);
+  await connectKeplr(page, run.labels);
+  await assertConnected(page, run.primary.address);
+  if (path !== "/assets") {
+    await page.goto(path, { waitUntil: "domcontentloaded" });
+  }
+}

--- a/e2e/src/t3/flows/support.ts
+++ b/e2e/src/t3/flows/support.ts
@@ -185,9 +185,10 @@ export async function getRunContext(testInfo: TestInfo): Promise<RunContext> {
 }
 
 /** Record a machine-readable skip and abort the current test as skipped (never a red). */
-export function annotateSkipAndStop(testInfo: TestInfo, category: FailureCategory, reason: string): void {
+export function annotateSkipAndStop(testInfo: TestInfo, category: FailureCategory, reason: string): never {
   testInfo.annotations.push({ type: SKIP_ANNOTATION, description: `${category}: ${reason}` });
   testInfo.skip(true, reason);
+  throw new Error("unreachable: testInfo.skip did not stop execution");
 }
 
 /**
@@ -212,7 +213,6 @@ export function classifyAndRoute(testInfo: TestInfo, error: unknown, rpcUrl: str
     throw error instanceof Error ? error : new Error(String(error));
   }
   annotateSkipAndStop(testInfo, classification.category, `${classification.signal}: ${classification.reason}`);
-  throw new Error("unreachable");
 }
 
 export interface JournaledSpendParams<T> {
@@ -265,6 +265,10 @@ export async function journaledSpend<T>(run: RunContext, params: JournaledSpendP
       walletRole: params.walletRole,
       action: params.action,
       denoms: params.denoms,
+      // The cap-charged SpendItems actually reserved — the ONLY source restart cap-seeding reads.
+      // Display `denoms` can carry a positive amount an inflow action never charged; `charged`
+      // mirrors what the SpendCap counted, so a restart never re-charges a zero-charge inflow.
+      charged: params.items.map((item) => ({ denom: item.denom, micro: item.micro.toString() })),
       ...(params.memo !== undefined ? { memo: params.memo } : {})
     })
   );
@@ -284,6 +288,32 @@ export async function journaledSpend<T>(run: RunContext, params: JournaledSpendP
     );
     throw error;
   }
+}
+
+/**
+ * Run a governed spend and return its committed value, or terminate the test: a thrown broadcast
+ * error is journaled + classified-and-routed, and a spend-cap abort is a clean precondition skip
+ * with a `spend-cap-abort` leftover report. The abort branch sits AFTER the try (like a
+ * `requireOrSkip`) so the skip throw is never caught by the error path and mis-reported as an app
+ * failure — `classifyAndRoute` can never receive the skip sentinel.
+ */
+export async function spendCommittedOrSkip<T>(
+  testInfo: TestInfo,
+  run: RunContext,
+  params: JournaledSpendParams<T>
+): Promise<T> {
+  let outcome: SpendOutcome<T>;
+  try {
+    outcome = await journaledSpend(run, params);
+  } catch (error) {
+    reportLeftover(run, testInfo, { terminal: "app-failure" });
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
+  if (outcome.status === "spend-cap-abort") {
+    reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
+    annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+  }
+  return outcome.value;
 }
 
 export interface LeftoverInput {

--- a/e2e/src/t3/flows/support.ts
+++ b/e2e/src/t3/flows/support.ts
@@ -28,6 +28,7 @@ import { writeReportFile } from "../journalStore.js";
 import type { OpenLease, PendingUnbonding, TerminalPath } from "../report.js";
 import { seqAllocatorFromJournal } from "./seq.js";
 import type { SeqAllocator } from "./seq.js";
+import { seedCapFromJournal } from "./capSeed.js";
 import { dayOfYearUtc, resolveLeaseSideSetting, resolveLeaseSides } from "./sideSelection.js";
 import type { LeaseSide } from "./sideSelection.js";
 
@@ -156,6 +157,10 @@ export async function getRunContext(testInfo: TestInfo): Promise<RunContext> {
   const queue = new SerialQueue();
   const cap = spendCapFromMicros({ nlsMicro: config.t3.spendCapNlsMicro, usdcMicro: config.t3.spendCapUsdcMicro });
   const store = new JournalStore(config.t3.resultsDir);
+  // A worker restart re-enters here with a full-budget cap; seed both the cap spent-state and the
+  // seq allocator from the same journal so the operator budget can never be double-spent.
+  const journal = store.readAll();
+  seedCapFromJournal(cap, journal);
 
   runContext = {
     ctx,
@@ -163,7 +168,7 @@ export async function getRunContext(testInfo: TestInfo): Promise<RunContext> {
     cap,
     queue,
     store,
-    seq: seqAllocatorFromJournal(store.readAll()),
+    seq: seqAllocatorFromJournal(journal),
     primary: roles.primary,
     secondary: roles.secondary,
     primaryMnemonic: config.t2.primaryMnemonic,
@@ -177,11 +182,6 @@ export async function getRunContext(testInfo: TestInfo): Promise<RunContext> {
     leaseSides: resolveLeaseSides(config.leaseSetting, dayOfYearUtc(new Date()))
   };
   return runContext;
-}
-
-/** Reset the singleton — test-support only, called between the worker's specs is never needed. */
-export function resetRunContext(): void {
-  runContext = undefined;
 }
 
 /** Record a machine-readable skip and abort the current test as skipped (never a red). */

--- a/e2e/src/t3/flows/swap.spec.ts
+++ b/e2e/src/t3/flows/swap.spec.ts
@@ -1,20 +1,13 @@
 import { test, expect } from "./support.js";
 import type { Page } from "@playwright/test";
 import type { RunContext } from "./support.js";
-import {
-  getRunContext,
-  connectFlow,
-  journaledSpend,
-  reportLeftover,
-  skipIfHalted,
-  classifyAndRoute,
-  annotateSkipAndStop
-} from "./support.js";
+import { getRunContext, connectFlow, reportLeftover, skipIfHalted, spendCommittedOrSkip } from "./support.js";
 import { typeAmount, requireOrSkip, waitForFundedFromNls } from "../../t2/matrixHelpers.js";
 import { NATIVE_DENOM, NATIVE_DECIMALS, toMicroAmount } from "../../transfer.js";
 import { hasSwapRoute } from "./preconditions.js";
 import { microBalanceByDenom } from "./apiReads.js";
 import { readJson } from "../runtime.js";
+import { USDC_DENOM } from "./denoms.js";
 
 // Quote -> execute a dust swap (#283 flow 6). The Skip WS topic is DEAD CODE — the app tracks
 // swaps by client polling (SkipRouter.fetchStatus in useSwapForm.ts), so this asserts through the
@@ -30,7 +23,7 @@ let run: RunContext;
 async function probeRoute(ctx: RunContext["ctx"], amountMicro: string): Promise<boolean> {
   const payload = await readJson(
     ctx,
-    `${ctx.origin}/api/swap/route?from=${encodeURIComponent(NATIVE_DENOM)}&to=${encodeURIComponent("ibc/usdc")}&amount=${encodeURIComponent(amountMicro)}`
+    `${ctx.origin}/api/swap/route?from=${encodeURIComponent(NATIVE_DENOM)}&to=${encodeURIComponent(USDC_DENOM)}&amount=${encodeURIComponent(amountMicro)}`
   ).catch(() => null);
   return hasSwapRoute(payload);
 }
@@ -84,40 +77,31 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
   await typeAmount(page, "swap-1", SWAP_NLS);
 
   const usdcBefore = await microBalanceByDenom(run.ctx, wallet.address, "usdc");
-  try {
-    const outcome = await journaledSpend(run, {
-      spec: "t3-flow-swap",
-      action: "swap",
-      walletRole: "primary",
-      walletKey: run.primary.key,
-      items: [{ denom: "nls", micro: BigInt(amountMicro) }],
-      denoms: [{ denom: NATIVE_DENOM, micro: amountMicro }],
-      execute: async () => {
-        await run.queue.pace("strict");
-        await page.getByRole("button", { name: /swap/i }).last().click({ timeout: TERMINAL_MS });
-        await page
-          .getByRole("button", { name: /confirm|submit/i })
-          .first()
-          .click({ timeout: TERMINAL_MS });
-        await expect
-          .poll(() => swapTerminal(page), {
-            message: "swap should reach a polled terminal state",
-            timeout: TERMINAL_MS
-          })
-          .not.toBe("pending");
-        if ((await swapTerminal(page)) === "failure") {
-          throw new Error(`swap reached a failed terminal state: ${(await swapDialogText(page)).slice(0, 200)}`);
-        }
+  await spendCommittedOrSkip(testInfo, run, {
+    spec: "t3-flow-swap",
+    action: "swap",
+    walletRole: "primary",
+    walletKey: run.primary.key,
+    items: [{ denom: "nls", micro: BigInt(amountMicro) }],
+    denoms: [{ denom: NATIVE_DENOM, micro: amountMicro }],
+    execute: async () => {
+      await run.queue.pace("strict");
+      await page.getByRole("button", { name: /swap/i }).last().click({ timeout: TERMINAL_MS });
+      await page
+        .getByRole("button", { name: /confirm|submit/i })
+        .first()
+        .click({ timeout: TERMINAL_MS });
+      await expect
+        .poll(() => swapTerminal(page), {
+          message: "swap should reach a polled terminal state",
+          timeout: TERMINAL_MS
+        })
+        .not.toBe("pending");
+      if ((await swapTerminal(page)) === "failure") {
+        throw new Error(`swap reached a failed terminal state: ${(await swapDialogText(page)).slice(0, 200)}`);
       }
-    });
-    if (outcome.status === "spend-cap-abort") {
-      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
-      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
     }
-  } catch (error) {
-    reportLeftover(run, testInfo, { terminal: "app-failure" });
-    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
-  }
+  });
 
   await expect
     .poll(() => microBalanceByDenom(run.ctx, wallet.address, "usdc"), {

--- a/e2e/src/t3/flows/swap.spec.ts
+++ b/e2e/src/t3/flows/swap.spec.ts
@@ -30,18 +30,31 @@ let run: RunContext;
 async function probeRoute(ctx: RunContext["ctx"], amountMicro: string): Promise<boolean> {
   const payload = await readJson(
     ctx,
-    `${ctx.origin}/api/swap/route?from=${NATIVE_DENOM}&to=ibc/usdc&amount=${amountMicro}`
+    `${ctx.origin}/api/swap/route?from=${encodeURIComponent(NATIVE_DENOM)}&to=${encodeURIComponent("ibc/usdc")}&amount=${encodeURIComponent(amountMicro)}`
   ).catch(() => null);
   return hasSwapRoute(payload);
 }
 
-async function pollSwapTerminal(page: Page): Promise<boolean> {
-  const text = await page
+type SwapTerminal = "success" | "failure" | "pending";
+
+async function swapDialogText(page: Page): Promise<string> {
+  return page
     .locator("#dialog-scroll")
     .first()
     .innerText()
     .catch(() => "");
-  return /done|success|completed|failed|error/i.test(text);
+}
+
+/** The app's polled swap state — success and failure are both terminal, only failure must not pass. */
+async function swapTerminal(page: Page): Promise<SwapTerminal> {
+  const text = (await swapDialogText(page)).toLowerCase();
+  if (/failed|error|rejected/.test(text)) {
+    return "failure";
+  }
+  if (/done|success|completed/.test(text)) {
+    return "success";
+  }
+  return "pending";
 }
 
 test.beforeAll(async () => {
@@ -87,11 +100,14 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
           .first()
           .click({ timeout: TERMINAL_MS });
         await expect
-          .poll(() => pollSwapTerminal(page), {
+          .poll(() => swapTerminal(page), {
             message: "swap should reach a polled terminal state",
             timeout: TERMINAL_MS
           })
-          .toBe(true);
+          .not.toBe("pending");
+        if ((await swapTerminal(page)) === "failure") {
+          throw new Error(`swap reached a failed terminal state: ${(await swapDialogText(page)).slice(0, 200)}`);
+        }
       }
     });
     if (outcome.status === "spend-cap-abort") {
@@ -105,11 +121,11 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
 
   await expect
     .poll(() => microBalanceByDenom(run.ctx, wallet.address, "usdc"), {
-      message: "the swapped-to USDC balance should settle at or above the pre-swap balance",
+      message: "the swapped-to USDC balance should strictly increase after a committed swap",
       timeout: TERMINAL_MS,
       intervals: [3000, 5000, 5000, 5000]
     })
-    .toBeGreaterThanOrEqual(usdcBefore);
+    .toBeGreaterThan(usdcBefore);
 
   reportLeftover(run, testInfo, { terminal: "success" });
 });

--- a/e2e/src/t3/flows/swap.spec.ts
+++ b/e2e/src/t3/flows/swap.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from "./support.js";
+import type { Page } from "@playwright/test";
+import type { RunContext } from "./support.js";
+import {
+  getRunContext,
+  connectFlow,
+  journaledSpend,
+  reportLeftover,
+  skipIfHalted,
+  classifyAndRoute,
+  annotateSkipAndStop
+} from "./support.js";
+import { typeAmount, requireOrSkip, waitForFundedFromNls } from "../../t2/matrixHelpers.js";
+import { NATIVE_DENOM, NATIVE_DECIMALS, toMicroAmount } from "../../transfer.js";
+import { hasSwapRoute } from "./preconditions.js";
+import { microBalanceByDenom } from "./apiReads.js";
+import { readJson } from "../runtime.js";
+
+// Quote -> execute a dust swap (#283 flow 6). The Skip WS topic is DEAD CODE — the app tracks
+// swaps by client polling (SkipRouter.fetchStatus in useSwapForm.ts), so this asserts through the
+// UI's polled terminal state and post-swap balances, NOT a WS event. A dust amount routinely has
+// no route, which is a precondition skip (not a red): the route is pre-probed before executing.
+// No matrix cell. Deviation from #283's acceptance wording (WS-tracked) documented in the README.
+
+const SWAP_NLS = "0.01";
+const TERMINAL_MS = 120000;
+
+let run: RunContext;
+
+async function probeRoute(ctx: RunContext["ctx"], amountMicro: string): Promise<boolean> {
+  const payload = await readJson(
+    ctx,
+    `${ctx.origin}/api/swap/route?from=${NATIVE_DENOM}&to=ibc/usdc&amount=${amountMicro}`
+  ).catch(() => null);
+  return hasSwapRoute(payload);
+}
+
+async function pollSwapTerminal(page: Page): Promise<boolean> {
+  const text = await page
+    .locator("#dialog-scroll")
+    .first()
+    .innerText()
+    .catch(() => "");
+  return /done|success|completed|failed|error/i.test(text);
+}
+
+test.beforeAll(async () => {
+  run = await getRunContext(test.info());
+});
+
+test.afterAll(async () => {
+  if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
+});
+
+test("a dust swap executes and reaches a polled terminal state with settled balances", async ({
+  page,
+  budget,
+  wallet
+}, testInfo) => {
+  skipIfHalted(testInfo, run);
+  test.setTimeout(TERMINAL_MS * 2);
+  budget.route = "/assets/swap";
+
+  const amountMicro = toMicroAmount(SWAP_NLS, NATIVE_DECIMALS);
+  const routable = await probeRoute(run.ctx, amountMicro);
+  requireOrSkip(testInfo, run.matrix.expectFunded, routable, "no Skip route for the dust swap amount");
+
+  await connectFlow(page, run, "/assets/swap");
+  await page.locator("#swap-1").waitFor({ state: "visible", timeout: 15000 });
+  await waitForFundedFromNls(page);
+  await typeAmount(page, "swap-1", SWAP_NLS);
+
+  const usdcBefore = await microBalanceByDenom(run.ctx, wallet.address, "usdc");
+  try {
+    const outcome = await journaledSpend(run, {
+      spec: "t3-flow-swap",
+      action: "swap",
+      walletRole: "primary",
+      walletKey: run.primary.key,
+      items: [{ denom: "nls", micro: BigInt(amountMicro) }],
+      denoms: [{ denom: NATIVE_DENOM, micro: amountMicro }],
+      execute: async () => {
+        await run.queue.pace("strict");
+        await page.getByRole("button", { name: /swap/i }).last().click({ timeout: TERMINAL_MS });
+        await page
+          .getByRole("button", { name: /confirm|submit/i })
+          .first()
+          .click({ timeout: TERMINAL_MS });
+        await expect
+          .poll(() => pollSwapTerminal(page), {
+            message: "swap should reach a polled terminal state",
+            timeout: TERMINAL_MS
+          })
+          .toBe(true);
+      }
+    });
+    if (outcome.status === "spend-cap-abort") {
+      reportLeftover(run, testInfo, { terminal: "spend-cap-abort" });
+      annotateSkipAndStop(testInfo, "precondition", `spend cap reached on ${outcome.check.overDenom}`);
+    }
+  } catch (error) {
+    reportLeftover(run, testInfo, { terminal: "app-failure" });
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
+
+  await expect
+    .poll(() => microBalanceByDenom(run.ctx, wallet.address, "usdc"), {
+      message: "the swapped-to USDC balance should settle at or above the pre-swap balance",
+      timeout: TERMINAL_MS,
+      intervals: [3000, 5000, 5000, 5000]
+    })
+    .toBeGreaterThanOrEqual(usdcBefore);
+
+  reportLeftover(run, testInfo, { terminal: "success" });
+});

--- a/e2e/src/t3/flows/tolerance.test.ts
+++ b/e2e/src/t3/flows/tolerance.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { assertNonZeroBasis, assertWithinTolerance, withinTolerance } from "./tolerance.js";
+
+describe("withinTolerance", () => {
+  it("accepts a value inside the tolerance band", () => {
+    const result = withinTolerance({ actual: "100.02", expected: "100.00", tolerance: "0.05" });
+    expect(result.ok).toBe(true);
+    expect(result.deltaAbs).toBe("0.02000000");
+  });
+
+  it("accepts a value exactly on the tolerance boundary", () => {
+    expect(withinTolerance({ actual: "100.05", expected: "100.00", tolerance: "0.05" }).ok).toBe(true);
+  });
+
+  it("rejects a value beyond the tolerance band regardless of sign", () => {
+    expect(withinTolerance({ actual: "100.06", expected: "100.00", tolerance: "0.05" }).ok).toBe(false);
+    expect(withinTolerance({ actual: "99.94", expected: "100.00", tolerance: "0.05" }).ok).toBe(false);
+  });
+
+  it("rejects a negative tolerance", () => {
+    expect(() => withinTolerance({ actual: "1", expected: "1", tolerance: "-0.1" })).toThrow(/non-negative/);
+  });
+});
+
+describe("tolerance self-test — a deliberately wrong value on a non-zero basis must fail", () => {
+  it("rejects a rendered figure that is off by more than tolerance on a priced value", () => {
+    const basis = "1543.21";
+    assertNonZeroBasis({ value: basis, description: "collateral leg" });
+    const result = withinTolerance({ actual: "1600.00", expected: basis, tolerance: "0.05" });
+    expect(result.ok).toBe(false);
+    expect(() => {
+      assertWithinTolerance({ actual: "1600.00", expected: basis, tolerance: "0.05" }, "liquidation");
+    }).toThrow(/outside tolerance/);
+  });
+});
+
+describe("assertNonZeroBasis", () => {
+  it("throws when the oracle basis is zero so a vacuous NLS-USD assertion is caught", () => {
+    expect(() => {
+      assertNonZeroBasis({ value: "0", description: "nls usd value" });
+    }).toThrow(/vacuous/);
+    expect(() => {
+      assertNonZeroBasis({ value: "0.00", description: "nls usd value" });
+    }).toThrow(/vacuous/);
+  });
+
+  it("passes a non-zero basis", () => {
+    expect(() => {
+      assertNonZeroBasis({ value: "42.5", description: "collateral" });
+    }).not.toThrow();
+  });
+});

--- a/e2e/src/t3/flows/tolerance.ts
+++ b/e2e/src/t3/flows/tolerance.ts
@@ -1,0 +1,60 @@
+import { Decimal } from "../../oracle/decimal.js";
+
+export interface ToleranceInput {
+  actual: string;
+  expected: string;
+  tolerance: string;
+}
+
+export interface ToleranceResult {
+  ok: boolean;
+  actual: string;
+  expected: string;
+  deltaAbs: string;
+  tolerance: string;
+}
+
+/**
+ * Compare a rendered value against the oracle-computed expectation within an absolute tolerance,
+ * all as truncating fixed-point decimals (never floats). `ok` is `|actual - expected| <= tolerance`.
+ * This is the comparator the value-moving specs assert through and the one the negative-control
+ * self-test drives to prove a wrong value is actually rejected.
+ */
+export function withinTolerance(input: ToleranceInput): ToleranceResult {
+  const actual = Decimal.fromString(input.actual);
+  const expected = Decimal.fromString(input.expected);
+  const tolerance = Decimal.fromString(input.tolerance);
+  if (tolerance.isNegative()) {
+    throw new Error(`tolerance must be non-negative (got "${input.tolerance}")`);
+  }
+  const deltaAbs = actual.sub(expected).abs();
+  return {
+    ok: !deltaAbs.gt(tolerance),
+    actual: input.actual,
+    expected: input.expected,
+    deltaAbs: deltaAbs.toString(8),
+    tolerance: input.tolerance
+  };
+}
+
+/**
+ * Guard against a vacuous comparison. A tolerance assertion on a value whose oracle basis is
+ * zero (NLS is priced at ~$0 on staging, so its USD figures are inert) proves nothing — any
+ * wrong value would pass. Specs call this on the basis before asserting so a PnL/liquidation
+ * tolerance is only ever taken on the non-zero-priced collateral leg.
+ */
+export function assertNonZeroBasis(input: { value: string; description: string }): void {
+  if (Decimal.fromString(input.value).isZero()) {
+    throw new Error(`tolerance basis "${input.description}" is zero — the assertion would be vacuous`);
+  }
+}
+
+/** Throw a descriptive error when a value falls outside tolerance; used by the live specs. */
+export function assertWithinTolerance(input: ToleranceInput, description: string): void {
+  const result = withinTolerance(input);
+  if (!result.ok) {
+    throw new Error(
+      `${description}: rendered ${result.actual} is outside tolerance ${result.tolerance} of expected ${result.expected} (|delta|=${result.deltaAbs})`
+    );
+  }
+}

--- a/e2e/src/t3/journal.ts
+++ b/e2e/src/t3/journal.ts
@@ -4,7 +4,17 @@ import type { Classification } from "./taxonomy.js";
 export type WalletRole = "primary" | "secondary";
 
 export type IntentAction =
-  "native-send" | "swap" | "lease-open" | "lease-close" | "delegate" | "undelegate" | "redelegate";
+  | "native-send"
+  | "swap"
+  | "lease-open"
+  | "lease-close"
+  | "delegate"
+  | "undelegate"
+  | "redelegate"
+  | "earn-supply"
+  | "earn-withdraw"
+  | "stake-claim"
+  | "ibc-transfer";
 
 export interface DenomAmount {
   denom: string;

--- a/e2e/src/t3/journal.ts
+++ b/e2e/src/t3/journal.ts
@@ -8,6 +8,7 @@ export type IntentAction =
   | "swap"
   | "lease-open"
   | "lease-close"
+  | "lease-repay"
   | "delegate"
   | "undelegate"
   | "redelegate"

--- a/e2e/src/t3/journal.ts
+++ b/e2e/src/t3/journal.ts
@@ -30,6 +30,13 @@ export interface JournalIntent {
   walletRole: WalletRole;
   action: IntentAction;
   denoms: DenomAmount[];
+  /**
+   * The cap-charged amounts (native micro) actually reserved against the SpendCap for this intent,
+   * keyed by cap denom. Distinct from `denoms`, which is display data an inflow action may report
+   * as positive while charging nothing. Restart cap-seeding reconstructs spent-state from this
+   * field exclusively, so a re-entered run never re-charges a zero-charge inflow.
+   */
+  charged?: DenomAmount[];
   memo?: string;
 }
 
@@ -64,6 +71,7 @@ export interface IntentInput {
   walletRole: WalletRole;
   action: IntentAction;
   denoms: DenomAmount[];
+  charged?: DenomAmount[];
   memo?: string;
 }
 
@@ -77,6 +85,9 @@ export function buildIntent(input: IntentInput): JournalIntent {
     action: input.action,
     denoms: input.denoms.map((d) => ({ denom: redact(d.denom), micro: d.micro }))
   };
+  if (input.charged !== undefined) {
+    record.charged = input.charged.map((c) => ({ denom: redact(c.denom), micro: c.micro }));
+  }
   if (input.memo !== undefined) {
     record.memo = redact(input.memo);
   }

--- a/e2e/src/t3/taxonomy.test.ts
+++ b/e2e/src/t3/taxonomy.test.ts
@@ -45,6 +45,12 @@ describe("classify precondition", () => {
     expect(classify({ message: "amount too small to route" }).signal).toBe("swap-amount-too-small");
     expect(classify({ message: "insufficient liquidity, no route found" }).signal).toBe("liquidity");
   });
+
+  it("classifies a spend-cap abort as a first-class precondition, never app/unclassified", () => {
+    const result = classify({ message: "spend-cap-abort on usdc" });
+    expect(result.category).toBe("precondition");
+    expect(result.signal).toBe("spend-cap-abort");
+  });
 });
 
 describe("classify redaction", () => {

--- a/e2e/src/t3/taxonomy.test.ts
+++ b/e2e/src/t3/taxonomy.test.ts
@@ -35,6 +35,16 @@ describe("classify precondition", () => {
     expect(classify({ message: "redelegation is in progress for this delegator" }).signal).toBe("redelegation-lock");
     expect(classify({ message: "missing osmosis balance for the swap leg" }).category).toBe("precondition");
   });
+
+  it("classifies a lease down-payment range rejection as precondition", () => {
+    expect(classify({ message: "down payment is below the minimum for this lease" }).signal).toBe("lease-amount-range");
+    expect(classify({ message: "downpayment too large, out of range" }).category).toBe("precondition");
+  });
+
+  it("classifies a dust swap with no routable amount as precondition, distinct from a liquidity outage", () => {
+    expect(classify({ message: "amount too small to route" }).signal).toBe("swap-amount-too-small");
+    expect(classify({ message: "insufficient liquidity, no route found" }).signal).toBe("liquidity");
+  });
 });
 
 describe("classify redaction", () => {

--- a/e2e/src/t3/taxonomy.ts
+++ b/e2e/src/t3/taxonomy.ts
@@ -39,6 +39,11 @@ function pattern(rule: PatternRule): Rule {
 const RULES: Rule[] = [
   pattern({
     category: "precondition",
+    signal: "spend-cap-abort",
+    regex: /spend[-\s]?cap[-\s]?abort|spend cap (reached|exceeded|hit)/i
+  }),
+  pattern({
+    category: "precondition",
     signal: "unfunded",
     regex: /unfunded|insufficient funds|not funded|no balance/i
   }),

--- a/e2e/src/t3/taxonomy.ts
+++ b/e2e/src/t3/taxonomy.ts
@@ -57,6 +57,17 @@ const RULES: Rule[] = [
     signal: "osmosis-side-funds",
     regex: /osmosis.*(funds|balance|liquidity is missing)|missing osmosis/i
   }),
+  pattern({
+    category: "precondition",
+    signal: "lease-amount-range",
+    regex:
+      /down\s?payment.*(too (small|low|large|high)|below|above|out of range)|lease.*(min|max).*(rejected|exceeded)/i
+  }),
+  pattern({
+    category: "precondition",
+    signal: "swap-amount-too-small",
+    regex: /amount too small|below.*minimum.*swap|dust.*(no route|not routable)|too small to route/i
+  }),
   {
     category: "environment",
     signal: "rate-limited",

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
         "src/t3/journalStore.ts",
         "src/t3/runtime.ts",
         "src/t3/repair.ts",
+        // T3 flow browser/network glue — the run singleton, live API reads, and form driver are
+        // exercised by the live t3-flows suite, not vitest. The pure helpers they compose
+        // (sideSelection, seq, tolerance, preconditions) stay included and unit-tested.
+        "src/t3/flows/support.ts",
+        "src/t3/flows/apiReads.ts",
+        "src/t3/flows/formDriver.ts",
         "src/t1/**",
         "src/t2/**",
         // Browser glue (Playwright fixtures / specs) is exercised by the live and


### PR DESCRIPTION
Closes #283. Part of epic #278 (M3) — the flow tier on top of the #310 tx engine.

## What ships

Six value-moving Playwright specs under `e2e/src/t3/flows/`, each wallet-connected, each driven through the tx engine (serialized, journaled, budgeted, retries 0), each ending in a tolerance-based UI-vs-chain assertion:

- **Lease** — one lease per run, side alternating by UTC day parity (`E2E_LEASE_SIDE` overrides): open at the live-resolved protocol minimum → TP/SL create + edit → dust repay → partial close (guarded to leave the protocol minimum position) → market close, with chain-truth assertions (debt non-increasing after repay, lease absent from the opened set after close) and oracle-recomputed size/PnL/liquidation values. The short side asserts the opened position uses the protocol lease-group stable ticker, not the downpayment or LPN.
- **Earn** — dust supply and withdraw; totals vs the API within tolerance; the WS earn tick must not clobber REST fields.
- **Stake** — dust delegate; undelegate (21-day unbonding acknowledged, gated below the 7-entry chain cap with validator rotation); redelegate (component-driven, serialized so two can never overlap); claim (accrual-dependent, tolerance-based, skips below a dust threshold).
- **Send** — native send to the receiver wallet; sender debit asserted on the rendered balance, receiver credit via the API, fee-aware.
- **IBC** — deposit/withdraw Nolus↔Osmosis, fully skip-gated on an Osmosis-side funding probe until funds exist.
- **Swap** — dust swap with a routability pre-probe; tracked to a terminal state via the app's own polling; a failed terminal fails the spec; post-swap balance must strictly increase. Deviation from the issue wording: the `skip_tx` WS topic is dead code in the app (nothing subscribes to it — swap progress is client-side polling), so the spec asserts the polled terminal state instead.

Run-safety machinery shared by all specs: one run-scoped engine/cap/queue/journal singleton (the per-run operator budget is enforced across the whole run, not per spec); the cap and the seq allocator are both seeded from the write-ahead journal's recorded charges, so a crashed-and-restarted worker resumes with the true spent-state; a spend-cap abort skips every remaining value-moving spec cleanly with a `spend-cap-abort` terminal report — never a red cascade; CI artifacts are scrubbed of the deploy host (text redaction plus deletion of any still-matching binary) before upload.

Suite impact: five previously funded-gated coverage-matrix cells now map to named live assertions (lease row/detail/cross-field, stake delegated, earn total); matrix at 40 mapped cells. Engine touches are additive only: five new journal intent actions, a `charged` field on intents, three new taxonomy signals — all unit-tested.

## Verification

- Full e2e package gate green on a clean standalone install at every commit: typecheck, format, lint at zero warnings, coverage 91.8/86.0/90.7/92.1 over the 88/83/86/88 floors (319 tests), matrix guard.
- Issue test plan covered in unit tests: side alternation, seq monotonicity and journal seeding, tolerance boundary plus the deliberate wrong-tolerance negative control on a non-zero basis, precondition gates (unbonding cap, validator rotation, route probe, downpayment floor), cap seeding from charged amounts including the zero-charge inflow case.
- Live execution is CI-gated behind the manual dispatch workflow (`e2e-t3-flows.yaml`, self-hosted runner, real caps: 100 NLS / 50 USDC per run); the DOM selectors in the live specs get their first confirmation on the first funded dispatch, mirroring how the t2 tier landed.

## Review notes

Three independent review rounds ran before push (correctness, security, and project-convention passes over the full range, after a failure-mode analysis of the plan and a planned-changes-only check on the diff):

1. Round 1: the lease spec had shipped open-only — the full same-run lifecycle (TP/SL, repay, partial close, market close) was implemented in response, along with first-class classification for budget aborts, abort handling on second legs, a strictly-increasing post-swap assertion, journal-seeded cap state, and the artifact scrub.
2. Round 2: the abort-skip control flow was restructured out of the error path (a budget abort could previously be misreported as an app failure), cap seeding switched to the actually-charged amounts, and the short-side stable-ticker and tolerance-comparator assertions — documented but unwired — were wired into the live specs.
3. Round 3: clean across all three passes.

Known deferrals (tracked, deliberate): Osmosis-side funding for live IBC; the engine smoke workflow adopting the same artifact scrub; funded variants of the t2 validation cells; the deposit leg of IBC charging the cap conservatively (over-counts, never under-counts).
