### PR TITLE
refactor(e2e): regression runs ad hoc and post-deploy, cron removed

### DIFF
--- a/.github/workflows/e2e-regression.yaml
+++ b/.github/workflows/e2e-regression.yaml
@@ -1,35 +1,41 @@
-name: E2E nightly (scheduled full run)
+name: E2E regression (post-deploy + manual)
 
 on:
-  schedule:
-    # 03:17 UTC — deliberately off the deploy window so a nightly never races a cutover.
-    - cron: "17 3 * * *"
+  # Ad-hoc: a manual full-suite run against any host.
   workflow_dispatch:
     inputs:
       base_domain:
-        description: "Target host to run against; falls back to the E2E_NIGHTLY_BASE_DOMAIN repo variable."
+        description: "Target host to run against; falls back to the E2E_REGRESSION_BASE_DOMAIN repo variable."
         required: false
         type: string
       prerelease:
-        description: "Pre-release full run before a release cutover (same tiers as the nightly)."
+        description: "Pre-release full run before a release cutover (same tiers as a regression run)."
         required: false
         default: false
         type: boolean
+  # Automatic: regression-validate the staging host after a dev deploy completes. The job-level
+  # `if` below gates this path on the deploy having SUCCEEDED (a failed deploy has nothing to
+  # validate). workflow_run has no inputs, so that path resolves the base domain from the repo var.
+  workflow_run:
+    workflows: ["Deploy dev"]
+    types: [completed]
 
-# Serialize with the deploy workflow's live e2e phase on the one per-host rate-limit bucket:
-# nightly and post-deploy runs must never hit the strict bucket at the same time. The group
-# expression is duplicated here (a top-level concurrency key cannot read a step output); the
-# tiers below take their base domain from the single resolve step instead.
+# Serialize with the deploy workflow's live e2e phase on the one per-host rate-limit bucket: a
+# regression run and a second deploy's post-run must never hit the strict bucket at the same time.
+# The group expression is duplicated here (a top-level concurrency key cannot read a step output);
+# the tiers below take their base domain from the single resolve step instead.
 concurrency:
-  group: e2e-live-${{ inputs.base_domain || vars.E2E_NIGHTLY_BASE_DOMAIN }}
+  group: e2e-live-${{ inputs.base_domain || vars.E2E_REGRESSION_BASE_DOMAIN }}
   cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
-  nightly:
-    name: Nightly full suite
+  regression:
+    name: Regression full suite
+    # Manual dispatch always runs; the post-deploy path runs only when the deploy succeeded.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: [self-hosted, frontend-deploy]
     timeout-minutes: 75
 
@@ -47,7 +53,7 @@ jobs:
       - name: Resolve target base domain
         env:
           INPUT_BASE_DOMAIN: ${{ inputs.base_domain }}
-          VAR_BASE_DOMAIN: ${{ vars.E2E_NIGHTLY_BASE_DOMAIN }}
+          VAR_BASE_DOMAIN: ${{ vars.E2E_REGRESSION_BASE_DOMAIN }}
           RESOLVER_TARGET: ${{ vars.DEPLOY_HOST }}
           PRERELEASE: ${{ inputs.prerelease }}
         run: |
@@ -62,7 +68,7 @@ jobs:
           base="${INPUT_BASE_DOMAIN:-}"
           if [ -z "$base" ]; then base="${VAR_BASE_DOMAIN:-}"; fi
           if [ -z "$base" ]; then
-            echo "::error::no base domain resolved — pass base_domain on dispatch or set the E2E_NIGHTLY_BASE_DOMAIN repo variable (the cron path has no inputs and depends on the variable)"
+            echo "::error::no base domain resolved — pass base_domain on dispatch or set the E2E_REGRESSION_BASE_DOMAIN repo variable (the post-deploy path has no inputs and depends on the variable)"
             exit 1
           fi
           # Reject anything that is not a bare hostname BEFORE writing $GITHUB_ENV — a dispatch
@@ -220,11 +226,11 @@ jobs:
           echo "report cli exit code: ${code}"
           exit 0
 
-      - name: Upload nightly artifacts
+      - name: Upload regression artifacts
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: e2e-nightly-${{ env.BASE_DOMAIN }}
+          name: e2e-regression-${{ env.BASE_DOMAIN }}
           path: |
             e2e/results/
             e2e/playwright-report/
@@ -232,7 +238,7 @@ jobs:
           retention-days: 14
           if-no-files-found: ignore
 
-      - name: Heartbeat — a crashed nightly must still be heard
+      - name: Heartbeat — a crashed regression run must still be heard
         if: always()
         working-directory: e2e
         env:
@@ -248,15 +254,15 @@ jobs:
             echo "heartbeat: report.json present; the report cli owns this run's alert"
             exit 0
           fi
-          echo "::warning::nightly produced no report.json — the run crashed before the report step"
+          echo "::warning::regression run produced no report.json — it crashed before the report step"
           if [ -z "${ALERT_WEBHOOK:-}" ]; then
-            echo "::error::heartbeat: no alert webhook configured — a crashed nightly cannot be announced"
-            exit 1
+            echo "::warning::heartbeat: no alert webhook configured — crash is loud in the job status; report absent from artifacts"
+            exit 0
           fi
           # Static text only: no host or dynamic value, so no scrub pass is required.
           curl -fsS --max-time 15 -X POST "$ALERT_WEBHOOK" \
             -H 'content-type: application/json' \
-            -d '{"suite":"e2e-nightly","urgency":"loud","kind":"heartbeat","summary":"nightly produced no report — the run crashed before the report step; investigate the run logs"}' \
+            -d '{"suite":"e2e-regression","urgency":"loud","kind":"heartbeat","summary":"regression run produced no report — it crashed before the report step; investigate the run logs"}' \
             || { echo "::error::heartbeat: alert delivery failed"; exit 1; }
           echo "heartbeat: posted no-report alert"
 
@@ -271,12 +277,12 @@ jobs:
           # recorded. A missing code means the report step never ran or crashed — fail closed.
           code="${REPORT_EXIT:-}"
           if [ -z "$code" ]; then
-            echo "::error::report step recorded no exit code — it never ran or crashed; failing the nightly"
+            echo "::error::report step recorded no exit code — it never ran or crashed; failing the regression run"
             exit 1
           fi
           case "$code" in
-            0) echo "nightly green — no classified failures" ; exit 0 ;;
-            1) echo "::error::nightly red — classified failures present (see report.md)" ; exit 1 ;;
-            2) echo "::error::nightly alert delivery/config failure" ; exit 2 ;;
+            0) echo "regression green — no classified failures" ; exit 0 ;;
+            1) echo "::error::regression red — classified failures present (see report.md)" ; exit 1 ;;
+            2) echo "::error::regression alert delivery failure" ; exit 2 ;;
             *) echo "::error::unexpected report exit code: ${code}" ; exit 1 ;;
           esac

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -618,8 +618,8 @@ a spend-cap dry proof, and the single operator-approved live broadcast: a dust n
 the primary and wallet-2). Base URL and host resolver are composed from the `base_domain` input and
 the `DEPLOY_HOST` var exactly as `deploy.yaml` does — never hardcoded. Per-run caps are tiny
 (`E2E_SPEND_CAP_NLS=1`, `E2E_SPEND_CAP_USDC=0`). Journal and report artifacts are uploaded on every
-run, not only on failure. The nightly schedule for this smoke belongs to issue #285, not this
-workflow.
+run, not only on failure. Automatic scheduling of this smoke (the post-deploy regression run)
+belongs to issue #285, not this workflow.
 
 ## The T3 value-moving flows
 
@@ -747,7 +747,7 @@ redelegate mutex), and claim on accrued rewards being **above a dust threshold**
 ## Reporting and alerting
 
 The reporting tier (`src/report/`) folds a whole run's artifacts into one machine-readable report,
-renders a human summary, and posts a classified alert. It is the arbiter for the nightly: the tiers
+renders a human summary, and posts a classified alert. It is the arbiter for the run: the tiers
 run `continue-on-error`, and the report — not any single tier's exit code — decides the run's colour.
 
 - **Report shape (versioned).** `aggregate.ts` produces a `RunReport` carrying a `version` (bumped on
@@ -775,49 +775,51 @@ run `continue-on-error`, and the report — not any single tier's exit code — 
   becomes an explicit `absent` / `corrupt` field in the report, so one torn artifact never loses the
   rest of the run.
 - **Webhook contract.** `alert.ts` posts a compact classified summary to `E2E_ALERT_WEBHOOK` (a
-  secret; the endpoint is never committed). A **green** run posts nothing. An **env-flake / spend-cap
-  only** red posts a **low-urgency** payload. **Any app-bug** posts a **loud** payload. Failure modes
-  are fail-loud, never fail-silent: a non-2xx response, a network error, or a delivery that exceeds
-  the `DEFAULT_ALERT_TIMEOUT_MS` (15s) abort deadline exits non-zero with `alert delivery failed`, and
-  a **red run with no webhook configured** exits non-zero with `alert channel unconfigured` — an
-  unconfigured nightly must never look green. Every POST carries an `AbortSignal.timeout` so a
-  black-hole webhook fails fast instead of hanging the step until the job timeout. `cli.ts` exit
-  codes: `0` green, `1` red, `2` alert delivery / config failure.
+  secret; the endpoint is never committed). The webhook is **optional** under the human-watched
+  regression model. A **green** run posts nothing. An **env-flake / spend-cap only** red posts a
+  **low-urgency** payload; **any app-bug** posts a **loud** payload. A **red run with no webhook
+  configured** logs `no alert webhook configured — report in artifacts` and still **exits `1`** — the
+  job status carries the redness and the report is in the artifacts (it is not an error to leave the
+  webhook unset). Only a **configured but failed** delivery — a non-2xx response, a network error, or
+  a delivery past the `DEFAULT_ALERT_TIMEOUT_MS` (15s) abort deadline — throws `alert delivery failed`
+  and exits `2`, so a dropped red fails loudly rather than vanishing. Every POST carries an
+  `AbortSignal.timeout` so a black-hole webhook fails fast instead of hanging the step until the job
+  timeout. `cli.ts` exit codes: `0` green, `1` red, `2` alert delivery failure.
 - **Scrubbing.** Every report / render / alert string is scrubbed twice: `sanitizeRpc` (bare IPv4 and
   `user:pass@` credential forms) plus explicit removal of the resolver-target value passed as
   `E2E_SCRUB_VALUE` (set by CI from `vars.DEPLOY_HOST`, never committed) and, when present in env, the
   run mnemonics. The suite's inputs are already sanitized at source; this is the belt-and-suspenders
   egress pass over `report.json`, `report.md`, and the webhook payload.
-- **Nightly schedule.** `.github/workflows/e2e-nightly.yaml` runs on cron `17 3 * * *` (off the deploy
-  window) and on `workflow_dispatch`. The target base domain resolves in one place —
-  `inputs.base_domain || vars.E2E_NIGHTLY_BASE_DOMAIN` — and the first step hard-fails if empty (the
-  cron path has no inputs, so it depends on the repo variable). That step also validates the resolved
-  base against `^[A-Za-z0-9.-]+$` before writing `$GITHUB_ENV` (a newline-bearing dispatch input must
-  not inject env entries) and `::add-mask::`es the resolver target so tier stdout/stderr can never
-  print the internal host in the public log. The job clears `results/`, `test-results/`, and
+- **Scheduling (ad-hoc + post-deploy regression).** `.github/workflows/e2e-regression.yaml` runs two
+  ways and **never on a cron**: a manual `workflow_dispatch` (optional `base_domain` input), and
+  automatically on `workflow_run` after the **Deploy dev** workflow completes — the job's `if` gates
+  that path on the deploy having **succeeded**, so a green staging deploy is immediately
+  regression-validated. The target base domain resolves in one place —
+  `inputs.base_domain || vars.E2E_REGRESSION_BASE_DOMAIN` — and the first step hard-fails if empty (the
+  post-deploy path has no inputs, so it depends on the repo variable). That step also validates the
+  resolved base against `^[A-Za-z0-9.-]+$` before writing `$GITHUB_ENV` (a newline-bearing dispatch
+  input must not inject env entries) and `::add-mask::`es the resolver target so tier stdout/stderr can
+  never print the internal host in the public log. The job clears `results/`, `test-results/`, and
   `playwright-report/` at the start, so `report.json` is present iff this run's cli wrote it. Tiers run
   `continue-on-error` so all of them run and the report arbitrates; the artifact scrub runs `always()`;
   the report step (also `continue-on-error`) records the cli's exit code to `$GITHUB_OUTPUT`; artifacts
   upload `always()`. **Exactly one alert leaves a run:** the cli owns it whenever a `report.json`
   exists (green→silent, red→posted, alert-failure→surfaced by the arbiter), and a final `always()`
-  heartbeat fires a loud static "no report" alert **only when `report.json` is absent** (a true crash),
-  failing loudly if no webhook is configured. A final `always()` arbiter step sets the job conclusion
-  from the recorded cli exit code (`1` red / `2` alert-failure; missing code → fail closed with `1`).
-  The nightly shares the `e2e-live-<base_domain>` concurrency group with the deploy workflow's live
-  e2e phase so the two never contend for the one per-host rate-limit bucket.
+  heartbeat fires a loud static "no report" alert **only when `report.json` is absent** (a true crash).
+  A final `always()` arbiter step sets the job conclusion from the recorded cli exit code (`1` red /
+  `2` alert-failure; missing code → fail closed with `1`). The run shares the `e2e-live-<base_domain>`
+  concurrency group with the deploy workflow's live e2e phase so a regression run and a second deploy's
+  post-run never contend for the one per-host rate-limit bucket. Both the `workflow_run` trigger and
+  this workflow file must live on the default branch for the post-deploy path to fire.
 - **Budget pre-flight.** Before the tiers, `report:preflight` derives the primary address, reads its
   USDC holding through the host-resolver-aware read path, and posts a low-urgency warning (then
   continues) when the balance is below `E2E_USDC_LOW_WATER` (default `45`) — a degrading budget is
   announced _before_ the value-moving specs start skipping forever, not inferred from a silent skip list.
 - **Pre-release runs.** A pre-release full run is a manual `workflow_dispatch` with `prerelease: true`
-  before a release cutover; it runs the same full tier set as the nightly (no grep filter).
+  before a release cutover; it runs the same full tier set as a regression run (no grep filter).
 - **Trace capture (CI-verified).** The browser projects run with `trace: retain-on-failure` and
   `screenshot: only-on-failure`; a forced-failure trace/screenshot capture is verified in CI, not by a
   unit test (the same posture as the flows' selector assertions).
-- **Cron freshness caveat.** GitHub disables scheduled workflows after a stretch of repository
-  inactivity, so the _absence_ of a nightly is itself a signal that in-repo tooling cannot catch. Pair
-  this with an external freshness check (alert if no nightly report has arrived in >48h); that check
-  is out of scope for this repo.
 
 ## Conventions
 

--- a/e2e/src/report/alert.test.ts
+++ b/e2e/src/report/alert.test.ts
@@ -59,7 +59,7 @@ describe("postAlert", () => {
   it("posts nothing for a green run", async () => {
     const { fetchImpl, calls } = okFetch();
     const result = await postAlert(runReport([]), { webhookUrl: "https://hook", fetchImpl, scrub: identity });
-    expect(result).toEqual({ posted: false });
+    expect(result).toEqual({ posted: false, reason: "green" });
     expect(calls).toHaveLength(0);
   });
 
@@ -71,7 +71,7 @@ describe("postAlert", () => {
       scrub: identity
     });
     expect(result).toEqual({ posted: true, urgency: "low" });
-    expect(JSON.parse(calls[0]?.request.body ?? "{}")).toMatchObject({ urgency: "low", suite: "e2e-nightly" });
+    expect(JSON.parse(calls[0]?.request.body ?? "{}")).toMatchObject({ urgency: "low", suite: "e2e-regression" });
   });
 
   it("posts a loud payload when any app-bug is present", async () => {
@@ -122,17 +122,21 @@ describe("postAlert", () => {
     ).rejects.toThrow("alert delivery failed");
   });
 
-  it("throws alert channel unconfigured on a red run with no webhook", async () => {
-    const { fetchImpl } = okFetch();
-    await expect(
-      postAlert(runReport([failure("env-flake")]), { webhookUrl: undefined, fetchImpl, scrub: identity })
-    ).rejects.toThrow("alert channel unconfigured");
+  it("reports a red run with no webhook as unconfigured rather than throwing", async () => {
+    const { fetchImpl, calls } = okFetch();
+    const result = await postAlert(runReport([failure("env-flake")]), {
+      webhookUrl: undefined,
+      fetchImpl,
+      scrub: identity
+    });
+    expect(result).toEqual({ posted: false, reason: "unconfigured" });
+    expect(calls).toHaveLength(0);
   });
 
   it("stays silent on a green run with no webhook", async () => {
     const { fetchImpl, calls } = okFetch();
     const result = await postAlert(runReport([]), { webhookUrl: "", fetchImpl, scrub: identity });
-    expect(result).toEqual({ posted: false });
+    expect(result).toEqual({ posted: false, reason: "green" });
     expect(calls).toHaveLength(0);
   });
 

--- a/e2e/src/report/alert.ts
+++ b/e2e/src/report/alert.ts
@@ -38,7 +38,7 @@ export interface AlertConfig {
   makeSignal?: () => AbortSignal;
 }
 
-export type AlertResult = { posted: false } | { posted: true; urgency: Urgency };
+export type AlertResult = { posted: false; reason: "green" | "unconfigured" } | { posted: true; urgency: Urgency };
 
 interface AlertPayloadFailure {
   tier: string;
@@ -55,7 +55,7 @@ interface AlertPayloadTier {
 }
 
 interface AlertPayload {
-  suite: "e2e-nightly";
+  suite: "e2e-regression";
   version: number;
   urgency: Urgency;
   generatedAt: string;
@@ -95,7 +95,7 @@ function payloadFailure(failure: ClassifiedFailure, scrub: Scrubber): AlertPaylo
 
 function buildPayload(report: RunReport, urgency: Urgency, scrub: Scrubber): AlertPayload {
   return {
-    suite: "e2e-nightly",
+    suite: "e2e-regression",
     version: report.version,
     urgency,
     generatedAt: report.generatedAt,
@@ -106,24 +106,23 @@ function buildPayload(report: RunReport, urgency: Urgency, scrub: Scrubber): Ale
 }
 
 /**
- * Post the classified run summary to the alert webhook, or refuse loudly. A green run posts
- * nothing. An env-flake / spend-cap-only red posts a low-urgency payload; any app-bug posts a loud
- * one. A red run with no webhook configured throws `alert channel unconfigured` so an unconfigured
- * nightly can never look green, and a non-2xx response or a network failure throws `alert delivery
- * failed` so a dropped red fails the step rather than vanishing. Every payload string is scrubbed
- * again at this boundary.
+ * Post the classified run summary to the alert webhook. A green run posts nothing. An env-flake /
+ * spend-cap-only red posts a low-urgency payload; any app-bug posts a loud one. The webhook is
+ * optional under the human-watched regression model: a red run with no webhook returns
+ * `{ posted: false, reason: "unconfigured" }` (the caller logs a warning and still exits red — the
+ * job status carries the redness, and the report is in the artifacts), and only a CONFIGURED but
+ * failed delivery — a non-2xx response, a network error, or a timed-out abort — throws
+ * `alert delivery failed` so a dropped red fails loudly rather than vanishing. Every payload string
+ * is scrubbed again at this boundary.
  */
 export async function postAlert(report: RunReport, config: AlertConfig): Promise<AlertResult> {
   const color = runColor(report);
+  if (color === "green") {
+    return { posted: false, reason: "green" };
+  }
   const hasWebhook = config.webhookUrl !== undefined && config.webhookUrl.length > 0;
   if (!hasWebhook) {
-    if (color === "green") {
-      return { posted: false };
-    }
-    throw new AlertDeliveryError("alert channel unconfigured");
-  }
-  if (color === "green") {
-    return { posted: false };
+    return { posted: false, reason: "unconfigured" };
   }
   const urgency: Urgency = color === "app" ? "loud" : "low";
   const payload = buildPayload(report, urgency, config.scrub);

--- a/e2e/src/report/cli.ts
+++ b/e2e/src/report/cli.ts
@@ -184,7 +184,15 @@ async function run(): Promise<number> {
   writeFileSync(join(resultsDir, "report.md"), renderMarkdown(report, scrub), "utf8");
   try {
     const result = await postAlert(report, { webhookUrl: process.env.E2E_ALERT_WEBHOOK, fetchImpl: httpFetch, scrub });
-    process.stdout.write(result.posted ? `alert posted (${result.urgency})\n` : "alert: green run, no post\n");
+    if (result.posted) {
+      process.stdout.write(`alert posted (${result.urgency})\n`);
+    } else if (result.reason === "unconfigured") {
+      // A red run with no webhook is still loudly red via the exit code below; the report is in
+      // the artifacts. Only a configured-but-failed delivery escalates to exit 2.
+      process.stderr.write("no alert webhook configured — report in artifacts\n");
+    } else {
+      process.stdout.write("alert: green run, no post\n");
+    }
   } catch (error) {
     process.stderr.write(`${error instanceof AlertDeliveryError ? error.message : "alert delivery failed"}\n`);
     return 2;

--- a/e2e/src/report/preflight.ts
+++ b/e2e/src/report/preflight.ts
@@ -49,7 +49,7 @@ async function postWarning(webhook: string, summary: string): Promise<void> {
     await fetch(webhook, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ suite: "e2e-nightly", urgency: "low", kind: "budget-preflight", summary }),
+      body: JSON.stringify({ suite: "e2e-regression", urgency: "low", kind: "budget-preflight", summary }),
       // Same abort deadline as alert.ts so a black-hole webhook can't hang the pre-flight step.
       signal: AbortSignal.timeout(DEFAULT_ALERT_TIMEOUT_MS)
     });
@@ -86,7 +86,7 @@ async function run(): Promise<void> {
     process.stdout.write(`preflight: primary USDC ${balance} at or above the ${floor} floor\n`);
     return;
   }
-  const summary = `primary USDC balance below the ${floor} low-water floor — value-moving specs may start skipping; top up before the next nightly`;
+  const summary = `primary USDC balance below the ${floor} low-water floor — value-moving specs may start skipping; top up before the next regression run`;
   process.stdout.write(`${summary}\n`);
   const webhook = process.env.E2E_ALERT_WEBHOOK ?? "";
   if (webhook.length > 0) {

--- a/e2e/src/report/render.ts
+++ b/e2e/src/report/render.ts
@@ -107,7 +107,7 @@ function journalSection(journal: JournalSummary): string {
 /** Render the run report as a human-readable markdown summary. Every dynamic string is re-scrubbed. */
 export function renderMarkdown(report: RunReport, scrub: Scrubber): string {
   return [
-    `# E2E Nightly Report (v${report.version})`,
+    `# E2E Regression Report (v${report.version})`,
     "",
     `Generated: ${report.generatedAt}`,
     "",

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
         "src/t3/repair.ts",
         // Reporting-tier fs/network glue: reads the tier result files, writes report.json +
         // report.md, and posts the alert. The pure aggregate/render/alert/scrub modules it
-        // composes are unit-tested; the CLI shell itself is exercised by the nightly workflow.
+        // composes are unit-tested; the CLI shell itself is exercised by the regression workflow.
         "src/report/cli.ts",
         "src/report/preflight.ts",
         // T3 flow browser/network glue — the run singleton, live API reads, and form driver are


### PR DESCRIPTION
The full-suite run is now a regression validator, not a schedule: the cron trigger is removed, and the workflow (renamed e2e-regression.yaml) runs on manual dispatch or automatically after a successful dev deploy (workflow_run, job-gated on the deploy conclusion). The origin for the post-deploy path comes from the E2E_REGRESSION_BASE_DOMAIN repo variable, hard-failing when unset.

The alert model matches the human-watched shape: a red run with no webhook configured logs a warning and exits 1 (still red — never silent); exit 2 is reserved for a configured webhook that fails delivery; a crash still fails closed through the arbiter. Naming (suite string, report heading, artifacts) follows the rename.

Verification: full e2e gate green (367 tests over the floors); review walked every green/red/crash and webhook present/absent/failing combination — no path yields a green job for a red or crashed run; no dangling nightly references repo-wide.