### PR TITLE
test(e2e): funded t2 cells, fixture schemas, ipv6 redaction

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -314,14 +314,14 @@ Every leaf form funnels its amount-field errors through the web-components
 so assertions are auto-retrying `toContainText`. Expected strings come from the live
 `GET /api/locales/en` (the deploy host can drift from the repo), never hard-coded.
 
-| Cell                           | Form route               | Trigger                       | Asserted outcome                               |
-| ------------------------------ | ------------------------ | ----------------------------- | ---------------------------------------------- |
-| lease long / short             | `/positions/open/{type}` | amount over an empty balance  | `invalid-balance-big` ("Insufficient balance") |
-| earn supply / withdraw         | `/earn/{type}`           | amount over an empty balance  | `invalid-balance-big`                          |
-| stake delegate / undelegate    | `/stake/{type}`          | amount over an empty balance  | `invalid-balance-big` + click-has-no-effect    |
-| lease long below-minimum       | `/positions/open/long`   | funded, priced, below the min | min/max error (funded-gated → skip)            |
-| earn withdraw over-position    | `/earn/withdraw`         | more than the LP deposit      | over-position error (funded-gated → skip)      |
-| stake undelegate over-position | `/stake/undelegate`      | more than the delegation      | over-position error (funded-gated → skip)      |
+| Cell                           | Form route               | Trigger                       | Asserted outcome                                                                                                          |
+| ------------------------------ | ------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| lease long / short             | `/positions/open/{type}` | amount over an empty balance  | `invalid-balance-big` ("Insufficient balance")                                                                            |
+| earn supply / withdraw         | `/earn/{type}`           | amount over an empty balance  | `invalid-balance-big`                                                                                                     |
+| stake delegate / undelegate    | `/stake/{type}`          | amount over an empty balance  | `invalid-balance-big` + click-has-no-effect                                                                               |
+| lease long below-minimum       | `/positions/open/long`   | funded, priced, below the min | `lease-min-error` ("Amount must be between …"), asserted by its live-resolved literal prefix; funded → asserts, else skip |
+| earn withdraw over-position    | `/earn/withdraw`         | over the LP deposit           | `invalid-balance-big` (reactive `validateAmountV2` over the deposit); funded + deposit → asserts, else skip               |
+| stake undelegate over-position | `/stake/undelegate`      | over the delegation           | `invalid-balance-big` (reactive `validateAmountV2` over the delegation); funded + delegation → asserts, else skip         |
 
 `validateAmountAgainstBalance` gates before `validateMinMaxValues` (issue #192), so a
 zero-balance wallet can only reach insufficient-balance; below-min/above-max and the

--- a/e2e/coverage-matrix.json
+++ b/e2e/coverage-matrix.json
@@ -530,7 +530,7 @@
       "mapping": {
         "type": "gap",
         "category": "schemaless-unvalidated",
-        "reason": "governance/proposals is schemaless; fixture shape-mirrored + live key-set guard; figure-level bridge is a follow-up"
+        "reason": "governance/proposals fixture is now schema-validated by ProposalsResponseSchema; the open gap is the figure-level render bridge, which no spec asserts yet"
       }
     },
     {

--- a/e2e/src/fixtures/registry.ts
+++ b/e2e/src/fixtures/registry.ts
@@ -4,9 +4,10 @@
  * browser-side fixture-mode interceptor, so the two never drift.
  *
  * `schema` names a whole-body object schema; `itemSchema` names a per-element schema for
- * a bare-array body (e.g. `/api/earn/pools`). Endpoints with neither are schemaless
- * (all `/api/etl/*`, `/api/governance/*`, `/api/staking/*`, and the config scaffolding):
- * their fixtures are shape-mirrored and guarded live against key-set drift, never parsed.
+ * a bare-array body (e.g. `/api/earn/pools`). Endpoints with neither are schemaless (the
+ * `/api/etl/*` batch/series endpoints, the remaining `/api/governance/*` and `/api/staking/*`
+ * scaffolding, and the config endpoints): their fixtures are shape-mirrored and guarded live
+ * against key-set drift, never parsed.
  */
 
 export type FixtureScope = "common" | "stats" | "vote" | "wallet";
@@ -18,7 +19,9 @@ export type SchemaName =
   | "earn-pool"
   | "earn-positions-response"
   | "balances-response"
-  | "skip-route-config";
+  | "skip-route-config"
+  | "proposals-response"
+  | "staking-positions-response";
 
 export interface FixtureRoute {
   /** Stable id for the coverage matrix and diagnostics. */
@@ -154,7 +157,8 @@ const VOTE: readonly FixtureRoute[] = [
     id: "proposals",
     pattern: /^\/api\/governance\/proposals$/,
     file: "routes/vote/governance-proposals.json",
-    scope: "vote"
+    scope: "vote",
+    schema: "proposals-response"
   },
   {
     id: "params-tallying",
@@ -190,7 +194,8 @@ const WALLET: readonly FixtureRoute[] = [
     id: "staking-positions",
     pattern: /^\/api\/staking\/positions$/,
     file: "wallet/staking-positions.json",
-    scope: "wallet"
+    scope: "wallet",
+    schema: "staking-positions-response"
   },
   {
     id: "user-dashboard",

--- a/e2e/src/t2/validation.spec.ts
+++ b/e2e/src/t2/validation.spec.ts
@@ -1,13 +1,6 @@
 import { test, expect } from "./support.js";
 import type { OriginContext, ConnectLabels } from "./appDriver.js";
-import {
-  resolveOrigin,
-  fetchLocale,
-  readConnectLabels,
-  messageValue,
-  connectThenGoto,
-  CONNECT_TIMEOUT
-} from "./appDriver.js";
+import { resolveOrigin, fetchLocale, readConnectLabels, messageValue, connectThenGoto } from "./appDriver.js";
 import {
   typeAmount,
   assertFieldError,
@@ -104,13 +97,25 @@ let ctx: OriginContext;
 let locale: unknown;
 let labels: ConnectLabels;
 let insufficientBalance: string;
+let leaseRangeError: string;
 let expectFunded: boolean;
+
+/**
+ * The invariant literal of an interpolated locale message — everything before the first
+ * `{placeholder}`. `lease-min-error` ("Amount must be between {minAmount} {symbol} …") yields
+ * "Amount must be between", a live-resolved assertion target whose min/max/symbol values are
+ * runtime-dependent and must not be hard-coded.
+ */
+function literalPrefix(message: string): string {
+  return message.split("{")[0]?.trim() ?? "";
+}
 
 test.beforeAll(async () => {
   ctx = resolveOrigin();
   locale = await fetchLocale(ctx);
   labels = readConnectLabels(locale);
   insufficientBalance = messageValue(locale, "invalid-balance-big");
+  leaseRangeError = literalPrefix(messageValue(locale, "lease-min-error"));
   const matrix = parseMatrixConfig(process.env);
   if (!matrix.ok) throw new Error(`matrix config error: ${matrix.errors.join("; ")}`);
   expectFunded = matrix.config.expectFunded;
@@ -175,19 +180,31 @@ test.describe("funded-dependent boundary cells", () => {
       "connected wallet holds no native balance for a lease down payment"
     );
     // A funded run continues here; the throwaway-wallet local run stops at the skip above.
+    // A tiny priced amount clears the balance gate (issue #192 gates balance before min/max)
+    // but sits below the protocol minimum, so the reactive validation resolves the min/max
+    // range message (`lease-min-error`, "Amount must be between {min} {symbol} and {max} …") —
+    // asserted by its live-resolved invariant prefix, never the runtime-dependent bounds.
     await connectThenGoto(page, labels, wallet.address, "/positions/open/long");
     await typeAmount(page, "receive-send", "0.0001");
-    await expect(fieldError(page)).toBeVisible({ timeout: CONNECT_TIMEOUT });
+    await assertFieldError(page, leaseRangeError);
   });
+
+  // A sentinel amount comfortably above any held LP deposit / delegation, so the reactive
+  // over-position validation is genuinely reached rather than accepting a within-position value.
+  const OVER_POSITION_AMOUNT = "100000000";
 
   test("earn withdraw over-position requires an existing LP deposit", async ({ page, budget, wallet }, testInfo) => {
     budget.route = "/earn/withdraw";
     allowStagingNoise(budget);
     const hasDeposit = await probeHasEntries(ctx, `/api/earn/positions?address=${wallet.address}`, "positions");
     requireOrSkip(testInfo, expectFunded, hasDeposit, "connected wallet has no LP deposit to over-withdraw");
+    // WithdrawForm.validateInputs runs validateAmountV2(amount, deposit): an amount over the
+    // deposit resolves to `invalid-balance-big` ("Insufficient balance"), the same reactive
+    // string the empty-balance cell shows — the two are distinguished by trigger (funded +
+    // over-position here vs empty balance there), never by message.
     await connectThenGoto(page, labels, wallet.address, "/earn/withdraw");
-    await typeAmount(page, "receive-send", "1");
-    await expect(fieldError(page)).toBeVisible({ timeout: CONNECT_TIMEOUT });
+    await typeAmount(page, "receive-send", OVER_POSITION_AMOUNT);
+    await assertFieldError(page, insufficientBalance);
   });
 
   test("stake undelegate over-position requires an existing delegation", async ({ page, budget, wallet }, testInfo) => {
@@ -195,11 +212,12 @@ test.describe("funded-dependent boundary cells", () => {
     allowStagingNoise(budget);
     const hasDelegation = await probeHasEntries(ctx, `/api/staking/positions?address=${wallet.address}`, "delegations");
     requireOrSkip(testInfo, expectFunded, hasDelegation, "connected wallet has no delegation to over-undelegate");
-    // Undelegate's submit catch never calls classifyError (logs only) — a submit failure
-    // renders nothing (a documented app gap), so this cell asserts only the reactive
-    // over-amount validation, never a submit-failure message.
+    // UndelegateForm.validateInputs runs validateAmountV2(amount, delegatedBalance): an amount
+    // over the delegation resolves to `invalid-balance-big` reactively. The submit catch never
+    // calls classifyError (a submit failure renders nothing — documented app gap), so this cell
+    // asserts only the reactive over-amount validation, never a submit-failure message.
     await connectThenGoto(page, labels, wallet.address, "/stake/undelegate");
-    await typeAmount(page, "receive-send", "1");
-    await expect(fieldError(page)).toBeVisible({ timeout: CONNECT_TIMEOUT });
+    await typeAmount(page, "receive-send", OVER_POSITION_AMOUNT);
+    await assertFieldError(page, insufficientBalance);
   });
 });

--- a/e2e/src/transfer.test.ts
+++ b/e2e/src/transfer.test.ts
@@ -93,6 +93,28 @@ describe("sanitizeRpc", () => {
     expect(out).toBe("connect ECONNREFUSED <rpc>");
   });
 
+  it("redacts a bracketed IPv6[:port] from a connection error", () => {
+    const out = sanitizeRpc("connect ECONNREFUSED [fd00::1]:26657", "https://rpc.nolus.network");
+    expect(out).not.toContain("fd00::1");
+    expect(out).toBe("connect ECONNREFUSED <rpc>");
+  });
+
+  it("redacts a bracketed IPv6 with no port", () => {
+    const out = sanitizeRpc("dial tcp [2001:db8::abcd] failed", "https://rpc.nolus.network");
+    expect(out).not.toContain("2001:db8");
+    expect(out).toBe("dial tcp <rpc> failed");
+  });
+
+  it("redacts a bare compressed IPv6:port from error text", () => {
+    const out = sanitizeRpc("connect ECONNREFUSED fd00::1:26657", "https://rpc.nolus.network");
+    expect(out).not.toContain("fd00::1");
+    expect(out).toBe("connect ECONNREFUSED <rpc>");
+  });
+
+  it("leaves a scoped `::` reference that is not an address:port untouched", () => {
+    expect(sanitizeRpc("thrown from Foo::bar", "https://rpc.nolus.network")).toBe("thrown from Foo::bar");
+  });
+
   it("is a no-op when the text has no rpc reference", () => {
     expect(sanitizeRpc("plain error", "https://rpc.nolus.network")).toBe("plain error");
   });

--- a/e2e/src/transfer.ts
+++ b/e2e/src/transfer.ts
@@ -75,10 +75,16 @@ export function sanitizeRpc(text: string, rpcUrl: string): string {
   let out = text;
   if (rpcUrl.length > 0) out = out.split(rpcUrl).join(RPC_PLACEHOLDER);
   if (host.length > 0) out = out.split(host).join(RPC_PLACEHOLDER);
-  // Also redact credential userinfo (`user:pass@`) and bare IPv4[:port] — a connection
-  // error reports the resolved address (e.g. "connect ECONNREFUSED 1.2.3.4:26657"), not
-  // the hostname the two replacements above cover.
+  // Also redact credential userinfo (`user:pass@`) and a bare resolved address — a
+  // connection error reports the resolved IP, not the hostname the two replacements above
+  // cover: "connect ECONNREFUSED 1.2.3.4:26657" (IPv4) or "connect ECONNREFUSED
+  // [fd00::1]:26657" (undici brackets IPv6). Order: credentials, then IPv6 (bracketed, then
+  // the bare `addr:port` form), then IPv4. The bare-IPv6 group count is bounded (2-7 groups
+  // after the first) so the address:port shape stays specific and the match cannot backtrack
+  // catastrophically on a long hex-and-colon run.
   out = out.replace(/[A-Za-z0-9._~%+-]+:[^@\s/]+@/g, `${RPC_PLACEHOLDER}@`);
+  out = out.replace(/\[[0-9a-fA-F:.]+\](?::\d+)?/g, RPC_PLACEHOLDER);
+  out = out.replace(/\b[0-9a-fA-F]{0,4}(?::[0-9a-fA-F]{0,4}){2,7}:\d+\b/g, RPC_PLACEHOLDER);
   out = out.replace(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?::\d+)?\b/g, RPC_PLACEHOLDER);
   return out;
 }

--- a/fixtures/schemas/proposals-response.json
+++ b/fixtures/schemas/proposals-response.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "proposals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "final_tally_result": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "yes_count": {
+                    "type": "string",
+                    "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+                    "minLength": 1
+                  },
+                  "abstain_count": {
+                    "type": "string",
+                    "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+                    "minLength": 1
+                  },
+                  "no_count": {
+                    "type": "string",
+                    "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+                    "minLength": 1
+                  },
+                  "no_with_veto_count": {
+                    "type": "string",
+                    "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "yes_count",
+                  "abstain_count",
+                  "no_count",
+                  "no_with_veto_count"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "submit_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "deposit_end_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "voting_start_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "voting_end_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "messages": {
+            "type": "array",
+            "items": {}
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tally": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "yes_count": {
+                    "type": "string",
+                    "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+                    "minLength": 1
+                  },
+                  "abstain_count": {
+                    "type": "string",
+                    "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+                    "minLength": 1
+                  },
+                  "no_count": {
+                    "type": "string",
+                    "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+                    "minLength": 1
+                  },
+                  "no_with_veto_count": {
+                    "type": "string",
+                    "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "yes_count",
+                  "abstain_count",
+                  "no_count",
+                  "no_with_veto_count"
+                ],
+                "additionalProperties": {}
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "voted": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "messages"
+        ],
+        "additionalProperties": {}
+      }
+    },
+    "pagination": {
+      "type": "object",
+      "properties": {
+        "total": {
+          "type": "string",
+          "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+          "minLength": 1
+        },
+        "next_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "total"
+      ],
+      "additionalProperties": {}
+    }
+  },
+  "required": [
+    "proposals",
+    "pagination"
+  ],
+  "additionalProperties": {}
+}

--- a/fixtures/schemas/staking-positions-response.json
+++ b/fixtures/schemas/staking-positions-response.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "delegations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "validator_address": {
+            "type": "string"
+          },
+          "validator_moniker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "shares": {
+            "type": "string",
+            "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+            "minLength": 1
+          },
+          "balance": {
+            "type": "object",
+            "properties": {
+              "denom": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "string",
+                "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "denom",
+              "amount"
+            ],
+            "additionalProperties": {}
+          }
+        },
+        "required": [
+          "validator_address",
+          "shares",
+          "balance"
+        ],
+        "additionalProperties": {}
+      }
+    },
+    "unbonding": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "validator_address": {
+            "type": "string"
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "completion_time": {
+                  "type": "string"
+                },
+                "balance": {
+                  "type": "string",
+                  "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+                  "minLength": 1
+                },
+                "creation_height": {
+                  "type": "string",
+                  "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "completion_time",
+                "balance",
+                "creation_height"
+              ],
+              "additionalProperties": {}
+            }
+          }
+        },
+        "required": [
+          "validator_address",
+          "entries"
+        ],
+        "additionalProperties": {}
+      }
+    },
+    "rewards": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "validator_address": {
+            "type": "string"
+          },
+          "rewards": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "denom": {
+                  "type": "string"
+                },
+                "amount": {
+                  "type": "string",
+                  "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "denom",
+                "amount"
+              ],
+              "additionalProperties": {}
+            }
+          }
+        },
+        "required": [
+          "validator_address",
+          "rewards"
+        ],
+        "additionalProperties": {}
+      }
+    },
+    "total_staked": {
+      "type": "string",
+      "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+      "minLength": 1
+    },
+    "total_rewards": {
+      "type": "string",
+      "pattern": "^-?(\\d+\\.?\\d*|\\.\\d+)$",
+      "minLength": 1
+    }
+  },
+  "required": [
+    "delegations",
+    "unbonding",
+    "rewards",
+    "total_staked",
+    "total_rewards"
+  ],
+  "additionalProperties": {}
+}

--- a/fixtures/wallet/staking-positions.json
+++ b/fixtures/wallet/staking-positions.json
@@ -1,1 +1,19 @@
-{"delegations":[{"validator":"nolusvaloper1val00000000000000000000000000000one","amount":"1000000000","rewards":"12500000"}],"total_delegated":"1000.00","total_rewards":"12.50"}
+{
+  "delegations": [
+    {
+      "validator_address": "nolusvaloper1val00000000000000000000000000000one",
+      "validator_moniker": "Nolus Validator One",
+      "shares": "1000000000",
+      "balance": { "denom": "unls", "amount": "1000000000" }
+    }
+  ],
+  "unbonding": [],
+  "rewards": [
+    {
+      "validator_address": "nolusvaloper1val00000000000000000000000000000one",
+      "rewards": [{ "denom": "unls", "amount": "12500000" }]
+    }
+  ],
+  "total_staked": "1000.00",
+  "total_rewards": "12.50"
+}

--- a/src/common/api/schemas/index.test.ts
+++ b/src/common/api/schemas/index.test.ts
@@ -8,7 +8,9 @@ import {
   EarnPoolSchema,
   EarnPositionsResponseSchema,
   GasFeeConfigResponseSchema,
-  SkipRouteConfigSchema
+  SkipRouteConfigSchema,
+  ProposalsResponseSchema,
+  StakingPositionsResponseSchema
 } from "./index";
 
 // These tests exercise the Zod runtime validation schemas that guard the
@@ -446,5 +448,107 @@ describe("SkipRouteConfigSchema", () => {
     if (result.success) {
       expect((result.data as Record<string, unknown>).swap_currency_osmosis).toBe("USDC");
     }
+  });
+});
+
+// ===========================================================================
+// ProposalsResponseSchema
+// ===========================================================================
+
+describe("ProposalsResponseSchema", () => {
+  const proposal = (overrides: Record<string, unknown> = {}) => ({
+    id: "337",
+    status: "PROPOSAL_STATUS_PASSED",
+    final_tally_result: {
+      yes_count: "173872067484325",
+      abstain_count: "0",
+      no_count: "0",
+      no_with_veto_count: "0"
+    },
+    title: "Close Inactive Market",
+    summary: "…",
+    messages: [{ "@type": "/cosmwasm.wasm.v1.MsgSudoContract" }],
+    metadata: "Close Inactive Market",
+    ...overrides
+  });
+
+  it("should accept a valid proposals response", () => {
+    const result = ProposalsResponseSchema.safeParse({
+      proposals: [proposal()],
+      pagination: { total: "99", next_key: null }
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept a proposal missing the optional tally/time fields (deposit-period)", () => {
+    const result = ProposalsResponseSchema.safeParse({
+      proposals: [{ id: "340", status: "PROPOSAL_STATUS_DEPOSIT_PERIOD", messages: [] }],
+      pagination: { total: "1" }
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject a non-numeric tally count", () => {
+    const result = ProposalsResponseSchema.safeParse({
+      proposals: [
+        proposal({
+          final_tally_result: { yes_count: "many", abstain_count: "0", no_count: "0", no_with_veto_count: "0" }
+        })
+      ],
+      pagination: { total: "1" }
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject a proposal missing the required messages field", () => {
+    const { messages: _messages, ...noMessages } = proposal();
+    const result = ProposalsResponseSchema.safeParse({ proposals: [noMessages], pagination: { total: "1" } });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ===========================================================================
+// StakingPositionsResponseSchema
+// ===========================================================================
+
+describe("StakingPositionsResponseSchema", () => {
+  const delegation = (balance: unknown) => ({
+    validator_address: "nolusvaloper1one",
+    validator_moniker: "One",
+    shares: "1000000000",
+    balance
+  });
+  const wrap = (deleg: unknown) => ({
+    delegations: [deleg],
+    unbonding: [],
+    rewards: [{ validator_address: "nolusvaloper1one", rewards: [{ denom: "unls", amount: "12500000" }] }],
+    total_staked: "1000.00",
+    total_rewards: "12.50"
+  });
+
+  it("should accept a valid positions response", () => {
+    const result = StakingPositionsResponseSchema.safeParse(wrap(delegation({ denom: "unls", amount: "1000000000" })));
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept an all-empty response", () => {
+    const result = StakingPositionsResponseSchema.safeParse({
+      delegations: [],
+      unbonding: [],
+      rewards: [],
+      total_staked: "0",
+      total_rewards: "0"
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject a delegation whose balance is a flat string, not the { denom, amount } object", () => {
+    const result = StakingPositionsResponseSchema.safeParse(wrap(delegation("1000000000")));
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject a non-numeric balance amount", () => {
+    const result = StakingPositionsResponseSchema.safeParse(wrap(delegation({ denom: "unls", amount: "lots" })));
+    expect(result.success).toBe(false);
   });
 });

--- a/src/common/api/schemas/index.ts
+++ b/src/common/api/schemas/index.ts
@@ -203,3 +203,100 @@ export const SkipRouteConfigSchema = z
     )
   })
   .passthrough();
+
+// =============================================================================
+// Governance (proposals)
+// =============================================================================
+
+const TallyResultSchema = z
+  .object({
+    yes_count: numericString,
+    abstain_count: numericString,
+    no_count: numericString,
+    no_with_veto_count: numericString
+  })
+  .passthrough();
+
+const ProposalInfoSchema = z
+  .object({
+    id: z.string(),
+    status: z.string(),
+    final_tally_result: TallyResultSchema.nullish(),
+    submit_time: z.string().nullish(),
+    deposit_end_time: z.string().nullish(),
+    voting_start_time: z.string().nullish(),
+    voting_end_time: z.string().nullish(),
+    title: z.string().nullish(),
+    summary: z.string().nullish(),
+    messages: z.array(z.unknown()),
+    metadata: z.string().nullish(),
+    tally: TallyResultSchema.nullish(),
+    voted: z.boolean().nullish()
+  })
+  .passthrough();
+
+export const ProposalsResponseSchema = z
+  .object({
+    proposals: z.array(ProposalInfoSchema),
+    pagination: z
+      .object({
+        total: numericString,
+        next_key: z.string().nullish()
+      })
+      .passthrough()
+  })
+  .passthrough();
+
+// =============================================================================
+// Staking (positions)
+// =============================================================================
+
+// The balance/reward coins are BalanceInfoSimple OBJECTS ({ denom, amount }), not flat
+// strings — reading them as strings is what dropped every delegation/reward upstream.
+const BalanceInfoSimpleSchema = z
+  .object({
+    denom: z.string(),
+    amount: numericString
+  })
+  .passthrough();
+
+const StakingPositionSchema = z
+  .object({
+    validator_address: z.string(),
+    validator_moniker: z.string().nullish(),
+    shares: numericString,
+    balance: BalanceInfoSimpleSchema
+  })
+  .passthrough();
+
+const UnbondingEntrySchema = z
+  .object({
+    completion_time: z.string(),
+    balance: numericString,
+    creation_height: numericString
+  })
+  .passthrough();
+
+const UnbondingPositionSchema = z
+  .object({
+    validator_address: z.string(),
+    entries: z.array(UnbondingEntrySchema)
+  })
+  .passthrough();
+
+const ValidatorRewardSchema = z
+  .object({
+    validator_address: z.string(),
+    rewards: z.array(BalanceInfoSimpleSchema)
+  })
+  .passthrough();
+
+export const StakingPositionsResponseSchema = z
+  .object({
+    delegations: z.array(StakingPositionSchema),
+    unbonding: z.array(UnbondingPositionSchema),
+    rewards: z.array(ValidatorRewardSchema),
+    total_staked: numericString,
+    total_rewards: numericString
+  })
+  .passthrough();


### PR DESCRIPTION
Three backlog items from the suite deep-dive list:

- The funded-dependent T2 boundary cells now make their real assertions: lease below-minimum asserts the live-resolved range message (bounds read from the locale, never hardcoded), and the earn-withdraw/stake-undelegate over-position cells type a sentinel above any held position and assert the exact reactive error, with skip-honesty preserved in both wallet states.
- Governance proposals and staking positions gain real Zod schema definitions (consumed by the fixture codegen and ajv validation — not wired into app runtime): the staking fixture was reshaped to the true object-form balance/rewards, with a negative test proving the old flat-string shape is rejected. The /vote coverage cell's gap reason now states the remaining gap precisely (render-level, schema validated).
- RPC error sanitization extends to IPv6 (bracketed with or without port, and bare host:port), ordered so credentials are consumed first; bounded quantifiers keep the patterns ReDoS-safe, verified empirically with adversarial input.

suite impact: T0/T2 + fixture seam, covered by the strengthened cells, the schema negative tests, and the new redaction vectors.

Verification: full e2e gate green on the rebased tree (384 tests over the 88/83/86/88 floors, matrix guard), root vue-tsc green for the schema module; single review round — all three passes clean.