### PR TITLE
fix(e2e): create results dir before writing repair attempts

### DIFF
--- a/e2e/src/t3/journalStore.ts
+++ b/e2e/src/t3/journalStore.ts
@@ -85,6 +85,8 @@ export function readAttempts(resultsDir: string): Map<string, number> {
 }
 
 export function writeAttempts(resultsDir: string, attempts: Map<string, number>): void {
-  const path = join(resolve(resultsDir), ATTEMPTS_FILE_NAME);
+  const dir = resolve(resultsDir);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, ATTEMPTS_FILE_NAME);
   writeFileSync(path, `${JSON.stringify(Object.fromEntries(attempts), null, 2)}\n`, "utf8");
 }


### PR DESCRIPTION
First run of the T3 engine smoke to reach the t3-engine project (dispatch 29582528606) failed on writeAttempts: unlike its sibling writers in journalStore, it never created the results directory, so a clean CI workspace hits ENOENT. Locally the directory always pre-existed from earlier runs, masking it.

Verification: typecheck/lint/format green; the mkdirSync mirrors the two adjacent writers; next smoke dispatch is the live proof.