### PR TITLE
fix(e2e): keep run dispatcher open across t3 flow spec files

### DIFF
--- a/e2e/src/t3/flows/earn.spec.ts
+++ b/e2e/src/t3/flows/earn.spec.ts
@@ -42,10 +42,6 @@ test.beforeAll(async () => {
   run = await getRunContext(test.info());
 });
 
-test.afterAll(async () => {
-  if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
-});
-
 test("earn supply then withdraw of dust USDC, rendered total matches the oracle", async ({
   page,
   budget,

--- a/e2e/src/t3/flows/ibc.spec.ts
+++ b/e2e/src/t3/flows/ibc.spec.ts
@@ -38,10 +38,6 @@ test.beforeAll(async () => {
   run = await getRunContext(test.info());
 });
 
-test.afterAll(async () => {
-  if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
-});
-
 test("IBC deposit then withdraw Nolus <-> Osmosis, gated on a funded Osmosis side", async ({
   page,
   budget,

--- a/e2e/src/t3/flows/lease.spec.ts
+++ b/e2e/src/t3/flows/lease.spec.ts
@@ -128,10 +128,6 @@ test.beforeAll(async () => {
   run = await getRunContext(test.info());
 });
 
-test.afterAll(async () => {
-  if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
-});
-
 test("a single alternating-side lease runs its full lifecycle through the engine", async ({
   page,
   budget,

--- a/e2e/src/t3/flows/send.spec.ts
+++ b/e2e/src/t3/flows/send.spec.ts
@@ -41,10 +41,6 @@ test.beforeAll(async () => {
   run = await getRunContext(test.info());
 });
 
-test.afterAll(async () => {
-  if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
-});
-
 test("a native send debits the sender and credits wallet-2 through the engine", async ({
   page,
   budget,

--- a/e2e/src/t3/flows/stake.spec.ts
+++ b/e2e/src/t3/flows/stake.spec.ts
@@ -54,10 +54,6 @@ test.beforeAll(async () => {
   run = await getRunContext(test.info());
 });
 
-test.afterAll(async () => {
-  if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
-});
-
 test("stake delegate of dust NLS renders the delegated amount matching the oracle", async ({
   page,
   budget,

--- a/e2e/src/t3/flows/support.ts
+++ b/e2e/src/t3/flows/support.ts
@@ -149,6 +149,8 @@ export async function getRunContext(testInfo: TestInfo): Promise<RunContext> {
   if (runContext !== undefined) {
     return runContext;
   }
+  // Run-scoped: the origin dispatcher must outlive every spec file (a per-file
+  // afterAll close destroys it for the files that follow); it is reaped with the worker.
   const ctx = resolveOrigin();
   const config = parseFlowConfig();
   const roles = await deriveRoles(config.t2);

--- a/e2e/src/t3/flows/swap.spec.ts
+++ b/e2e/src/t3/flows/swap.spec.ts
@@ -54,10 +54,6 @@ test.beforeAll(async () => {
   run = await getRunContext(test.info());
 });
 
-test.afterAll(async () => {
-  if (run.ctx.dispatcher !== undefined) await run.ctx.dispatcher.close();
-});
-
 test("a dust swap executes and reaches a polled terminal state with settled balances", async ({
   page,
   budget,


### PR DESCRIPTION
First funded t3-flows dispatch (run 29589162653): the run-scoped singleton shares one origin dispatcher across all six flow spec files, but each file closed it in afterAll — the first file to finish destroyed the client for every later file (ibc/lease/stake/swap failed instantly with ClientDestroyedError before any broadcast; no funds moved on the failures).

The per-file closes are removed; the dispatcher is run-scoped by design and is reaped with the worker process. A comment at the construction site records the constraint.

Verification: gate green (typecheck, lint, format, 319 tests, matrix); the next funded dispatch is the live proof.