### PR TITLE
fix(backend): fall back across protocol price keys in balances

### DIFF
--- a/backend/src/handlers/currencies.rs
+++ b/backend/src/handlers/currencies.rs
@@ -288,10 +288,7 @@ pub async fn compute_balances(
             let decimal_factor = 10_f64.powi(i32::from(currency.decimal_digits));
             let human_amount = amount_f64 / decimal_factor;
 
-            let price_usd = prices
-                .get(&currency.key)
-                .and_then(|p| p.price_usd.parse::<f64>().ok())
-                .unwrap_or(0.0);
+            let price_usd = resolve_price_usd(prices, &currency.key, &currency.ticker);
 
             let amount_usd = human_amount * price_usd;
             total_usd += amount_usd;
@@ -312,6 +309,26 @@ pub async fn compute_balances(
         balances,
         total_value_usd: total_usd.to_string(),
     })
+}
+
+/// Resolve a held currency's USD price from the oracle price feed.
+///
+/// Prices are keyed `TICKER@PROTOCOL` and are sparse: each protocol's oracle
+/// only publishes the tickers it quotes plus its own LPN, so a currency's exact
+/// `key` frequently has no price entry even though the same ticker is priced
+/// under another protocol. Returns `0.0` when the ticker has no price at all.
+fn resolve_price_usd(prices: &HashMap<String, PriceInfo>, key: &str, ticker: &str) -> f64 {
+    prices
+        .get(key)
+        .or_else(|| {
+            let prefix = format!("{ticker}@");
+            prices
+                .iter()
+                .find(|(k, _)| k.starts_with(&prefix))
+                .map(|(_, price)| price)
+        })
+        .and_then(|p| p.price_usd.parse::<f64>().ok())
+        .unwrap_or(0.0)
 }
 
 /// Calculate price with LPN base and decimal adjustment
@@ -390,5 +407,67 @@ mod tests {
             }
             _ => panic!("expected Validation for an invalid address"),
         }
+    }
+
+    use super::{resolve_price_usd, PriceInfo};
+    use std::collections::HashMap;
+
+    fn price(key: &str, price_usd: &str) -> (String, PriceInfo) {
+        (
+            key.to_string(),
+            PriceInfo {
+                key: key.to_string(),
+                symbol: key.split('@').next().unwrap_or(key).to_string(),
+                price_usd: price_usd.to_string(),
+            },
+        )
+    }
+
+    /// Regression for the balances USD-join miss: a held denom (USDC_NOBLE) maps
+    /// to a currency whose `key` is a protocol the price feed does not publish
+    /// under (`...-ATOM`), while the same ticker IS priced under another protocol
+    /// (`...-USDC_NOBLE` = $1). The exact-key-only lookup collapsed amount_usd to
+    /// 0; resolution must fall back to the ticker's price.
+    #[test]
+    fn resolve_price_falls_back_to_ticker_when_exact_key_absent() {
+        let prices: HashMap<String, PriceInfo> = [
+            price("USDC_NOBLE@OSMOSIS-OSMOSIS-USDC_NOBLE", "1"),
+            price("USDC_NOBLE@OSMOSIS-OSMOSIS-ALL_BTC", "1.0000000000000002"),
+            price("NLS@OSMOSIS-OSMOSIS-USDC_NOBLE", "0.00122679"),
+        ]
+        .into_iter()
+        .collect();
+
+        let resolved = resolve_price_usd(&prices, "USDC_NOBLE@OSMOSIS-OSMOSIS-ATOM", "USDC_NOBLE");
+        assert!(
+            (resolved - 1.0).abs() < 1e-9,
+            "expected ~1.0 via ticker fallback, got {resolved}"
+        );
+    }
+
+    /// The exact protocol-scoped key still wins when present (most-specific price).
+    #[test]
+    fn resolve_price_prefers_exact_key() {
+        let prices: HashMap<String, PriceInfo> = [
+            price("ATOM@OSMOSIS-OSMOSIS-ATOM", "4.20"),
+            price("ATOM@OSMOSIS-OSMOSIS-USDC_NOBLE", "4.25"),
+        ]
+        .into_iter()
+        .collect();
+
+        let resolved = resolve_price_usd(&prices, "ATOM@OSMOSIS-OSMOSIS-ATOM", "ATOM");
+        assert!(
+            (resolved - 4.20).abs() < 1e-9,
+            "expected exact key 4.20, got {resolved}"
+        );
+    }
+
+    /// No price for the ticker anywhere → 0.0 (unchanged behavior).
+    #[test]
+    fn resolve_price_zero_when_ticker_unpriced() {
+        let prices: HashMap<String, PriceInfo> = [price("NLS@OSMOSIS-OSMOSIS-USDC_NOBLE", "0.001")]
+            .into_iter()
+            .collect();
+        assert_eq!(resolve_price_usd(&prices, "FOO@BAR", "FOO"), 0.0);
     }
 }

--- a/backend/src/handlers/currencies.rs
+++ b/backend/src/handlers/currencies.rs
@@ -375,8 +375,9 @@ pub fn calculate_price_with_decimals(
 
 #[cfg(test)]
 mod tests {
-    use super::{calculate_price_with_decimals, PriceInfo};
     use std::collections::HashMap;
+
+    use super::{calculate_price_with_decimals, PriceInfo};
 
     #[test]
     fn test_calculate_price_with_decimals() {

--- a/backend/src/handlers/currencies.rs
+++ b/backend/src/handlers/currencies.rs
@@ -311,20 +311,29 @@ pub async fn compute_balances(
     })
 }
 
+/// Delimiter between the ticker and protocol halves of a `TICKER@PROTOCOL` price key.
+const PRICE_KEY_DELIMITER: char = '@';
+
 /// Resolve a held currency's USD price from the oracle price feed.
 ///
 /// Prices are keyed `TICKER@PROTOCOL` and are sparse: each protocol's oracle
 /// only publishes the tickers it quotes plus its own LPN, so a currency's exact
 /// `key` frequently has no price entry even though the same ticker is priced
-/// under another protocol. Returns `0.0` when the ticker has no price at all.
+/// under another protocol. Prefer the exact key; otherwise fall back to the
+/// lexicographically smallest matching `TICKER@` key. The canonical
+/// `gated_assets::get_price_for_asset` returns whatever the `HashMap` yields
+/// first (arbitrary order); pinning the smallest key keeps the rendered USD
+/// value reproducible run-to-run for the same feed. Returns `0.0` when the
+/// ticker has no price at all.
 fn resolve_price_usd(prices: &HashMap<String, PriceInfo>, key: &str, ticker: &str) -> f64 {
     prices
         .get(key)
         .or_else(|| {
-            let prefix = format!("{ticker}@");
+            let prefix = format!("{ticker}{PRICE_KEY_DELIMITER}");
             prices
                 .iter()
-                .find(|(k, _)| k.starts_with(&prefix))
+                .filter(|(k, _)| k.starts_with(&prefix))
+                .min_by(|(a, _), (b, _)| a.cmp(b))
                 .map(|(_, price)| price)
         })
         .and_then(|p| p.price_usd.parse::<f64>().ok())
@@ -366,7 +375,8 @@ pub fn calculate_price_with_decimals(
 
 #[cfg(test)]
 mod tests {
-    use super::calculate_price_with_decimals;
+    use super::{calculate_price_with_decimals, PriceInfo};
+    use std::collections::HashMap;
 
     #[test]
     fn test_calculate_price_with_decimals() {
@@ -409,20 +419,6 @@ mod tests {
         }
     }
 
-    use super::{resolve_price_usd, PriceInfo};
-    use std::collections::HashMap;
-
-    fn price(key: &str, price_usd: &str) -> (String, PriceInfo) {
-        (
-            key.to_string(),
-            PriceInfo {
-                key: key.to_string(),
-                symbol: key.split('@').next().unwrap_or(key).to_string(),
-                price_usd: price_usd.to_string(),
-            },
-        )
-    }
-
     /// Regression for the balances USD-join miss: a held denom (USDC_NOBLE) maps
     /// to a currency whose `key` is a protocol the price feed does not publish
     /// under (`...-ATOM`), while the same ticker IS priced under another protocol
@@ -438,7 +434,8 @@ mod tests {
         .into_iter()
         .collect();
 
-        let resolved = resolve_price_usd(&prices, "USDC_NOBLE@OSMOSIS-OSMOSIS-ATOM", "USDC_NOBLE");
+        let resolved =
+            super::resolve_price_usd(&prices, "USDC_NOBLE@OSMOSIS-OSMOSIS-ATOM", "USDC_NOBLE");
         assert!(
             (resolved - 1.0).abs() < 1e-9,
             "expected ~1.0 via ticker fallback, got {resolved}"
@@ -455,10 +452,31 @@ mod tests {
         .into_iter()
         .collect();
 
-        let resolved = resolve_price_usd(&prices, "ATOM@OSMOSIS-OSMOSIS-ATOM", "ATOM");
+        let resolved = super::resolve_price_usd(&prices, "ATOM@OSMOSIS-OSMOSIS-ATOM", "ATOM");
         assert!(
             (resolved - 4.20).abs() < 1e-9,
             "expected exact key 4.20, got {resolved}"
+        );
+    }
+
+    /// The fallback is deterministic: with two priced protocols for the ticker
+    /// and no exact-key hit, the lexicographically smallest key wins regardless
+    /// of `HashMap` iteration order (both prices differ so a wrong pick shows).
+    #[test]
+    fn resolve_price_fallback_is_deterministic_lowest_key() {
+        let prices: HashMap<String, PriceInfo> = [
+            price("ATOM@OSMOSIS-OSMOSIS-USDC_NOBLE", "5.10"),
+            price("ATOM@OSMOSIS-OSMOSIS-ALL_BTC", "5.00"),
+        ]
+        .into_iter()
+        .collect();
+
+        // `...-ALL_BTC` sorts before `...-USDC_NOBLE`, so its price must win even
+        // though it is not the higher value.
+        let resolved = super::resolve_price_usd(&prices, "ATOM@OSMOSIS-OSMOSIS-ATOM", "ATOM");
+        assert!(
+            (resolved - 5.00).abs() < 1e-9,
+            "expected smallest-key 5.00, got {resolved}"
         );
     }
 
@@ -468,6 +486,17 @@ mod tests {
         let prices: HashMap<String, PriceInfo> = [price("NLS@OSMOSIS-OSMOSIS-USDC_NOBLE", "0.001")]
             .into_iter()
             .collect();
-        assert_eq!(resolve_price_usd(&prices, "FOO@BAR", "FOO"), 0.0);
+        assert_eq!(super::resolve_price_usd(&prices, "FOO@BAR", "FOO"), 0.0);
+    }
+
+    fn price(key: &str, price_usd: &str) -> (String, PriceInfo) {
+        (
+            key.to_string(),
+            PriceInfo {
+                key: key.to_string(),
+                symbol: key.split('@').next().unwrap_or(key).to_string(),
+                price_usd: price_usd.to_string(),
+            },
+        )
     }
 }

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -113,6 +113,18 @@ asserts:
 
 With zero inspected leases the check **passes** with a degenerate note.
 
+### `priced-balances-nonzero`
+
+Fetches `GET /api/balances`, `GET /api/currencies`, and `GET /api/prices` for the
+configured address. Each balance denom is resolved to its ticker via `/api/currencies`
+(the shared `denomResolver` used by the T3 tier — assets are identified by bank denom,
+never by the entry's `symbol`/`amount_usd`). For every balance whose ticker has **any**
+`TICKER@…` price key in `/api/prices` and a positive held amount, it asserts
+`amount_usd` parses to a value **strictly greater than zero**. This guards the balances
+USD-join: a held, priced asset must never render at $0. Zero-balance entries and entries
+whose ticker has no price key are **exempt**. With no priced, non-zero balances the check
+**passes** with a degenerate note.
+
 ## Machine-readable output
 
 The run prints one JSON document to stdout and writes the same document to

--- a/e2e/src/checks/pricedBalancesNonzero.test.ts
+++ b/e2e/src/checks/pricedBalancesNonzero.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { classifyPricedBalances } from "./pricedBalancesNonzero.js";
+import type { PricedBalanceCase } from "./pricedBalancesNonzero.js";
+
+function priced(denom: string, ticker: string, amountMicro: string, amountUsd: string): PricedBalanceCase {
+  return { denom, ticker, amountMicro, amountUsd, priced: true };
+}
+
+describe("classifyPricedBalances", () => {
+  it("passes when every priced, non-zero balance has a positive amount_usd", () => {
+    const result = classifyPricedBalances([
+      priced("ibc/USDC", "USDC_NOBLE", "74577016", "74.58"),
+      priced("unls", "NLS", "6506577367", "7.98")
+    ]);
+    expect(result.status).toBe("pass");
+    expect(result.observed).toEqual({ checkedCount: 2, exemptCount: 0, offenders: [] });
+    expect(result.note).toBeUndefined();
+  });
+
+  it("fails when a priced, non-zero balance reports amount_usd of 0 (the USD-join regression)", () => {
+    const result = classifyPricedBalances([
+      priced("ibc/USDC", "USDC_NOBLE", "74577016", "0"),
+      priced("unls", "NLS", "6506577367", "7.98")
+    ]);
+    expect(result.status).toBe("fail");
+    expect(result.observed.offenders).toEqual([
+      { denom: "ibc/USDC", ticker: "USDC_NOBLE", amountMicro: "74577016", amountUsd: "0" }
+    ]);
+    expect(result.observed.checkedCount).toBe(2);
+  });
+
+  it("exempts zero-balance entries even when the ticker is priced", () => {
+    const result = classifyPricedBalances([priced("ibc/USDC", "USDC_NOBLE", "0", "0")]);
+    expect(result.status).toBe("pass");
+    expect(result.observed).toEqual({ checkedCount: 0, exemptCount: 1, offenders: [] });
+    expect(result.note).toContain("degenerate");
+  });
+
+  it("exempts entries whose ticker has no price key", () => {
+    const result = classifyPricedBalances([
+      { denom: "ibc/FOO", ticker: "FOO", amountMicro: "1000000", amountUsd: "0", priced: false }
+    ]);
+    expect(result.status).toBe("pass");
+    expect(result.observed).toEqual({ checkedCount: 0, exemptCount: 1, offenders: [] });
+  });
+
+  it("exempts entries whose denom did not resolve to a ticker", () => {
+    const result = classifyPricedBalances([
+      { denom: "ibc/UNKNOWN", ticker: undefined, amountMicro: "1000000", amountUsd: "0", priced: false }
+    ]);
+    expect(result.status).toBe("pass");
+    expect(result.observed.exemptCount).toBe(1);
+  });
+
+  it("treats a non-numeric amount_usd on a checked entry as a failure", () => {
+    const result = classifyPricedBalances([priced("ibc/USDC", "USDC_NOBLE", "74577016", "NaN")]);
+    expect(result.status).toBe("fail");
+    expect(result.observed.offenders).toHaveLength(1);
+  });
+
+  it("passes with a degenerate note when there are no cases at all", () => {
+    const result = classifyPricedBalances([]);
+    expect(result.status).toBe("pass");
+    expect(result.observed).toEqual({ checkedCount: 0, exemptCount: 0, offenders: [] });
+    expect(result.note).toContain("degenerate");
+  });
+});

--- a/e2e/src/checks/pricedBalancesNonzero.ts
+++ b/e2e/src/checks/pricedBalancesNonzero.ts
@@ -1,0 +1,149 @@
+import type { Dispatcher } from "undici";
+import { getJson } from "../http.js";
+import { parseBalancesResponse } from "../validate.js";
+import { parseCurrencyResolver, priceUsdOf } from "../t3/flows/denomResolver.js";
+import type { BalanceInfo, CheckResult } from "../types.js";
+
+const CHECK_ID = "priced-balances-nonzero";
+const CHECK_TITLE = "Every priced, non-zero balance carries a positive amount_usd";
+const RULE = "amount_usd > 0 for each balance whose ticker has any TICKER@... price key and a positive amount";
+const DEGENERATE_NOTE = "no priced, non-zero balances for the configured address: the check is degenerate";
+
+export interface PricedBalanceCase {
+  denom: string;
+  ticker: string | undefined;
+  amountMicro: string;
+  amountUsd: string;
+  priced: boolean;
+}
+
+export interface PricedBalanceOffender {
+  denom: string;
+  ticker: string | undefined;
+  amountMicro: string;
+  amountUsd: string;
+}
+
+export interface PricedBalancesResult {
+  status: "pass" | "fail";
+  observed: {
+    checkedCount: number;
+    exemptCount: number;
+    offenders: PricedBalanceOffender[];
+  };
+  expected: { rule: string };
+  note?: string;
+}
+
+function isPositiveMicro(amount: string): boolean {
+  return /^\d+$/.test(amount) && BigInt(amount) > 0n;
+}
+
+function parsesPositive(amountUsd: string): boolean {
+  const parsed = Number(amountUsd);
+  return Number.isFinite(parsed) && parsed > 0;
+}
+
+/**
+ * Pure classification: a balance is checked only when its denom resolved to a ticker, that ticker
+ * has a price key, and the held amount is positive. Zero-balance and unpriced/unknown entries are
+ * exempt (degenerate, like the sibling T0 checks). A checked entry fails when amount_usd does not
+ * parse to a value strictly greater than zero — the exact regression the balances USD-join fix
+ * addresses.
+ */
+export function classifyPricedBalances(cases: PricedBalanceCase[]): PricedBalancesResult {
+  const expected = { rule: RULE };
+  const offenders: PricedBalanceOffender[] = [];
+  let checkedCount = 0;
+  let exemptCount = 0;
+
+  for (const entry of cases) {
+    const eligible = entry.ticker !== undefined && entry.priced && isPositiveMicro(entry.amountMicro);
+    if (!eligible) {
+      exemptCount += 1;
+      continue;
+    }
+    checkedCount += 1;
+    if (!parsesPositive(entry.amountUsd)) {
+      offenders.push({
+        denom: entry.denom,
+        ticker: entry.ticker,
+        amountMicro: entry.amountMicro,
+        amountUsd: entry.amountUsd
+      });
+    }
+  }
+
+  const observed = { checkedCount, exemptCount, offenders };
+  if (offenders.length > 0) {
+    return { status: "fail", observed, expected };
+  }
+  if (checkedCount === 0) {
+    return { status: "pass", observed, expected, note: DEGENERATE_NOTE };
+  }
+  return { status: "pass", observed, expected };
+}
+
+/** Reverse the ticker->bankSymbols resolver into denom->ticker for balance-entry identity. */
+function buildDenomToTicker(currenciesPayload: unknown): Map<string, string> {
+  const resolver = parseCurrencyResolver(currenciesPayload);
+  const denomToTicker = new Map<string, string>();
+  for (const [ticker, asset] of resolver) {
+    for (const bank of asset.bankSymbols) {
+      denomToTicker.set(bank, ticker);
+    }
+  }
+  return denomToTicker;
+}
+
+function toCases(
+  balances: BalanceInfo[],
+  denomToTicker: Map<string, string>,
+  pricesPayload: unknown
+): PricedBalanceCase[] {
+  return balances.map((balance) => {
+    const ticker = denomToTicker.get(balance.denom);
+    const priced = ticker !== undefined && priceUsdOf(pricesPayload, ticker) !== undefined;
+    return { denom: balance.denom, ticker, amountMicro: balance.amount, amountUsd: balance.amount_usd, priced };
+  });
+}
+
+export async function runPricedBalancesNonzero(params: {
+  baseUrl: string;
+  address: string;
+  dispatcher: Dispatcher | undefined;
+}): Promise<CheckResult> {
+  const startedAt = Date.now();
+  const base: Pick<CheckResult, "id" | "title"> = { id: CHECK_ID, title: CHECK_TITLE };
+
+  try {
+    const [balancesJson, currenciesJson, pricesJson] = await Promise.all([
+      getJson(`${params.baseUrl}/api/balances?address=${params.address}`, params.dispatcher),
+      getJson(`${params.baseUrl}/api/currencies`, params.dispatcher),
+      getJson(`${params.baseUrl}/api/prices`, params.dispatcher)
+    ]);
+    const balances = parseBalancesResponse(balancesJson).balances;
+    const denomToTicker = buildDenomToTicker(currenciesJson);
+    const result = classifyPricedBalances(toCases(balances, denomToTicker, pricesJson));
+    return {
+      ...base,
+      status: result.status,
+      durationMs: Date.now() - startedAt,
+      observed: result.observed,
+      expected: result.expected,
+      ...(result.note !== undefined ? { notes: result.note } : {}),
+      ...(result.status === "fail"
+        ? { reason: "a priced, non-zero balance reported amount_usd <= 0 (USD-join miss)" }
+        : {})
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ...base,
+      status: "fail",
+      durationMs: Date.now() - startedAt,
+      observed: { error: message },
+      reason: "REST balances/currencies/prices fetch or parse failed"
+    };
+  }
+}

--- a/e2e/src/t0.ts
+++ b/e2e/src/t0.ts
@@ -7,6 +7,7 @@ import { createLookup, createUndiciConnector } from "./resolver.js";
 import { runWsRestParity } from "./checks/wsRestParity.js";
 import { runTotalsReconcile } from "./checks/totalsReconcile.js";
 import { runRateUnitSanity } from "./checks/rateUnitSanity.js";
+import { runPricedBalancesNonzero } from "./checks/pricedBalancesNonzero.js";
 import { assembleDocument, exitCodeFor, writeDocument } from "./report.js";
 import type { CheckResult } from "./types.js";
 
@@ -47,7 +48,12 @@ async function runAllChecks(config: Config, dispatch: Dispatch): Promise<CheckRe
     band: { minPercent: config.rateMinPercent, maxPercent: config.rateMaxPercent },
     dispatcher: dispatch.dispatcher
   });
-  return [parity, totals, rate];
+  const pricedBalances = await runPricedBalancesNonzero({
+    baseUrl: config.baseUrl,
+    address: config.readonlyAddress,
+    dispatcher: dispatch.dispatcher
+  });
+  return [parity, totals, rate, pricedBalances];
 }
 
 function reportConfigErrors(errors: string[]): void {


### PR DESCRIPTION
The balances USD enrichment joined a held bank denom to a nondeterministic TICKER@PROTOCOL currency key, then did an exact-only lookup against a per-protocol-sparse price feed: a correctly-priced asset rendered $0 whenever the arbitrary key pick landed on a protocol the oracle does not quote (live-reproduced with a 74.5 USDC balance showing $0; NLS priced only by chance). The same computation feeds the WebSocket balance broadcaster.

The price resolution now tries the exact protocol-scoped key first, then falls back deterministically to the lexicographically smallest matching TICKER@ key (the @ delimiter prevents USDC/USDC_NOBLE prefix collisions) — mirroring the canonical asset-price helper while pinning its arbitrary pick. Wire contract unchanged.

suite impact: T0, covered by the new priced-balances-nonzero invariant check — any held balance whose ticker carries a live price key must render a non-zero USD value; identity resolved via currencies metadata, never the balances symbol field.

Verification: failing-first regression test proven against the unfixed helper, plus determinism and exemption tests (backend 506, e2e 374, both gates green over their floors); two review rounds.