### PR TITLE
fix(e2e): accept keyed protocols object from api config

### DIFF
--- a/e2e/src/t3/flows/apiReads.ts
+++ b/e2e/src/t3/flows/apiReads.ts
@@ -51,7 +51,9 @@ export async function leaseConfig(ctx: OriginContext, protocol: string): Promise
 export async function leaseProtocols(ctx: OriginContext): Promise<string[]> {
   const payload = await readJson(ctx, `${ctx.origin}/api/config`);
   const protocols = asRecord(payload)?.protocols;
-  return Array.isArray(protocols) ? protocols.filter((p): p is string => typeof p === "string") : [];
+  if (Array.isArray(protocols)) return protocols.filter((p): p is string => typeof p === "string");
+  const record = asRecord(protocols);
+  return record === undefined ? [] : Object.keys(record);
 }
 
 /**


### PR DESCRIPTION
GET /api/config serves `protocols` as an object keyed by protocol name; the lease-protocol reader only accepted an array of strings and resolved an empty list, failing the lease flow before selection (funded dispatch 29592221504, the single remaining failure). The reader now accepts both shapes (array of strings, or keyed object via its keys).

Verification: e2e gate green on a clean install; live /api/config shape confirmed (dict of 10 protocol keys).