### PR TITLE
fix(e2e): resolve asset identity via currencies metadata in probes

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -680,10 +680,25 @@ top and treats an abort as a clean **precondition skip** (annotated), so a cap a
 remaining flows rather than producing a red cascade of `EngineHaltedError` failures. Each terminal
 writes the leftover-state report and annotates where it landed.
 
+### Asset identity and valuation (denom resolution)
+
+Every value probe identifies assets by **resolved bank denom**, never by the `/api/balances`
+`symbol` (which carries the raw `ibc/...` hash for IBC assets) and never by `amount_usd` (unreliable,
+≈0 for USDC). `denomResolver.ts` loads `/api/currencies` once per run (cached on the run singleton)
+to map each ticker → its `bank_symbol` denom(s) + `decimal_digits`; a balance micro is summed by
+matching `balances[].denom` against those bank symbols, and USD value comes from `/api/prices`
+(`price_usd`) as `micro / 10^decimals × price` in scaled-integer decimals. Staking probes read the
+nested object fields (`StakingPosition.balance.amount`, each `ValidatorReward.rewards[].amount`),
+never the object as a string. The pure resolution/parse logic (`denomResolver.ts`, `staking.ts`) is
+unit-tested against fixtures shaped like the real responses (hash `symbol`, object `balance`).
+
 ### Precondition gates and the failure taxonomy
 
 Environment / precondition failures are skipped, not failed (`classifyAndRoute`); only `app`
-failures are reds. The taxonomy is extended with two precondition signals for these flows:
+failures are reds. A swap-route probe distinguishes a genuine no-route (a precondition) from a
+probe **error** (API/network failure → an `environment` skip with its own reason), never silently
+reporting an error as no-route; and every lease-downpayment skip annotates `matrix-skip` with the
+plan reason. The taxonomy is extended with two precondition signals for these flows:
 `lease-amount-range` (a downpayment below/above the lease range) and `swap-amount-too-small` (a
 dust amount with no Skip route, distinct from a genuine `liquidity` outage). Stake gates: undelegate
 is gated on the **7-entry unbonding cap** per validator (rotating the target when near it via

--- a/e2e/src/t3/flows/apiReads.ts
+++ b/e2e/src/t3/flows/apiReads.ts
@@ -1,9 +1,12 @@
 import type { OriginContext } from "../../t2/appDriver.js";
 import { readString } from "../../t2/matrixHelpers.js";
 import { readJson } from "../runtime.js";
-import { Decimal } from "../../oracle/decimal.js";
+import type { Decimal } from "../../oracle/decimal.js";
 import { parseDownpaymentRanges } from "./preconditions.js";
 import type { ProtocolConfig } from "./leasePlan.js";
+import { heldMicro, priceUsdOf, microToUsd, tickersMatching } from "./denomResolver.js";
+import type { ResolvedAsset } from "./denomResolver.js";
+import { hasSwapRoute } from "./preconditions.js";
 
 // Node-side, host-resolver-aware reads of the live API used by the flow specs to build the
 // oracle inputs and precondition probes. Coverage-excluded browser/network glue (see
@@ -18,18 +21,53 @@ function listAt(payload: unknown, key: string): unknown[] {
   return Array.isArray(list) ? list : [];
 }
 
-/** Sum of an address's micro balances whose denom contains `denomSubstr` (case-insensitive). */
-export async function microBalanceByDenom(ctx: OriginContext, address: string, denomSubstr: string): Promise<bigint> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/balances?address=${encodeURIComponent(address)}`);
-  let total = 0n;
-  for (const entry of listAt(payload, "balances")) {
-    const denom = readString(entry, "denom") ?? "";
-    const amount = readString(entry, "amount");
-    if (denom.toLowerCase().includes(denomSubstr.toLowerCase()) && amount !== undefined && /^\d+$/.test(amount)) {
-      total += BigInt(amount);
-    }
+/** Raw `/api/balances` payload for an address. */
+export async function fetchBalances(ctx: OriginContext, address: string): Promise<unknown> {
+  return readJson(ctx, `${ctx.origin}/api/balances?address=${encodeURIComponent(address)}`);
+}
+
+/** Micro balance of a ticker, identified by its RESOLVED bank denom (never the balances `symbol`). */
+export async function assetMicro(
+  ctx: OriginContext,
+  address: string,
+  resolver: Map<string, ResolvedAsset>,
+  ticker: string
+): Promise<bigint> {
+  return heldMicro(await fetchBalances(ctx, address), resolver.get(ticker));
+}
+
+/** Total micro across every USDC-variant ticker the resolver knows (the downpayment funding source). */
+export async function usdcMicro(
+  ctx: OriginContext,
+  address: string,
+  resolver: Map<string, ResolvedAsset>
+): Promise<bigint> {
+  const balances = await fetchBalances(ctx, address);
+  return tickersMatching(resolver, "USDC").reduce((sum, ticker) => sum + heldMicro(balances, resolver.get(ticker)), 0n);
+}
+
+export type RouteProbe = { status: "routable" } | { status: "no-route" } | { status: "error"; reason: string };
+
+/**
+ * Probe a swap route, distinguishing a genuine "no route for this amount" (a precondition) from a
+ * probe ERROR (the API/network failed) — the latter must not be silently reported as no-route.
+ */
+export async function probeSwapRoute(
+  ctx: OriginContext,
+  fromDenom: string,
+  toTicker: string,
+  amountMicro: string
+): Promise<RouteProbe> {
+  let payload: unknown;
+  try {
+    payload = await readJson(
+      ctx,
+      `${ctx.origin}/api/swap/route?from=${encodeURIComponent(fromDenom)}&to=${encodeURIComponent(toTicker)}&amount=${encodeURIComponent(amountMicro)}`
+    );
+  } catch (error) {
+    return { status: "error", reason: error instanceof Error ? error.message : String(error) };
   }
-  return total;
+  return { status: hasSwapRoute(payload) ? "routable" : "no-route" };
 }
 
 /** The first lease enumerated for `address` with `status === "opened"`, or undefined. */
@@ -82,19 +120,24 @@ export async function leaseProtocolConfigs(ctx: OriginContext): Promise<Protocol
 }
 
 /**
- * The wallet's USD holdings keyed by asset ticker — the intersection basis for downpayment
- * selection. Read from `/api/balances`; each entry's ticker/symbol and USD value are taken when the
- * payload exposes them (the live field names are confirmed in CI). An asset with no parseable USD
- * value contributes nothing, so the plan falls through to acquisition rather than over-claiming.
+ * The wallet's USD holdings per asset ticker — the intersection basis for downpayment selection.
+ * Each ticker's micro is summed by its RESOLVED bank denom (never the balances `symbol`, never the
+ * unreliable `amount_usd`) and valued as `micro/10^decimals × price_usd` from `/api/prices`. A
+ * ticker with no price or no holding contributes nothing.
  */
-export async function heldAssetUsd(ctx: OriginContext, address: string): Promise<Map<string, Decimal>> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/balances?address=${encodeURIComponent(address)}`);
+export async function heldAssetUsd(
+  ctx: OriginContext,
+  address: string,
+  resolver: Map<string, ResolvedAsset>,
+  pricesPayload: unknown
+): Promise<Map<string, Decimal>> {
+  const balances = await fetchBalances(ctx, address);
   const held = new Map<string, Decimal>();
-  for (const entry of listAt(payload, "balances")) {
-    const ticker = readString(entry, "ticker") ?? readString(entry, "symbol");
-    const usd = readString(entry, "value_usd") ?? readString(entry, "usd_value") ?? readString(entry, "balance_usd");
-    if (ticker !== undefined && usd !== undefined && /^\d+(\.\d+)?$/.test(usd)) {
-      held.set(ticker.toUpperCase(), (held.get(ticker.toUpperCase()) ?? Decimal.zero()).add(Decimal.fromString(usd)));
+  for (const [ticker, resolved] of resolver) {
+    const micro = heldMicro(balances, resolved);
+    const price = priceUsdOf(pricesPayload, ticker);
+    if (micro > 0n && price !== undefined) {
+      held.set(ticker, microToUsd(micro, resolved.decimalDigits, price));
     }
   }
   return held;

--- a/e2e/src/t3/flows/denomResolver.test.ts
+++ b/e2e/src/t3/flows/denomResolver.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { heldMicro, microToUsd, parseCurrencyResolver, priceUsdOf, tickersMatching } from "./denomResolver.js";
+import { Decimal } from "../../oracle/decimal.js";
+
+// Fixtures shaped like the REAL responses: balances `symbol`/`denom` carry the ibc bank hash and
+// `amount_usd` reads ≈0, so identity must come from the resolved bank denom and value from prices.
+const CURRENCIES = {
+  currencies: {
+    "USDC_NOBLE@osmosis-1": {
+      key: "USDC_NOBLE@osmosis-1",
+      ticker: "USDC_NOBLE",
+      symbol: "ibc/USDCHASH",
+      bank_symbol: "ibc/USDCHASH",
+      decimal_digits: 6
+    },
+    "OSMO@osmosis-1": {
+      key: "OSMO@osmosis-1",
+      ticker: "OSMO",
+      symbol: "ibc/OSMOHASH",
+      bank_symbol: "ibc/OSMOHASH",
+      decimal_digits: 6
+    },
+    "NLS@osmosis-1": { key: "NLS@osmosis-1", ticker: "NLS", symbol: "unls", bank_symbol: "unls", decimal_digits: 6 }
+  }
+};
+
+const BALANCES = {
+  balances: [
+    {
+      key: "USDC_NOBLE@osmosis-1",
+      symbol: "ibc/USDCHASH",
+      denom: "ibc/USDCHASH",
+      amount: "74577016",
+      amount_usd: "0",
+      decimal_digits: 6
+    },
+    { key: "NLS@osmosis-1", symbol: "unls", denom: "unls", amount: "5000000", amount_usd: "0", decimal_digits: 6 }
+  ],
+  total_value_usd: "0"
+};
+
+const PRICES = {
+  prices: {
+    "USDC_NOBLE@osmosis-1": { key: "USDC_NOBLE@osmosis-1", symbol: "USDC_NOBLE", price_usd: "1.00" },
+    "ATOM@osmosis-1": { key: "ATOM@osmosis-1", symbol: "ATOM", price_usd: "1.52" }
+  }
+};
+
+describe("parseCurrencyResolver", () => {
+  it("maps a ticker to its bank denom and decimals from the hash-symbol payload", () => {
+    const resolver = parseCurrencyResolver(CURRENCIES);
+    expect(resolver.get("USDC_NOBLE")).toEqual({
+      ticker: "USDC_NOBLE",
+      bankSymbols: ["ibc/USDCHASH"],
+      decimalDigits: 6
+    });
+    expect(resolver.get("NLS")?.bankSymbols).toEqual(["unls"]);
+  });
+});
+
+describe("heldMicro", () => {
+  it("sums balances by resolved bank denom, ignoring symbol and amount_usd", () => {
+    const resolver = parseCurrencyResolver(CURRENCIES);
+    expect(heldMicro(BALANCES, resolver.get("USDC_NOBLE"))).toBe(74577016n);
+    expect(heldMicro(BALANCES, resolver.get("OSMO"))).toBe(0n);
+  });
+
+  it("returns 0 for an unresolved asset", () => {
+    expect(heldMicro(BALANCES, undefined)).toBe(0n);
+  });
+});
+
+describe("priceUsdOf / microToUsd", () => {
+  it("resolves the USD price by symbol or key ticker", () => {
+    expect(priceUsdOf(PRICES, "USDC_NOBLE")?.toString(2)).toBe("1.00");
+    expect(priceUsdOf(PRICES, "ATOM")?.toString(2)).toBe("1.52");
+    expect(priceUsdOf(PRICES, "UNKNOWN")).toBeUndefined();
+  });
+
+  it("values a micro holding as micro/10^decimals × price", () => {
+    expect(microToUsd(74577016n, 6, Decimal.fromString("1.00")).toString(2)).toBe("74.57");
+    expect(microToUsd(30000000n, 6, Decimal.fromString("1.52")).toString(2)).toBe("45.60");
+  });
+});
+
+describe("tickersMatching", () => {
+  it("finds every ticker variant containing the needle", () => {
+    const resolver = new Map(parseCurrencyResolver(CURRENCIES));
+    resolver.set("USDC_AXELAR", { ticker: "USDC_AXELAR", bankSymbols: ["ibc/AX"], decimalDigits: 6 });
+    expect(tickersMatching(resolver, "usdc").sort()).toEqual(["USDC_AXELAR", "USDC_NOBLE"]);
+  });
+});

--- a/e2e/src/t3/flows/denomResolver.ts
+++ b/e2e/src/t3/flows/denomResolver.ts
@@ -1,0 +1,89 @@
+import { Decimal } from "../../oracle/decimal.js";
+import { readString } from "../../t2/matrixHelpers.js";
+
+// Pure asset-identity resolution. Live `/api/balances` entries carry the bank denom (an `ibc/...`
+// hash) in `denom`/`symbol` and an unreliable `amount_usd` (≈0 for USDC), so assets are identified
+// ONLY by their resolved bank denom from `/api/currencies` and valued ONLY via `/api/prices`.
+
+export interface ResolvedAsset {
+  ticker: string;
+  bankSymbols: string[];
+  decimalDigits: number;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function values(payload: unknown, key: string): unknown[] {
+  const root = asRecord(payload)?.[key] ?? payload;
+  const record = asRecord(root);
+  if (record !== undefined) {
+    return Object.values(record);
+  }
+  return Array.isArray(root) ? root : [];
+}
+
+/**
+ * Build a ticker → { bankSymbols, decimalDigits } map from `/api/currencies`. A ticker present in
+ * several protocols contributes each protocol's `bank_symbol`; `decimalDigits` is taken from the
+ * first entry (consistent per ticker on Nolus).
+ */
+export function parseCurrencyResolver(payload: unknown): Map<string, ResolvedAsset> {
+  const resolver = new Map<string, ResolvedAsset>();
+  for (const entry of values(payload, "currencies")) {
+    const ticker = readString(entry, "ticker") ?? readString(entry, "key")?.split("@")[0];
+    const bank = readString(entry, "bank_symbol");
+    const digits = asRecord(entry)?.decimal_digits;
+    if (ticker === undefined || bank === undefined || typeof digits !== "number") {
+      continue;
+    }
+    const existing = resolver.get(ticker) ?? { ticker, bankSymbols: [], decimalDigits: digits };
+    if (!existing.bankSymbols.includes(bank)) {
+      existing.bankSymbols.push(bank);
+    }
+    resolver.set(ticker, existing);
+  }
+  return resolver;
+}
+
+/** Sum the wallet's micro balance of a ticker by its resolved bank denom(s) — never `symbol`/`amount_usd`. */
+export function heldMicro(balancesPayload: unknown, resolved: ResolvedAsset | undefined): bigint {
+  if (resolved === undefined) {
+    return 0n;
+  }
+  const banks = new Set(resolved.bankSymbols);
+  let total = 0n;
+  for (const entry of values(balancesPayload, "balances")) {
+    const denom = readString(entry, "denom");
+    const amount = readString(entry, "amount");
+    if (denom !== undefined && banks.has(denom) && amount !== undefined && /^\d+$/.test(amount)) {
+      total += BigInt(amount);
+    }
+  }
+  return total;
+}
+
+/** The USD price of a ticker from `/api/prices` (`price_usd`), or undefined when absent. */
+export function priceUsdOf(pricesPayload: unknown, ticker: string): Decimal | undefined {
+  for (const entry of values(pricesPayload, "prices")) {
+    const price = readString(entry, "price_usd");
+    const symbol = readString(entry, "symbol");
+    const keyTicker = readString(entry, "key")?.split("@")[0];
+    if (price !== undefined && /^\d+(\.\d+)?$/.test(price) && (symbol === ticker || keyTicker === ticker)) {
+      return Decimal.fromString(price);
+    }
+  }
+  return undefined;
+}
+
+/** USD value of a micro holding: `micro / 10^decimals × priceUsd`, all scaled-integer decimals. */
+export function microToUsd(micro: bigint, decimalDigits: number, priceUsd: Decimal): Decimal {
+  return Decimal.fromAtomics(micro.toString(), decimalDigits).mul(priceUsd);
+}
+
+/** Tickers the resolver knows whose name contains `needle` (e.g. every USDC variant). */
+export function tickersMatching(resolver: Map<string, ResolvedAsset>, needle: string): string[] {
+  const wanted = needle.toUpperCase();
+  return [...resolver.keys()].filter((ticker) => ticker.toUpperCase().includes(wanted));
+}

--- a/e2e/src/t3/flows/earn.spec.ts
+++ b/e2e/src/t3/flows/earn.spec.ts
@@ -7,7 +7,7 @@ import { USDC_DECIMALS } from "../../config.js";
 import { toMicroAmount } from "../../transfer.js";
 import { Decimal } from "../../oracle/decimal.js";
 import { formatDecAsUsd } from "../../oracle/format.js";
-import { microBalanceByDenom } from "./apiReads.js";
+import { usdcMicro } from "./apiReads.js";
 import { submitForm } from "./formDriver.js";
 import { readJson } from "../runtime.js";
 import { assertNonZeroBasis } from "./tolerance.js";
@@ -52,7 +52,7 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
   budget.route = "/earn/supply";
 
   const requiredMicro = BigInt(toMicroAmount(DUST_USDC, USDC_DECIMALS));
-  const balance = await microBalanceByDenom(run.ctx, wallet.address, "usdc");
+  const balance = await usdcMicro(run.ctx, wallet.address, run.currencyResolver);
   requireOrSkip(
     testInfo,
     run.matrix.expectFunded,

--- a/e2e/src/t3/flows/lease.spec.ts
+++ b/e2e/src/t3/flows/lease.spec.ts
@@ -15,16 +15,23 @@ import { USDC_DECIMALS } from "../../config.js";
 import { toMicroAmount } from "../../transfer.js";
 import { Decimal } from "../../oracle/decimal.js";
 import { computeLiquidation, leaseSizeCell } from "../../oracle/lease.js";
-import { microBalanceByDenom, openedLease, leaseProtocolConfigs, heldAssetUsd, currencies } from "./apiReads.js";
+import {
+  usdcMicro,
+  assetMicro,
+  probeSwapRoute,
+  openedLease,
+  leaseProtocolConfigs,
+  heldAssetUsd,
+  currencies
+} from "./apiReads.js";
 import { submitForm, openDetailDialog } from "./formDriver.js";
-import { remainsAboveMin, hasSwapRoute } from "./preconditions.js";
+import { remainsAboveMin } from "./preconditions.js";
 import { planLeaseDownpayment } from "./leasePlan.js";
 import type { LeaseDownpaymentPlan } from "./leasePlan.js";
 import { resolveShortLeaseStable } from "./sideSelection.js";
 import type { LeaseSide } from "./sideSelection.js";
 import { assertNonZeroBasis, assertWithinTolerance } from "./tolerance.js";
 import { USDC_DENOM } from "./denoms.js";
-import { readJson } from "../runtime.js";
 
 // The alternating-side single-lease lifecycle (#283 flow 1), run same-run on ONE opened lease so
 // the pre-run sweep never sees a cross-run orphan: open → TP/SL create + edit → dust repay
@@ -141,27 +148,22 @@ async function assertOpenedLeaseOracle(
   }
 }
 
-/** The wallet's USDC balance expressed in USD (USDC ~ $1 at 6 decimals). */
+/** The wallet's USDC balance expressed in USD (USDC ~ $1 at 6 decimals), summed by resolved denom. */
 async function usdcHeldUsd(ctx: RunContext["ctx"], address: string): Promise<Decimal> {
-  return Decimal.fromAtomics((await microBalanceByDenom(ctx, address, "usdc")).toString(), USDC_DECIMALS);
-}
-
-/** Whether a USDC → target swap route exists for the acquisition amount (dust routinely has none). */
-async function acquireRoutable(ctx: RunContext["ctx"], acquireUsdcMicro: string): Promise<boolean> {
-  const payload = await readJson(
-    ctx,
-    `${ctx.origin}/api/swap/route?from=${encodeURIComponent(USDC_DENOM)}&to=${encodeURIComponent(ACQUIRE_TARGET)}&amount=${encodeURIComponent(acquireUsdcMicro)}`
-  ).catch(() => null);
-  return hasSwapRoute(payload);
+  return Decimal.fromAtomics((await usdcMicro(ctx, address, run.currencyResolver)).toString(), USDC_DECIMALS);
 }
 
 /** Acquire the downpayment asset by swapping USDC through the engine — capped in USDC, route-gated. */
 async function acquireDownpaymentAsset(page: Page, testInfo: TestInfo, acquireUsd: Decimal): Promise<void> {
   const acquireMicro = toMicroAmount(acquireUsd.toString(USDC_DECIMALS), USDC_DECIMALS);
+  const route = await probeSwapRoute(run.ctx, USDC_DENOM, ACQUIRE_TARGET, acquireMicro);
+  if (route.status === "error") {
+    annotateSkipAndStop(testInfo, "environment", `acquire route probe failed: ${route.reason}`);
+  }
   requireOrSkip(
     testInfo,
     run.matrix.expectFunded,
-    await acquireRoutable(run.ctx, acquireMicro),
+    route.status === "routable",
     `no swap route to acquire the ${ACQUIRE_TARGET} downpayment`
   );
   await connectFlow(page, run, "/assets/swap");
@@ -202,18 +204,19 @@ async function resolveDownpayment(
 ): Promise<ResolvedDownpayment> {
   const plan: LeaseDownpaymentPlan = planLeaseDownpayment({
     protocols: await leaseProtocolConfigs(run.ctx),
-    heldUsd: await heldAssetUsd(run.ctx, address),
+    heldUsd: await heldAssetUsd(run.ctx, address, run.currencyResolver, run.pricesPayload),
     usdcUsd: await usdcHeldUsd(run.ctx, address),
     acquireTarget: ACQUIRE_TARGET,
     acquireBufferUsd: Decimal.fromString(ACQUIRE_BUFFER_USD)
   });
   if (plan.kind === "skip") {
+    testInfo.annotations.push({ type: "matrix-skip", description: `lease downpayment: ${plan.reason}` });
     annotateSkipAndStop(testInfo, "precondition", `lease downpayment unavailable: ${plan.reason}`);
   }
   if (plan.kind === "acquire") {
     await acquireDownpaymentAsset(page, testInfo, plan.acquireUsd);
   }
-  const micro = await microBalanceByDenom(run.ctx, address, ACQUIRE_TARGET.toLowerCase());
+  const micro = await assetMicro(run.ctx, address, run.currencyResolver, ACQUIRE_TARGET);
   requireOrSkip(
     testInfo,
     run.matrix.expectFunded,

--- a/e2e/src/t3/flows/stake.spec.ts
+++ b/e2e/src/t3/flows/stake.spec.ts
@@ -9,13 +9,15 @@ import {
   spendCommittedOrSkip
 } from "./support.js";
 import { messageValue } from "../../t2/appDriver.js";
-import { typeAmount, requireOrSkip, probeNativeMicroBalance, readString } from "../../t2/matrixHelpers.js";
+import { typeAmount, requireOrSkip, probeNativeMicroBalance } from "../../t2/matrixHelpers.js";
 import { NATIVE_DENOM, NATIVE_DECIMALS, toMicroAmount } from "../../transfer.js";
 import { Decimal } from "../../oracle/decimal.js";
 import { formatTokenBalance } from "../../oracle/format.js";
 import { submitForm } from "./formDriver.js";
 import { unbondingEntriesFor } from "./apiReads.js";
 import { pickUnbondingValidator, unbondingEntryGate } from "./preconditions.js";
+import { parseDelegations, parseAccruedRewardMicro, parseMaturingRedelegationCount } from "./staking.js";
+import type { Delegation } from "./staking.js";
 import { readJson } from "../runtime.js";
 
 // Stake delegate / undelegate / redelegate / claim of dust NLS (#283 flow 3). Undelegate is
@@ -29,25 +31,12 @@ const TERMINAL_MS = 120000;
 
 let run: RunContext;
 
-interface Delegation {
-  validatorAddress: string;
-  amountMicro: bigint;
+async function stakingPositions(ctx: RunContext["ctx"], address: string): Promise<unknown> {
+  return readJson(ctx, `${ctx.origin}/api/staking/positions?address=${encodeURIComponent(address)}`);
 }
 
 async function delegations(ctx: RunContext["ctx"], address: string): Promise<Delegation[]> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${encodeURIComponent(address)}`);
-  const list = typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).delegations : [];
-  const out: Delegation[] = [];
-  if (Array.isArray(list)) {
-    for (const entry of list) {
-      const validatorAddress = readString(entry, "validator_address");
-      const amount = readString(entry, "balance") ?? readString(entry, "amount");
-      if (validatorAddress !== undefined && amount !== undefined && /^\d+$/.test(amount)) {
-        out.push({ validatorAddress, amountMicro: BigInt(amount) });
-      }
-    }
-  }
-  return out;
+  return parseDelegations(await stakingPositions(ctx, address));
 }
 
 test.beforeAll(async () => {
@@ -141,9 +130,7 @@ test("stake undelegate is precondition-gated on the per-validator unbonding-entr
 });
 
 async function maturingRedelegationCount(ctx: RunContext["ctx"], address: string): Promise<number> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${encodeURIComponent(address)}`);
-  const list = typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).redelegation : [];
-  return Array.isArray(list) ? list.length : 0;
+  return parseMaturingRedelegationCount(await stakingPositions(ctx, address));
 }
 
 test("stake redelegate runs through the engine redelegate mutex, gated on no maturing redelegation", async ({
@@ -188,16 +175,7 @@ test("stake redelegate runs through the engine redelegate mutex, gated on no mat
 });
 
 async function accruedRewardMicro(ctx: RunContext["ctx"], address: string): Promise<bigint> {
-  const payload = await readJson(ctx, `${ctx.origin}/api/staking/positions?address=${encodeURIComponent(address)}`);
-  const rewards = typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>).rewards : [];
-  let total = 0n;
-  if (Array.isArray(rewards)) {
-    for (const entry of rewards) {
-      const amount = readString(entry, "amount") ?? readString(entry, "balance");
-      if (amount !== undefined && /^\d+$/.test(amount)) total += BigInt(amount);
-    }
-  }
-  return total;
+  return parseAccruedRewardMicro(await stakingPositions(ctx, address));
 }
 
 test("stake claim is tolerance-gated and skips cleanly when accrued rewards are below dust", async ({

--- a/e2e/src/t3/flows/staking.test.ts
+++ b/e2e/src/t3/flows/staking.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { parseAccruedRewardMicro, parseDelegations, parseMaturingRedelegationCount } from "./staking.js";
+
+// Real /api/staking/positions shape: StakingPosition.balance and ValidatorReward.rewards[] are
+// BalanceInfoSimple OBJECTS { denom, amount }, not strings.
+const POSITIONS = {
+  delegations: [
+    { validator_address: "nolusvaloper1a", shares: "500000000", balance: { denom: "unls", amount: "500000000" } },
+    { validator_address: "nolusvaloper1b", shares: "0", balance: { denom: "unls", amount: "0" } }
+  ],
+  unbonding: [],
+  rewards: [
+    {
+      validator_address: "nolusvaloper1a",
+      rewards: [
+        { denom: "unls", amount: "12345" },
+        { denom: "ibc/x", amount: "6" }
+      ]
+    }
+  ],
+  redelegation: [{ validator_src_address: "nolusvaloper1a", validator_dst_address: "nolusvaloper1b" }],
+  total_staked: "500000000",
+  total_rewards: "12345"
+};
+
+describe("parseDelegations", () => {
+  it("reads the micro amount from the nested balance object (not the object itself)", () => {
+    expect(parseDelegations(POSITIONS)).toEqual([
+      { validatorAddress: "nolusvaloper1a", amountMicro: 500000000n },
+      { validatorAddress: "nolusvaloper1b", amountMicro: 0n }
+    ]);
+  });
+
+  it("returns empty for a missing delegations array", () => {
+    expect(parseDelegations({})).toEqual([]);
+  });
+});
+
+describe("parseAccruedRewardMicro", () => {
+  it("sums the nested reward coins' amounts across validators", () => {
+    expect(parseAccruedRewardMicro(POSITIONS)).toBe(12351n);
+  });
+
+  it("returns 0 when there are no rewards", () => {
+    expect(parseAccruedRewardMicro({ rewards: [] })).toBe(0n);
+  });
+});
+
+describe("parseMaturingRedelegationCount", () => {
+  it("counts in-progress redelegations", () => {
+    expect(parseMaturingRedelegationCount(POSITIONS)).toBe(1);
+    expect(parseMaturingRedelegationCount({})).toBe(0);
+  });
+});

--- a/e2e/src/t3/flows/staking.ts
+++ b/e2e/src/t3/flows/staking.ts
@@ -1,0 +1,50 @@
+import { readString } from "../../t2/matrixHelpers.js";
+
+// Pure parsers over the live `/api/staking/positions` shape. `StakingPosition.balance` and each
+// `ValidatorReward.rewards[]` are BalanceInfoSimple OBJECTS ({ denom, amount }) — reading them as
+// strings is what dropped every delegation/reward and made the specs skip with "no delegation".
+
+export interface Delegation {
+  validatorAddress: string;
+  amountMicro: bigint;
+}
+
+function listAt(payload: unknown, key: string): unknown[] {
+  const list = typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>)[key] : undefined;
+  return Array.isArray(list) ? list : [];
+}
+
+/** Delegations with their micro amount read from the nested `balance.amount` object field. */
+export function parseDelegations(payload: unknown): Delegation[] {
+  const out: Delegation[] = [];
+  for (const entry of listAt(payload, "delegations")) {
+    const validatorAddress = readString(entry, "validator_address");
+    const amount = readString(entry, "balance", "amount");
+    if (validatorAddress !== undefined && amount !== undefined && /^\d+$/.test(amount)) {
+      out.push({ validatorAddress, amountMicro: BigInt(amount) });
+    }
+  }
+  return out;
+}
+
+/** Total accrued reward micro, summed over each `ValidatorReward.rewards[]` coin's `amount`. */
+export function parseAccruedRewardMicro(payload: unknown): bigint {
+  let total = 0n;
+  for (const entry of listAt(payload, "rewards")) {
+    const coins = typeof entry === "object" && entry !== null ? (entry as Record<string, unknown>).rewards : [];
+    if (Array.isArray(coins)) {
+      for (const coin of coins) {
+        const amount = readString(coin, "amount");
+        if (amount !== undefined && /^\d+$/.test(amount)) {
+          total += BigInt(amount);
+        }
+      }
+    }
+  }
+  return total;
+}
+
+/** Count of in-progress redelegations (a second is locked while any is maturing). */
+export function parseMaturingRedelegationCount(payload: unknown): number {
+  return listAt(payload, "redelegation").length;
+}

--- a/e2e/src/t3/flows/support.ts
+++ b/e2e/src/t3/flows/support.ts
@@ -29,6 +29,8 @@ import type { OpenLease, PendingUnbonding, TerminalPath } from "../report.js";
 import { seqAllocatorFromJournal } from "./seq.js";
 import type { SeqAllocator } from "./seq.js";
 import { seedCapFromJournal } from "./capSeed.js";
+import { parseCurrencyResolver } from "./denomResolver.js";
+import type { ResolvedAsset } from "./denomResolver.js";
 import { dayOfYearUtc, resolveLeaseSideSetting, resolveLeaseSides } from "./sideSelection.js";
 import type { LeaseSide } from "./sideSelection.js";
 
@@ -69,6 +71,10 @@ export interface RunContext {
   labels: ConnectLabels;
   usdTolerance: string;
   leaseSides: LeaseSide[];
+  /** ticker → resolved bank denom(s) + decimals, loaded once from /api/currencies. */
+  currencyResolver: Map<string, ResolvedAsset>;
+  /** Raw /api/prices payload, loaded once (ticker → price_usd). */
+  pricesPayload: unknown;
 }
 
 let runContext: RunContext | undefined;
@@ -156,6 +162,8 @@ export async function getRunContext(testInfo: TestInfo): Promise<RunContext> {
   const roles = await deriveRoles(config.t2);
   const chain = await resolveChain(ctx, config.matrix.chainRpc);
   const locale = await fetchLocale(ctx);
+  const currencyResolver = parseCurrencyResolver(await readJson(ctx, `${ctx.origin}/api/currencies`));
+  const pricesPayload = await readJson(ctx, `${ctx.origin}/api/prices`);
   const queue = new SerialQueue();
   const cap = spendCapFromMicros({ nlsMicro: config.t3.spendCapNlsMicro, usdcMicro: config.t3.spendCapUsdcMicro });
   const store = new JournalStore(config.t3.resultsDir);
@@ -181,7 +189,9 @@ export async function getRunContext(testInfo: TestInfo): Promise<RunContext> {
     locale,
     labels: readConnectLabels(locale),
     usdTolerance: process.env.E2E_USD_TOLERANCE?.trim() || DEFAULT_USD_TOLERANCE,
-    leaseSides: resolveLeaseSides(config.leaseSetting, dayOfYearUtc(new Date()))
+    leaseSides: resolveLeaseSides(config.leaseSetting, dayOfYearUtc(new Date())),
+    currencyResolver,
+    pricesPayload
   };
   return runContext;
 }

--- a/e2e/src/t3/flows/swap.spec.ts
+++ b/e2e/src/t3/flows/swap.spec.ts
@@ -1,12 +1,17 @@
 import { test, expect } from "./support.js";
 import type { Page } from "@playwright/test";
 import type { RunContext } from "./support.js";
-import { getRunContext, connectFlow, reportLeftover, skipIfHalted, spendCommittedOrSkip } from "./support.js";
+import {
+  getRunContext,
+  connectFlow,
+  reportLeftover,
+  skipIfHalted,
+  spendCommittedOrSkip,
+  annotateSkipAndStop
+} from "./support.js";
 import { typeAmount, requireOrSkip, waitForFundedFromNls } from "../../t2/matrixHelpers.js";
 import { NATIVE_DENOM, NATIVE_DECIMALS, toMicroAmount } from "../../transfer.js";
-import { hasSwapRoute } from "./preconditions.js";
-import { microBalanceByDenom } from "./apiReads.js";
-import { readJson } from "../runtime.js";
+import { usdcMicro, probeSwapRoute } from "./apiReads.js";
 import { USDC_DENOM } from "./denoms.js";
 
 // Quote -> execute a dust swap (#283 flow 6). The Skip WS topic is DEAD CODE — the app tracks
@@ -19,14 +24,6 @@ const SWAP_NLS = "0.01";
 const TERMINAL_MS = 120000;
 
 let run: RunContext;
-
-async function probeRoute(ctx: RunContext["ctx"], amountMicro: string): Promise<boolean> {
-  const payload = await readJson(
-    ctx,
-    `${ctx.origin}/api/swap/route?from=${encodeURIComponent(NATIVE_DENOM)}&to=${encodeURIComponent(USDC_DENOM)}&amount=${encodeURIComponent(amountMicro)}`
-  ).catch(() => null);
-  return hasSwapRoute(payload);
-}
 
 type SwapTerminal = "success" | "failure" | "pending";
 
@@ -64,15 +61,23 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
   budget.route = "/assets/swap";
 
   const amountMicro = toMicroAmount(SWAP_NLS, NATIVE_DECIMALS);
-  const routable = await probeRoute(run.ctx, amountMicro);
-  requireOrSkip(testInfo, run.matrix.expectFunded, routable, "no Skip route for the dust swap amount");
+  const route = await probeSwapRoute(run.ctx, NATIVE_DENOM, USDC_DENOM, amountMicro);
+  if (route.status === "error") {
+    annotateSkipAndStop(testInfo, "environment", `swap route probe failed: ${route.reason}`);
+  }
+  requireOrSkip(
+    testInfo,
+    run.matrix.expectFunded,
+    route.status === "routable",
+    "no Skip route for the dust swap amount"
+  );
 
   await connectFlow(page, run, "/assets/swap");
   await page.locator("#swap-1").waitFor({ state: "visible", timeout: 15000 });
   await waitForFundedFromNls(page);
   await typeAmount(page, "swap-1", SWAP_NLS);
 
-  const usdcBefore = await microBalanceByDenom(run.ctx, wallet.address, "usdc");
+  const usdcBefore = await usdcMicro(run.ctx, wallet.address, run.currencyResolver);
   await spendCommittedOrSkip(testInfo, run, {
     spec: "t3-flow-swap",
     action: "swap",
@@ -100,7 +105,7 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
   });
 
   await expect
-    .poll(() => microBalanceByDenom(run.ctx, wallet.address, "usdc"), {
+    .poll(() => usdcMicro(run.ctx, wallet.address, run.currencyResolver), {
       message: "the swapped-to USDC balance should strictly increase after a committed swap",
       timeout: TERMINAL_MS,
       intervals: [3000, 5000, 5000, 5000]


### PR DESCRIPTION
Fifth funded t3-flows dispatch (29596627623) went green but every value-moving spec skipped: the precondition probes identified assets via the balances endpoint symbol and amount_usd fields, and live those carry the raw ibc bank hash and a near-zero USD join for the USDC denom. Separately, the staking probes read StakingPosition.balance as a string when it is an object, dropping every delegation.

Probes now resolve asset identity through the currencies metadata (ticker to bank denom and decimals, loaded once per run), compare micro amounts by resolved bank denom, and take USD valuation from the prices endpoint with scaled-integer math. The staking reads parse the real object shapes (delegation balance, nested reward arrays, redelegation entries). A swap-route probe error is now its own logged environment skip rather than a silent no-route, and the lease plan-skip path annotates its reason like every other skip.

Verification: full e2e gate green on a clean install (367 tests; the new resolver and staking parsers unit-tested against fixtures shaped like the real responses — hash symbols, zero USD joins, object balances); the next funded dispatch is the live proof.