### PR TITLE
fix(e2e): lease protocol via config list, osmo-side ibc probe

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -647,8 +647,11 @@ The lease side alternates by **UTC day-of-year parity** — even opens a long, o
 `E2E_LEASE_SIDE` (`long` / `short` / `both`) pins it. `both` is reserved for a future raised-cap
 run: when the second open would exceed the USDC cap it precondition-skips rather than aborting.
 USDC is the only viable downpayment denom (NLS is priced ~$0 on staging, so its USD figures are
-vacuous and its ranges unreachable). The lease minimum downpayment is **$40 USD-equivalent**,
-resolved **live** from `GET /api/leases/config/<protocol>` at test time, never hardcoded. One
+vacuous and its ranges unreachable). The protocol is resolved live from `GET /api/config`'s
+top-level `protocols[]` — `selectLeaseProtocol` picks the first identifier naming the downpayment
+ticker whose `GET /api/leases/config/<protocol>` carries a matching downpayment range (the bare
+`/api/leases/config` endpoint 400s — the protocol param is required). The lease minimum downpayment
+is **$40 USD-equivalent**, read from that per-protocol config at test time, never hardcoded. One
 lease cycle per run is roughly $42 gross, which fits the $50 USDC cap. A short lease asserts its
 opened position ticker equals `resolveShortLeaseStable(currencies)` (the lease-group stable, never
 the downpayment/LPN) — the `#283` short-side acceptance criterion. The rendered lease USD value is
@@ -701,7 +704,10 @@ redelegate mutex), and claim on accrued rewards being **above a dust threshold**
   step (its journal/report are already sanitized; only the browser traces are the residual leak surface).
 - **IBC is inert until funded.** `ibc.spec.ts` is entirely skip-gated on an Osmosis-side funding
   probe (escalated to a hard failure under `E2E_EXPECT_FUNDED`); its structure is complete but the
-  live path stays inert until the counterparty side is funded.
+  live path stays inert until the counterparty side is funded. The probe uses the bech32-re-encoded
+  Osmosis address (`toOsmosisAddress`, `osmo1…` — the raw `nolus1…` HRP is rejected by the Osmosis
+  chain), and the probe + skip decision run **network-only, before any page navigation or the
+  console-budget window opens**, so an unfunded run never navigates and never trips console errors.
 - **Send receiver credit.** `send.spec.ts` renders the sender's debit (the Swap From=NLS technique)
   and confirms the receiver's credit through the balances API, since a second rendered session would
   need a reconnect and break the single-broadcast model.

--- a/e2e/src/t3/flows/address.test.ts
+++ b/e2e/src/t3/flows/address.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { reencodeAddress, toOsmosisAddress } from "./address.js";
+
+// A real nolus bech32 address (valid checksum) and its verified osmo re-encoding of the same bytes.
+const NOLUS = "nolus10hvz04hh92xzct5hxnpsn5h2fp3p4amm28vhvp";
+const OSMO = "osmo10hvz04hh92xzct5hxnpsn5h2fp3p4amm5v0cck";
+
+describe("toOsmosisAddress", () => {
+  it("re-encodes a nolus address under the osmo HRP preserving the key bytes", () => {
+    expect(toOsmosisAddress(NOLUS)).toBe(OSMO);
+  });
+
+  it("round-trips back to the original nolus address", () => {
+    expect(reencodeAddress(toOsmosisAddress(NOLUS), "nolus")).toBe(NOLUS);
+  });
+
+  it("throws on a malformed bech32 address rather than returning a bad string", () => {
+    expect(() => toOsmosisAddress("not-a-bech32-address")).toThrow();
+  });
+});

--- a/e2e/src/t3/flows/address.ts
+++ b/e2e/src/t3/flows/address.ts
@@ -1,0 +1,30 @@
+import { createRequire } from "node:module";
+
+interface EncodingLib {
+  fromBech32(address: string): { prefix: string; data: Uint8Array };
+  toBech32(prefix: string, data: Uint8Array): string;
+}
+
+// Playwright (pinned 1.61) installs a require-hook that cannot interop cosmjs's CJS build with its
+// ESM-only deps, so a static `import` of `@cosmjs/encoding` aborts the browser run at collection —
+// the same reason `signer.ts` loads cosmjs through `createRequire`. This module reuses that path so
+// it is usable by both the Playwright specs and the vitest unit tests.
+const loadModule = createRequire(import.meta.url);
+const encodingLib = loadModule("@cosmjs/encoding") as EncodingLib;
+
+const OSMOSIS_PREFIX = "osmo";
+
+/** Re-encode a bech32 address under a different HRP, preserving its byte payload. */
+export function reencodeAddress(address: string, prefix: string): string {
+  const { data } = encodingLib.fromBech32(address);
+  return encodingLib.toBech32(prefix, data);
+}
+
+/**
+ * The Osmosis-side counterparty address for a Nolus account — the same key bytes under the `osmo`
+ * HRP. Probing an Osmosis balance with the raw `nolus1…` string is rejected by the Osmosis chain
+ * (wrong HRP); this yields the address the counterparty side actually holds.
+ */
+export function toOsmosisAddress(nolusAddress: string): string {
+  return reencodeAddress(nolusAddress, OSMOSIS_PREFIX);
+}

--- a/e2e/src/t3/flows/apiReads.ts
+++ b/e2e/src/t3/flows/apiReads.ts
@@ -1,6 +1,7 @@
 import type { OriginContext } from "../../t2/appDriver.js";
 import { readString } from "../../t2/matrixHelpers.js";
 import { readJson } from "../runtime.js";
+import { selectLeaseProtocol } from "./leaseProtocol.js";
 
 // Node-side, host-resolver-aware reads of the live API used by the flow specs to build the
 // oracle inputs and precondition probes. Coverage-excluded browser/network glue (see
@@ -46,14 +47,25 @@ export async function leaseConfig(ctx: OriginContext, protocol: string): Promise
   return readJson(ctx, `${ctx.origin}/api/leases/config/${encodeURIComponent(protocol)}`);
 }
 
-/** The first protocol key from `/api/leases/config`, or throws if none resolvable. */
-export async function firstProtocol(ctx: OriginContext): Promise<string> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/leases/config`);
-  const protocol = Object.keys(asRecord(payload) ?? {})[0];
-  if (protocol === undefined) {
-    throw new Error("no lease protocol resolvable from /api/leases/config");
-  }
-  return protocol;
+/** The protocol identifiers from `/api/config` (top-level `protocols: string[]`). */
+export async function leaseProtocols(ctx: OriginContext): Promise<string[]> {
+  const payload = await readJson(ctx, `${ctx.origin}/api/config`);
+  const protocols = asRecord(payload)?.protocols;
+  return Array.isArray(protocols) ? protocols.filter((p): p is string => typeof p === "string") : [];
+}
+
+/**
+ * Resolve a lease protocol for the given downpayment ticker: the deterministic first `/api/config`
+ * protocol naming the ticker whose `/api/leases/config/<protocol>` carries a matching downpayment
+ * range. The bare `/api/leases/config` endpoint 400s (the protocol param is required), so the list
+ * comes from `/api/config`, never that endpoint.
+ */
+export async function resolveLeaseProtocol(ctx: OriginContext, downpaymentTicker: string): Promise<string> {
+  return selectLeaseProtocol({
+    protocols: await leaseProtocols(ctx),
+    downpaymentTicker,
+    loadConfig: (protocol) => leaseConfig(ctx, protocol)
+  });
 }
 
 /** The currencies list for lease-group stable resolution. */

--- a/e2e/src/t3/flows/ibc.spec.ts
+++ b/e2e/src/t3/flows/ibc.spec.ts
@@ -8,6 +8,7 @@ import { toMicroAmount } from "../../transfer.js";
 import { submitForm } from "./formDriver.js";
 import { readJson } from "../runtime.js";
 import { USDC_DENOM } from "./denoms.js";
+import { toOsmosisAddress } from "./address.js";
 
 // IBC deposit + withdraw Nolus <-> Osmosis (#283 flow 5). ENTIRELY skip-gated on a funded
 // Osmosis-side probe: the whole flow is inert until that funding is confirmed, at which point
@@ -44,10 +45,12 @@ test("IBC deposit then withdraw Nolus <-> Osmosis, gated on a funded Osmosis sid
   wallet
 }, testInfo) => {
   skipIfHalted(testInfo, run);
-  test.setTimeout(TERMINAL_MS * 3);
-  budget.route = "/assets";
 
-  const funded = await osmosisFunded(run.ctx, wallet.address);
+  // Network-only gate: derive the Osmosis-side address (bech32 re-encode; probing with the raw
+  // nolus HRP is rejected by the Osmosis chain) and decide the skip BEFORE opening the page or the
+  // console-budget window, so an unfunded run never navigates and never trips console errors.
+  const osmosisAddress = toOsmosisAddress(wallet.address);
+  const funded = await osmosisFunded(run.ctx, osmosisAddress);
   requireOrSkip(
     testInfo,
     run.matrix.expectFunded,
@@ -55,6 +58,8 @@ test("IBC deposit then withdraw Nolus <-> Osmosis, gated on a funded Osmosis sid
     "Osmosis counterparty side is not funded for an IBC round trip"
   );
 
+  test.setTimeout(TERMINAL_MS * 3);
+  budget.route = "/assets";
   const requiredMicro = BigInt(toMicroAmount(DUST_USDC, USDC_DECIMALS));
   await connectFlow(page, run, "/assets");
   // The deposit leg's own cap abort skips the whole test (spendCommittedOrSkip), so the withdraw

--- a/e2e/src/t3/flows/lease.spec.ts
+++ b/e2e/src/t3/flows/lease.spec.ts
@@ -8,7 +8,7 @@ import { USDC_DECIMALS } from "../../config.js";
 import { toMicroAmount } from "../../transfer.js";
 import { Decimal } from "../../oracle/decimal.js";
 import { computeLiquidation, leaseSizeCell } from "../../oracle/lease.js";
-import { microBalanceByDenom, openedLease, leaseConfig, firstProtocol, currencies } from "./apiReads.js";
+import { microBalanceByDenom, openedLease, leaseConfig, resolveLeaseProtocol, currencies } from "./apiReads.js";
 import { submitForm, openDetailDialog } from "./formDriver.js";
 import { resolveDownpaymentFloorUsd, remainsAboveMin } from "./preconditions.js";
 import { resolveShortLeaseStable } from "./sideSelection.js";
@@ -138,7 +138,7 @@ test("a single alternating-side lease runs its full lifecycle through the engine
   const side: LeaseSide = run.leaseSides[0] ?? "long";
   budget.route = `/positions/open/${side}`;
 
-  const protocol = await firstProtocol(run.ctx);
+  const protocol = await resolveLeaseProtocol(run.ctx, "USDC");
   const floorUsd = resolveDownpaymentFloorUsd(await leaseConfig(run.ctx, protocol));
   const downpayment = floorUsd.add(Decimal.fromString("2")).toString(2);
   const requiredMicro = BigInt(toMicroAmount(downpayment, USDC_DECIMALS));

--- a/e2e/src/t3/flows/leaseProtocol.test.ts
+++ b/e2e/src/t3/flows/leaseProtocol.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { protocolMatchesTicker, selectLeaseProtocol } from "./leaseProtocol.js";
+
+const CONFIGS: Record<string, unknown> = {
+  "OSMOSIS-OSMOSIS-ATOM": { downpayment_ranges: { ATOM: { min: "45.0" } } },
+  "OSMOSIS-OSMOSIS-USDC_NOBLE": { downpayment_ranges: { USDC_NOBLE: { min: "40.0" } } },
+  "NEUTRON-ASTROPORT-USDC_AXELAR": { downpayment_ranges: { USDC_AXELAR: { min: "40.0" } } }
+};
+
+function loaderFrom(configs: Record<string, unknown>): (protocol: string) => Promise<unknown> {
+  return (protocol) => {
+    if (!(protocol in configs)) {
+      return Promise.reject(new Error(`config fetch failed for ${protocol}`));
+    }
+    return Promise.resolve(configs[protocol]);
+  };
+}
+
+describe("protocolMatchesTicker", () => {
+  it("matches the ticker case-insensitively anywhere in the identifier", () => {
+    expect(protocolMatchesTicker("OSMOSIS-OSMOSIS-USDC_NOBLE", "usdc")).toBe(true);
+    expect(protocolMatchesTicker("OSMOSIS-OSMOSIS-ATOM", "USDC")).toBe(false);
+  });
+});
+
+describe("selectLeaseProtocol", () => {
+  it("picks the first USDC-named protocol whose config carries a matching downpayment range", async () => {
+    const protocol = await selectLeaseProtocol({
+      protocols: ["OSMOSIS-OSMOSIS-ATOM", "OSMOSIS-OSMOSIS-USDC_NOBLE", "NEUTRON-ASTROPORT-USDC_AXELAR"],
+      downpaymentTicker: "USDC",
+      loadConfig: loaderFrom(CONFIGS)
+    });
+    expect(protocol).toBe("OSMOSIS-OSMOSIS-USDC_NOBLE");
+  });
+
+  it("skips a USDC-named protocol whose config fetch fails and falls through to the next", async () => {
+    const protocol = await selectLeaseProtocol({
+      protocols: ["OSMOSIS-OSMOSIS-USDC_NOBLE", "NEUTRON-ASTROPORT-USDC_AXELAR"],
+      downpaymentTicker: "USDC",
+      loadConfig: loaderFrom({ "NEUTRON-ASTROPORT-USDC_AXELAR": CONFIGS["NEUTRON-ASTROPORT-USDC_AXELAR"] })
+    });
+    expect(protocol).toBe("NEUTRON-ASTROPORT-USDC_AXELAR");
+  });
+
+  it("skips a USDC-named protocol whose config lacks a USDC downpayment range", async () => {
+    const protocol = await selectLeaseProtocol({
+      protocols: ["OSMOSIS-OSMOSIS-USDC_NOBLE", "NEUTRON-ASTROPORT-USDC_AXELAR"],
+      downpaymentTicker: "USDC",
+      loadConfig: loaderFrom({
+        "OSMOSIS-OSMOSIS-USDC_NOBLE": { downpayment_ranges: { ATOM: { min: "45.0" } } },
+        "NEUTRON-ASTROPORT-USDC_AXELAR": CONFIGS["NEUTRON-ASTROPORT-USDC_AXELAR"]
+      })
+    });
+    expect(protocol).toBe("NEUTRON-ASTROPORT-USDC_AXELAR");
+  });
+
+  it("throws a clear error when a USDC-named protocol qualifies for none", async () => {
+    await expect(
+      selectLeaseProtocol({
+        protocols: ["OSMOSIS-OSMOSIS-USDC_NOBLE"],
+        downpaymentTicker: "USDC",
+        loadConfig: loaderFrom({ "OSMOSIS-OSMOSIS-USDC_NOBLE": { downpayment_ranges: { ATOM: { min: "45.0" } } } })
+      })
+    ).rejects.toThrow(/no lease protocol with a USDC downpayment range.*tried/s);
+  });
+
+  it("throws without a tried-list when no protocol even names the ticker", async () => {
+    await expect(
+      selectLeaseProtocol({
+        protocols: ["OSMOSIS-OSMOSIS-ATOM"],
+        downpaymentTicker: "USDC",
+        loadConfig: loaderFrom(CONFIGS)
+      })
+    ).rejects.toThrow(/no lease protocol with a USDC downpayment range among \[OSMOSIS-OSMOSIS-ATOM\]/);
+  });
+});

--- a/e2e/src/t3/flows/leaseProtocol.ts
+++ b/e2e/src/t3/flows/leaseProtocol.ts
@@ -1,0 +1,41 @@
+import { hasDownpaymentRange } from "./preconditions.js";
+
+/** Whether a protocol identifier names the downpayment asset (e.g. contains "USDC"). */
+export function protocolMatchesTicker(protocol: string, ticker: string): boolean {
+  return protocol.toUpperCase().includes(ticker.toUpperCase());
+}
+
+export interface SelectProtocolInput {
+  protocols: string[];
+  downpaymentTicker: string;
+  loadConfig: (protocol: string) => Promise<unknown>;
+}
+
+/**
+ * Pick, deterministically, the first protocol whose identifier names the downpayment ticker AND
+ * whose `/api/leases/config/<protocol>` payload loads and carries a downpayment range for that
+ * ticker. `loadConfig` is injected so the selection logic is unit-tested without the network. A
+ * protocol whose config fetch fails or lacks the range is skipped; when none qualifies this throws
+ * a clear error naming every protocol tried.
+ */
+export async function selectLeaseProtocol(input: SelectProtocolInput): Promise<string> {
+  const candidates = input.protocols.filter((protocol) => protocolMatchesTicker(protocol, input.downpaymentTicker));
+  const tried: string[] = [];
+  for (const protocol of candidates) {
+    let config: unknown;
+    try {
+      config = await input.loadConfig(protocol);
+    } catch {
+      tried.push(`${protocol} (config fetch failed)`);
+      continue;
+    }
+    if (hasDownpaymentRange(config, input.downpaymentTicker)) {
+      return protocol;
+    }
+    tried.push(`${protocol} (no ${input.downpaymentTicker} downpayment range)`);
+  }
+  throw new Error(
+    `no lease protocol with a ${input.downpaymentTicker} downpayment range among [${input.protocols.join(", ")}]` +
+      (tried.length > 0 ? `; tried: ${tried.join("; ")}` : "")
+  );
+}

--- a/e2e/src/t3/flows/preconditions.ts
+++ b/e2e/src/t3/flows/preconditions.ts
@@ -107,6 +107,12 @@ export function resolveDownpaymentFloorUsd(payload: unknown, currency?: string):
   return ranges.reduce((max, range) => (range.min.gt(max) ? range.min : max), Decimal.zero());
 }
 
+/** Whether the lease config carries a downpayment range for a currency naming `ticker`. */
+export function hasDownpaymentRange(config: unknown, ticker: string): boolean {
+  const wanted = ticker.toUpperCase();
+  return extractRanges(config).some((range) => range.currency.toUpperCase().includes(wanted));
+}
+
 /** True when a partial repay/close leaves at least the protocol's `min_asset` residual. */
 export function remainsAboveMin(remainingMicro: bigint, minMicro: bigint): boolean {
   return remainingMicro >= minMicro;


### PR DESCRIPTION
Two fixes from the second funded t3-flows dispatch (run 29590099747):

- The lease spec resolved its protocol from a bare GET /api/leases/config, which the backend rejects (the protocol belongs in the path). Protocol selection now reads the protocols list from GET /api/config and deterministically picks the first USDC-named protocol whose per-protocol config carries a USDC downpayment range (pure, dependency-injected, unit-tested).
- The IBC funding probe sent the wallet address with its nolus prefix to the osmosis-side balance query; the chain rejected the bech32 hrp, the probe misread the failure as funded, and the spec navigated — surfacing the same hrp error from the app in the console budget. The probe now re-encodes the address to the osmo prefix via cosmjs bech32 (unit-tested roundtrip) and the funded/skip decision completes network-only, before any navigation.

Verification: full e2e gate green on a clean install (328 tests, coverage over floors, matrix unchanged); the next funded dispatch is the live proof.