### PR TITLE
fix(stake): surface classified error on undelegate failure

### DIFF
--- a/src/modules/stake/components/UndelegateForm.test.ts
+++ b/src/modules/stake/components/UndelegateForm.test.ts
@@ -99,7 +99,9 @@ vi.mock("@/common/utils", () => ({
   Logger: { error: vi.fn() },
   formatDateTime: (d: string) => d,
   validateAmountV2: hoisted.validateAmountV2Mock,
-  walletOperation: hoisted.walletOperationMock
+  walletOperation: hoisted.walletOperationMock,
+  classifyError: (e: unknown) =>
+    e instanceof Error && /liquidity/i.test(e.message) ? "message.no-liquidity" : "message.unexpected-error"
 }));
 
 vi.mock("@/common/utils/NumberFormatUtils", () => ({
@@ -242,6 +244,19 @@ describe("UndelegateForm.vue", () => {
     expect(txs.length).toBe(2);
     const total = txs.reduce((acc, t) => acc + BigInt(t.amount.amount), 0n);
     expect(total).toBe(800_000_000n);
+    wrapper.unmount();
+  });
+
+  it("surfaces a localized message (not a silent stop) when undelegate rejects", async () => {
+    hoisted.walletOperationMock.mockRejectedValueOnce(new Error("broadcast failed"));
+    const wrapper = factory();
+    await wrapper.find('[data-test="amount"]').setValue("100");
+    await wrapper.find('[data-test="submit"]').trigger("click");
+    await flushPromises();
+    await nextTick();
+    // The failure used to be swallowed (Logger.error only) - the field now shows
+    // a classified message instead of staying blank.
+    expect(wrapper.find('[data-test="error"]').text()).toBe("message.unexpected-error");
     wrapper.unmount();
   });
 

--- a/src/modules/stake/components/UndelegateForm.vue
+++ b/src/modules/stake/components/UndelegateForm.vue
@@ -74,7 +74,7 @@ import { useBalancesStore } from "@/common/stores/balances";
 import { useStakingStore } from "@/common/stores/staking";
 import { useHistoryStore } from "@/common/stores/history";
 import { Dec } from "@keplr-wallet/unit";
-import { formatDateTime, Logger, validateAmountV2, walletOperation } from "@/common/utils";
+import { classifyError, formatDateTime, Logger, validateAmountV2, walletOperation } from "@/common/utils";
 import { useRouter } from "vue-router";
 import { RouteNames } from "@/router";
 import { formatDecAsUsd, formatTokenBalance } from "@/common/utils/NumberFormatUtils";
@@ -155,6 +155,9 @@ async function onNextClick() {
       await walletOperation(undelegate);
     } catch (e) {
       Logger.error(e);
+      // Don't swallow: an undelegate failure after validation (simulation /
+      // broadcast) must surface a localized message on the field.
+      validationError.value = i18n.t(classifyError(e));
     } finally {
       disabled.value = false;
     }


### PR DESCRIPTION
UndelegateForm's submit catch only logged: a rejected undelegate after validation (validator fetch, simulation, broadcast) surfaced nothing to the user. Ports the identical classify-and-surface pattern DelegateForm already uses.

Verification: new component test proves the rejection surfaces the classified message — it fails against the unfixed component (field stays blank) and passes after; full root gate green (vue-tsc, eslint, style, prettier, 1042 vitest tests, build).