### PR TITLE
fix(e2e): use delegations key in the undelegate premise probe

### DIFF
--- a/e2e/src/t2/validation.spec.ts
+++ b/e2e/src/t2/validation.spec.ts
@@ -92,7 +92,7 @@ async function emptyBalancePremiseHolds(cell: FormCell, ctx: OriginContext, addr
     case "earn-position":
       return !(await probeHasEntries(ctx, `/api/earn/positions?address=${address}`, "positions"));
     case "stake-position":
-      return !(await probeHasEntries(ctx, `/api/staking/positions?address=${address}`, "positions"));
+      return !(await probeHasEntries(ctx, `/api/staking/positions?address=${address}`, "delegations"));
     default: {
       const unreachable: never = cell.premise;
       throw new Error(`unhandled balance premise: ${String(unreachable)}`);


### PR DESCRIPTION
Completes #315: the premise-probe helper itself (emptyBalancePremiseHolds, the call the empty-balance cells actually gate on) still read the nonexistent positions key from /api/staking/positions; #315 fixed only the over-position gate one screen lower. With the wrong key the probe saw no delegations, the undelegate cell ran against the account holding a live delegation, no error rendered, and the cell stayed red (dispatch run 29581301604).

Verification: e2e typecheck + tests green on a clean install; zero remaining staking-endpoint probes reading positions (grep).