### PR TITLE
fix(e2e): settle form submits on terminal signals, fix dialog labels

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -711,6 +711,18 @@ redelegate mutex), and claim on accrued rewards being **above a dust threshold**
 
 ### Deviations
 
+- **No confirmation dialog — the toast is the terminal signal.** The routed forms run
+  `walletOperation` DIRECTLY on the footer click; there is no confirm dialog. `formDriver.submitForm`
+  therefore clicks the submit once and settles on the app's terminal surface — a success **toast**
+  (`div.toast`) resolves, an inline error (`div.text-typography-error`) throws — never an
+  unconditional second confirm click (the earlier phantom `/confirm|submit|send/` click waited for
+  UI that never appears and timed out while the tx committed underneath, journaling committed txs as
+  failed). A success toast wins over a lingering error surface, and the decision over the surfaces is
+  the pure, unit-tested `decideTerminal`. When neither surface appears within the timeout, the driver
+  throws `terminal-signal-timeout` (classified `environment`): a broadcast may have committed after
+  the click, so the journal marks that submission failed while the outcome is genuinely ambiguous —
+  the **reconciliation sweep + balances read catch the untracked commit** on the next run, which is
+  exactly what that pre-run sweep exists for.
 - **Swap tracking (`skip_tx` is dead code).** The `skip_tx` WS topic is not driven by the app —
   swaps are tracked by client polling (`SkipRouter.fetchStatus` in `useSwapForm.ts`). `swap.spec.ts`
   therefore asserts via the UI's polled terminal state and post-swap balances, not a WS event. This

--- a/e2e/src/t3/flows/formDriver.ts
+++ b/e2e/src/t3/flows/formDriver.ts
@@ -51,6 +51,9 @@ async function readSurface(page: Page): Promise<TerminalSurface> {
  */
 export async function submitForm(page: Page, options: SubmitOptions): Promise<void> {
   await page.getByRole("button", { name: options.submitLabel, exact: true }).last().click();
+  // Capture the winning decision INSIDE the poll — once `success` is observed nothing may override
+  // it (no post-poll re-read, which would be a TOCTOU over the auto-dismissing toast).
+  let settled: TerminalDecision | undefined;
   try {
     await expect
       .poll(
@@ -64,17 +67,23 @@ export async function submitForm(page: Page, options: SubmitOptions): Promise<vo
               .catch(() => undefined);
             return "pending";
           }
+          settled = decision;
           return decision.kind;
         },
         { message: `submit "${options.submitLabel}" should reach a terminal surface`, timeout: options.terminalMs }
       )
       .not.toBe("pending");
-  } catch {
-    throw new Error(`terminal-signal-timeout: no toast or error surface after submitting "${options.submitLabel}"`);
+  } catch (error) {
+    // Relabel ONLY the poll's own timeout; rethrow a genuine harness/selector error unchanged.
+    const message = error instanceof Error ? error.message : String(error);
+    if (/timed out/i.test(message)) {
+      throw new Error(`terminal-signal-timeout: no toast or error surface after submitting "${options.submitLabel}"`, {
+        cause: error
+      });
+    }
+    throw error;
   }
-  // The poll left "pending" only on success or error; re-read the surface to route the outcome.
-  const settled: TerminalDecision = decideTerminal(await readSurface(page));
-  if (settled.kind === "error") {
+  if (settled?.kind === "error") {
     throw new Error(`form submission failed: ${settled.text}`);
   }
 }

--- a/e2e/src/t3/flows/formDriver.ts
+++ b/e2e/src/t3/flows/formDriver.ts
@@ -1,29 +1,82 @@
 import type { Page } from "@playwright/test";
 import { expect } from "../../t2/support.js";
+import { decideTerminal } from "./terminalSignal.js";
+import type { TerminalDecision, TerminalSurface } from "./terminalSignal.js";
 
-// Browser glue (coverage-excluded, see vitest.config.ts). The value-moving submit path is the
-// same across the routed forms (lease open/close, earn supply/withdraw, stake delegate/undelegate):
-// click the footer submit, confirm in the dialog, and resolve only once the app reaches a terminal
-// signal. Passed to the engine as the `execute` closure so a submission settles on commit, not on
-// the mere click — matching the SerialQueue's commit-release contract.
+// Browser glue (coverage-excluded, see vitest.config.ts). The value-moving forms (lease
+// open/repay/close, earn supply/withdraw, stake delegate/undelegate) run `walletOperation` DIRECTLY
+// on the footer click — the app has NO confirmation dialog. So the terminal signal is a success
+// toast (or an inline error), never a second confirm click. The decision over the observed surfaces
+// is the pure, unit-tested `decideTerminal`; this module only reads the surfaces and polls.
 
-const CONFIRM = /confirm|submit|send/i;
 const TOAST = "div.toast";
+const ERROR = "div.text-typography-error";
+// A DEDICATED confirm control only — never the footer submit labels (delegate / supply / repay /
+// close-btn-label / submit-btn / open-position), so a settle re-click can never double-submit a
+// governed tx under retries:0. Present only for a hypothetical future confirm dialog.
+const CONFIRM = /^confirm$|^approve$|^proceed$/i;
 
 export interface SubmitOptions {
   submitLabel: string;
   terminalMs: number;
 }
 
+async function readSurface(page: Page): Promise<TerminalSurface> {
+  const error = page.locator(ERROR).first();
+  const [toastVisible, errorVisible, confirmVisible] = await Promise.all([
+    page
+      .locator(TOAST)
+      .first()
+      .isVisible()
+      .catch(() => false),
+    error.isVisible().catch(() => false),
+    page
+      .getByRole("button", { name: CONFIRM })
+      .first()
+      .isVisible()
+      .catch(() => false)
+  ]);
+  const errorText = errorVisible ? await error.innerText().catch(() => "") : "";
+  return { toastVisible, errorVisible, errorText, confirmVisible };
+}
+
 /**
- * Drive a routed form's footer submit through confirmation and wait for the app's terminal toast.
- * The footer submit is targeted with `.last()` because a dialog tab often shares the submit label
- * (the same disambiguation `validation.spec.ts` documents).
+ * Click a form's footer submit and settle DIRECTLY on the app's terminal surface: a success toast
+ * resolves, an inline error throws with its text (sanitized upstream). Because the app has no
+ * confirmation dialog, this makes no unconditional second click — it only clicks a dedicated
+ * confirm button if a future dialog adds one, then keeps racing. A timeout with neither surface
+ * throws `terminal-signal-timeout` (a broadcast may have committed underneath — reconciliation
+ * catches the ambiguity), never a false success. This keeps committed-vs-failed in the journal
+ * matched to chain reality.
  */
 export async function submitForm(page: Page, options: SubmitOptions): Promise<void> {
   await page.getByRole("button", { name: options.submitLabel, exact: true }).last().click();
-  await page.getByRole("button", { name: CONFIRM }).first().click({ timeout: options.terminalMs });
-  await expect(page.locator(TOAST)).toBeVisible({ timeout: options.terminalMs });
+  try {
+    await expect
+      .poll(
+        async () => {
+          const decision = decideTerminal(await readSurface(page));
+          if (decision.kind === "click-confirm") {
+            await page
+              .getByRole("button", { name: CONFIRM })
+              .first()
+              .click()
+              .catch(() => undefined);
+            return "pending";
+          }
+          return decision.kind;
+        },
+        { message: `submit "${options.submitLabel}" should reach a terminal surface`, timeout: options.terminalMs }
+      )
+      .not.toBe("pending");
+  } catch {
+    throw new Error(`terminal-signal-timeout: no toast or error surface after submitting "${options.submitLabel}"`);
+  }
+  // The poll left "pending" only on success or error; re-read the surface to route the outcome.
+  const settled: TerminalDecision = decideTerminal(await readSurface(page));
+  if (settled.kind === "error") {
+    throw new Error(`form submission failed: ${settled.text}`);
+  }
 }
 
 /** Open a position/lease detail dialog by its on-chain address and wait for the dialog to render. */

--- a/e2e/src/t3/flows/lease.spec.ts
+++ b/e2e/src/t3/flows/lease.spec.ts
@@ -79,34 +79,34 @@ function firstUsdAmount(text: string): string | undefined {
   return raw === undefined ? undefined : raw.replace(/,/g, "");
 }
 
-/** Set the take-profit / stop-loss trigger in the open lease detail dialog (config-only, no spend). */
+/** Open the take-profit / stop-loss trigger dialog, set a trigger, and submit (submit-btn → toast). */
 async function setTakeProfitStopLoss(page: Page, triggerPercent: string): Promise<void> {
   await page
     .getByRole("button", { name: /take.?profit|stop.?loss|tp\s?\/?\s?sl/i })
     .first()
     .click({ timeout: TERMINAL_MS });
   await typeAmount(page, "receive-send", triggerPercent);
-  await page
-    .getByRole("button", { name: /save|set|apply|confirm/i })
-    .first()
-    .click({ timeout: TERMINAL_MS });
+  await submitForm(page, { submitLabel: messageValue(run.locale, "submit-btn"), terminalMs: TERMINAL_MS });
 }
 
-/** Drive the detail-dialog close flow — market (full) or partial with an amount. */
+/**
+ * Drive the close flow. The `close` action opens the CloseDialog (a single amount input + full/debt
+ * selector and a `close-btn-label` submit — there are no separate market/partial buttons): a market
+ * close selects the full position, a partial close types the amount. The submit settles on the
+ * success toast via `submitForm`.
+ */
 async function driveClose(page: Page, mode: "market" | "partial", amount?: string): Promise<void> {
   await page.getByRole("button", { name: /close/i }).first().click({ timeout: TERMINAL_MS });
-  await page
-    .getByRole("button", { name: mode === "market" ? /market/i : /partial/i })
-    .first()
-    .click({ timeout: TERMINAL_MS });
   if (mode === "partial" && amount !== undefined) {
     await typeAmount(page, "receive-send", amount);
+  } else {
+    await page
+      .getByText(/full/i)
+      .first()
+      .click({ timeout: TERMINAL_MS })
+      .catch(() => undefined);
   }
-  await page
-    .getByRole("button", { name: /confirm|submit|send/i })
-    .first()
-    .click({ timeout: TERMINAL_MS });
-  await expect(page.locator("div.toast")).toBeVisible({ timeout: TERMINAL_MS });
+  await submitForm(page, { submitLabel: messageValue(run.locale, "close-btn-label"), terminalMs: TERMINAL_MS });
 }
 
 /** Assert the opened lease's rendered row, detail size, and liquidation ordering against the oracle. */
@@ -178,12 +178,8 @@ async function acquireDownpaymentAsset(page: Page, testInfo: TestInfo, acquireUs
     execute: async () => {
       await run.queue.pace("strict");
       await page.locator("#swap-1").waitFor({ state: "visible", timeout: 15000 });
-      await page.getByRole("button", { name: /swap/i }).last().click({ timeout: TERMINAL_MS });
-      await page
-        .getByRole("button", { name: /confirm|submit/i })
-        .first()
-        .click({ timeout: TERMINAL_MS });
-      await expect(page.locator("div.toast")).toBeVisible({ timeout: TERMINAL_MS });
+      // The swap runs on the click (no confirmation dialog); settle on the success toast / error.
+      await submitForm(page, { submitLabel: messageValue(run.locale, "swap"), terminalMs: TERMINAL_MS });
     }
   });
 }

--- a/e2e/src/t3/flows/swap.spec.ts
+++ b/e2e/src/t3/flows/swap.spec.ts
@@ -87,11 +87,8 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
     denoms: [{ denom: NATIVE_DENOM, micro: amountMicro }],
     execute: async () => {
       await run.queue.pace("strict");
+      // The swap runs on the click (no confirmation dialog); track the app's polled terminal state.
       await page.getByRole("button", { name: /swap/i }).last().click({ timeout: TERMINAL_MS });
-      await page
-        .getByRole("button", { name: /confirm|submit/i })
-        .first()
-        .click({ timeout: TERMINAL_MS });
       await expect
         .poll(() => swapTerminal(page), {
           message: "swap should reach a polled terminal state",

--- a/e2e/src/t3/flows/terminalSignal.test.ts
+++ b/e2e/src/t3/flows/terminalSignal.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { decideTerminal } from "./terminalSignal.js";
+
+const surface = (over: Partial<Parameters<typeof decideTerminal>[0]>) => ({
+  toastVisible: false,
+  errorVisible: false,
+  errorText: "",
+  confirmVisible: false,
+  ...over
+});
+
+describe("decideTerminal", () => {
+  it("resolves success on a toast", () => {
+    expect(decideTerminal(surface({ toastVisible: true }))).toEqual({ kind: "success" });
+  });
+
+  it("prefers a success toast over a lingering error surface (committed tx is never a failure)", () => {
+    expect(decideTerminal(surface({ toastVisible: true, errorVisible: true, errorText: "stale" }))).toEqual({
+      kind: "success"
+    });
+  });
+
+  it("throws-worthy error carries the inline error text, or a fallback", () => {
+    expect(decideTerminal(surface({ errorVisible: true, errorText: "  Insufficient balance  " }))).toEqual({
+      kind: "error",
+      text: "Insufficient balance"
+    });
+    expect(decideTerminal(surface({ errorVisible: true, errorText: "   " }))).toEqual({
+      kind: "error",
+      text: "form error"
+    });
+  });
+
+  it("asks to click a confirm control only when no terminal surface is present yet", () => {
+    expect(decideTerminal(surface({ confirmVisible: true }))).toEqual({ kind: "click-confirm" });
+  });
+
+  it("is pending when nothing is visible", () => {
+    expect(decideTerminal(surface({}))).toEqual({ kind: "pending" });
+  });
+});

--- a/e2e/src/t3/flows/terminalSignal.ts
+++ b/e2e/src/t3/flows/terminalSignal.ts
@@ -1,0 +1,30 @@
+export interface TerminalSurface {
+  toastVisible: boolean;
+  errorVisible: boolean;
+  errorText: string;
+  confirmVisible: boolean;
+}
+
+export type TerminalDecision =
+  { kind: "success" } | { kind: "error"; text: string } | { kind: "click-confirm" } | { kind: "pending" };
+
+/**
+ * Decide the terminal outcome of a form submit from the observed surfaces. The app runs
+ * `walletOperation` directly on the footer click — there is NO confirmation dialog — so a success
+ * TOAST is the commit signal and the inline error surface is the failure signal. A success toast
+ * WINS over a lingering error surface so a committed tx is never journaled as failed. A confirm
+ * button is acted on only for forward-compatibility with a future confirm dialog (and the driver
+ * scopes it to a dedicated confirm control so it can never re-click a footer submit).
+ */
+export function decideTerminal(surface: TerminalSurface): TerminalDecision {
+  if (surface.toastVisible) {
+    return { kind: "success" };
+  }
+  if (surface.errorVisible) {
+    return { kind: "error", text: surface.errorText.trim() || "form error" };
+  }
+  if (surface.confirmVisible) {
+    return { kind: "click-confirm" };
+  }
+  return { kind: "pending" };
+}

--- a/e2e/src/t3/taxonomy.test.ts
+++ b/e2e/src/t3/taxonomy.test.ts
@@ -13,6 +13,12 @@ describe("classify environment", () => {
     expect(classify({ message: "connect ETIMEDOUT waiting for RPC" }).category).toBe("environment");
     expect(classify({ message: "timed out waiting for chain state" }).signal).toBe("chain-state-timeout");
   });
+
+  it("classifies a terminal-signal timeout as its own environment signal, ahead of chain-state-timeout", () => {
+    const result = classify({ message: 'terminal-signal-timeout: no toast or error after submitting "supply"' });
+    expect(result.category).toBe("environment");
+    expect(result.signal).toBe("terminal-signal-timeout");
+  });
 });
 
 describe("classify app", () => {

--- a/e2e/src/t3/taxonomy.ts
+++ b/e2e/src/t3/taxonomy.ts
@@ -104,6 +104,11 @@ const RULES: Rule[] = [
   }),
   pattern({
     category: "environment",
+    signal: "terminal-signal-timeout",
+    regex: /terminal[-\s]?signal[-\s]?timeout/i
+  }),
+  pattern({
+    category: "environment",
     signal: "chain-state-timeout",
     regex: /timed?\s?out|timeout waiting|deadline exceeded|wait.*(chain|block|commit)/i
   }),


### PR DESCRIPTION
The flow driver assumed a confirmation dialog between the footer submit and the toast; the app has none — routed forms broadcast directly on the footer click, so the driver's wait for a confirm control timed out while transactions committed underneath (on-chain staking totals moved during runs the journal recorded as failed).

The driver now clicks the footer submit once and settles on the app's real terminal surface through a polled pure decision: a success toast resolves (and, once observed, is final — the decision is captured inside the poll, with no post-poll re-read that a dismissed toast could invalidate); an inline classified error throws its text; only the poll's own timeout is relabeled as a first-class environment signal, other errors rethrow unchanged. The call-site audit also fixed real label drift: the close dialog is one amount input with a full/debt selector (no separate market/partial buttons), and take-profit/stop-loss submits under its own label. A confirm-click remains only for a dedicated, anchored confirm control that today's app never renders.

Verification: full e2e gate green (373 tests over the floors); the pure decision logic unit-tested including toast-wins ordering; two review rounds — the second confirmed the captured-decision routing has no race or drop path across poll retries. The post-merge regression run is the live proof.