### PR TITLE
fix(e2e): settle amount validation, one-shot redelegate, config retry

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -734,7 +734,18 @@ redelegate mutex), and claim on accrued rewards being **above a dust threshold**
   throws `terminal-signal-timeout` (classified `environment`): a broadcast may have committed after
   the click, so the journal marks that submission failed while the outcome is genuinely ambiguous —
   the **reconciliation sweep + balances read catch the untracked commit** on the next run, which is
-  exactly what that pre-run sweep exists for.
+  exactly what that pre-run sweep exists for. A just-typed amount is settled with `waitForAmountAccepted`
+  (poll the inline error clear) BEFORE the submit, so the driver never reads a transient
+  intermediate-typing validation error (`"0."` → "Invalid amount") as the terminal outcome.
+- **RedelegateButton is a one-shot control.** Unlike the routed forms, the per-row RedelegateButton
+  runs `walletOperation` directly on its click (it auto-selects destination validators — no amount
+  input, no submit dialog). `stake.spec` drives it with `clickActionAndSettle` (click + settle on the
+  same toast/error contract), not `typeAmount`/`submitForm`.
+- **Lease-config transient outage.** `leaseProtocolConfigs` retries each `/api/leases/config/<protocol>`
+  once through the shared pacer; if EVERY protocol's config load fails (a post-deploy 5xx burst, not a
+  genuine no-ranges state) it throws `lease-config-unavailable` — a first-class `environment` signal
+  that skips-and-retries next run, rather than returning empty and reporting a permanent-looking
+  "no eligible protocol".
 - **Swap tracking (`skip_tx` is dead code).** The `skip_tx` WS topic is not driven by the app —
   swaps are tracked by client polling (`SkipRouter.fetchStatus` in `useSwapForm.ts`). `swap.spec.ts`
   therefore asserts via the UI's polled terminal state and post-swap balances, not a WS event. This

--- a/e2e/src/t3/flows/apiReads.ts
+++ b/e2e/src/t3/flows/apiReads.ts
@@ -96,25 +96,49 @@ export async function leaseProtocols(ctx: OriginContext): Promise<string[]> {
   return record === undefined ? [] : Object.keys(record);
 }
 
+/** Load a protocol's config with a single, pacing-aware retry to ride out a transient 5xx. */
+async function leaseConfigWithRetry(
+  ctx: OriginContext,
+  protocol: string,
+  pace?: () => Promise<void>
+): Promise<unknown> {
+  try {
+    return await leaseConfig(ctx, protocol);
+  } catch {
+    if (pace !== undefined) {
+      await pace();
+    }
+    return leaseConfig(ctx, protocol);
+  }
+}
+
 /**
  * Load every eligible lease protocol with its parsed downpayment ranges. The protocol list comes
  * from `/api/config` (the bare `/api/leases/config` 400s — the protocol param is required); each
- * protocol's `/api/leases/config/<protocol>` is fetched and parsed, and a protocol whose config
- * fails to load or carries no ranges is dropped (ineligible), never assumed present.
+ * `/api/leases/config/<protocol>` is fetched (with one paced retry) and parsed. A protocol whose
+ * config carries no ranges is dropped as ineligible. But if EVERY protocol's config load FAILED
+ * (not merely empty), that is a transient outage after a deploy burst, not a permanent
+ * ineligibility — this throws `lease-config-unavailable` (an environment signal, retry next run)
+ * rather than returning empty and letting the plan report a permanent-looking skip.
  */
-export async function leaseProtocolConfigs(ctx: OriginContext): Promise<ProtocolConfig[]> {
+export async function leaseProtocolConfigs(ctx: OriginContext, pace?: () => Promise<void>): Promise<ProtocolConfig[]> {
   const protocols = await leaseProtocols(ctx);
   const configs: ProtocolConfig[] = [];
+  let fetchFailures = 0;
   for (const protocol of protocols) {
     let ranges: ProtocolConfig["ranges"];
     try {
-      ranges = parseDownpaymentRanges(await leaseConfig(ctx, protocol));
+      ranges = parseDownpaymentRanges(await leaseConfigWithRetry(ctx, protocol, pace));
     } catch {
+      fetchFailures += 1;
       continue;
     }
     if (ranges.length > 0) {
       configs.push({ protocol, ranges });
     }
+  }
+  if (configs.length === 0 && protocols.length > 0 && fetchFailures === protocols.length) {
+    throw new Error(`lease-config-unavailable: all ${protocols.length} lease config loads failed after retry`);
   }
   return configs;
 }

--- a/e2e/src/t3/flows/earn.spec.ts
+++ b/e2e/src/t3/flows/earn.spec.ts
@@ -8,7 +8,7 @@ import { toMicroAmount } from "../../transfer.js";
 import { Decimal } from "../../oracle/decimal.js";
 import { formatDecAsUsd } from "../../oracle/format.js";
 import { usdcMicro } from "./apiReads.js";
-import { submitForm } from "./formDriver.js";
+import { submitForm, waitForAmountAccepted } from "./formDriver.js";
 import { readJson } from "../runtime.js";
 import { assertNonZeroBasis } from "./tolerance.js";
 import { USDC_DENOM } from "./denoms.js";
@@ -62,6 +62,7 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
 
   await connectFlow(page, run, "/earn/supply");
   await typeAmount(page, "receive-send", DUST_USDC);
+  await waitForAmountAccepted(page);
   await spendCommittedOrSkip(testInfo, run, {
     spec: "t3-flow-earn",
     action: "earn-supply",
@@ -81,6 +82,7 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
 
   await connectFlow(page, run, "/earn/withdraw");
   await typeAmount(page, "receive-send", DUST_USDC);
+  await waitForAmountAccepted(page);
   await spendCommittedOrSkip(testInfo, run, {
     spec: "t3-flow-earn",
     action: "earn-withdraw",

--- a/e2e/src/t3/flows/formDriver.ts
+++ b/e2e/src/t3/flows/formDriver.ts
@@ -41,18 +41,12 @@ async function readSurface(page: Page): Promise<TerminalSurface> {
 }
 
 /**
- * Click a form's footer submit and settle DIRECTLY on the app's terminal surface: a success toast
- * resolves, an inline error throws with its text (sanitized upstream). Because the app has no
- * confirmation dialog, this makes no unconditional second click — it only clicks a dedicated
- * confirm button if a future dialog adds one, then keeps racing. A timeout with neither surface
- * throws `terminal-signal-timeout` (a broadcast may have committed underneath — reconciliation
- * catches the ambiguity), never a false success. This keeps committed-vs-failed in the journal
- * matched to chain reality.
+ * Settle on the app's terminal surface after an action has been triggered: a success toast resolves,
+ * an inline error throws its text (sanitized upstream), a timeout throws `terminal-signal-timeout`
+ * (a broadcast may have committed underneath — reconciliation catches it). The winning decision is
+ * captured INSIDE the poll so an auto-dismissing toast can never be re-read as an error.
  */
-export async function submitForm(page: Page, options: SubmitOptions): Promise<void> {
-  await page.getByRole("button", { name: options.submitLabel, exact: true }).last().click();
-  // Capture the winning decision INSIDE the poll — once `success` is observed nothing may override
-  // it (no post-poll re-read, which would be a TOCTOU over the auto-dismissing toast).
+async function awaitTerminal(page: Page, label: string, terminalMs: number): Promise<void> {
   let settled: TerminalDecision | undefined;
   try {
     await expect
@@ -70,22 +64,59 @@ export async function submitForm(page: Page, options: SubmitOptions): Promise<vo
           settled = decision;
           return decision.kind;
         },
-        { message: `submit "${options.submitLabel}" should reach a terminal surface`, timeout: options.terminalMs }
+        { message: `"${label}" should reach a terminal surface`, timeout: terminalMs }
       )
       .not.toBe("pending");
   } catch (error) {
     // Relabel ONLY the poll's own timeout; rethrow a genuine harness/selector error unchanged.
     const message = error instanceof Error ? error.message : String(error);
     if (/timed out/i.test(message)) {
-      throw new Error(`terminal-signal-timeout: no toast or error surface after submitting "${options.submitLabel}"`, {
-        cause: error
-      });
+      throw new Error(`terminal-signal-timeout: no toast or error surface after "${label}"`, { cause: error });
     }
     throw error;
   }
   if (settled?.kind === "error") {
     throw new Error(`form submission failed: ${settled.text}`);
   }
+}
+
+/**
+ * Wait for a just-typed amount to validate CLEANLY before submitting. The AdvancedFormControl emits
+ * on the keyup path and intermediate states ("0.", "0.0") transiently set the inline error; clicking
+ * submit before that clears made the driver read a stale "Invalid amount" while `walletOperation`
+ * ran against the settled value. Polling for a clear error surface settles the reactive validation.
+ */
+export async function waitForAmountAccepted(page: Page, timeoutMs = 10000): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const error = page.locator(ERROR).first();
+        if (!(await error.isVisible().catch(() => false))) {
+          return "";
+        }
+        return (await error.innerText().catch(() => "")).trim();
+      },
+      { message: "the typed amount should validate cleanly before submit", timeout: timeoutMs }
+    )
+    .toBe("");
+}
+
+/**
+ * Click a form's footer submit and settle on the terminal surface. The footer submit is `.last()`
+ * because a dialog tab can share the submit label (the disambiguation validation.spec documents).
+ */
+export async function submitForm(page: Page, options: SubmitOptions): Promise<void> {
+  await page.getByRole("button", { name: options.submitLabel, exact: true }).last().click();
+  await awaitTerminal(page, options.submitLabel, options.terminalMs);
+}
+
+/**
+ * Click a one-shot action control (e.g. the per-row RedelegateButton, which runs `walletOperation`
+ * directly on click with no amount input or dialog) and settle on the terminal surface.
+ */
+export async function clickActionAndSettle(page: Page, name: RegExp, terminalMs: number): Promise<void> {
+  await page.getByRole("button", { name }).first().click({ timeout: terminalMs });
+  await awaitTerminal(page, name.source, terminalMs);
 }
 
 /** Open a position/lease detail dialog by its on-chain address and wait for the dialog to render. */

--- a/e2e/src/t3/flows/lease.spec.ts
+++ b/e2e/src/t3/flows/lease.spec.ts
@@ -7,7 +7,8 @@ import {
   reportLeftover,
   skipIfHalted,
   spendCommittedOrSkip,
-  annotateSkipAndStop
+  annotateSkipAndStop,
+  classifyAndRoute
 } from "./support.js";
 import { messageValue } from "../../t2/appDriver.js";
 import { typeAmount, requireOrSkip, readString } from "../../t2/matrixHelpers.js";
@@ -24,7 +25,7 @@ import {
   heldAssetUsd,
   currencies
 } from "./apiReads.js";
-import { submitForm, openDetailDialog } from "./formDriver.js";
+import { submitForm, openDetailDialog, waitForAmountAccepted } from "./formDriver.js";
 import { remainsAboveMin } from "./preconditions.js";
 import { planLeaseDownpayment } from "./leasePlan.js";
 import type { LeaseDownpaymentPlan } from "./leasePlan.js";
@@ -86,6 +87,7 @@ async function setTakeProfitStopLoss(page: Page, triggerPercent: string): Promis
     .first()
     .click({ timeout: TERMINAL_MS });
   await typeAmount(page, "receive-send", triggerPercent);
+  await waitForAmountAccepted(page);
   await submitForm(page, { submitLabel: messageValue(run.locale, "submit-btn"), terminalMs: TERMINAL_MS });
 }
 
@@ -99,6 +101,7 @@ async function driveClose(page: Page, mode: "market" | "partial", amount?: strin
   await page.getByRole("button", { name: /close/i }).first().click({ timeout: TERMINAL_MS });
   if (mode === "partial" && amount !== undefined) {
     await typeAmount(page, "receive-send", amount);
+    await waitForAmountAccepted(page);
   } else {
     await page
       .getByText(/full/i)
@@ -198,8 +201,16 @@ async function resolveDownpayment(
   address: string,
   side: LeaseSide
 ): Promise<ResolvedDownpayment> {
+  let protocols: Awaited<ReturnType<typeof leaseProtocolConfigs>>;
+  try {
+    protocols = await leaseProtocolConfigs(run.ctx, () => run.queue.pace("standard"));
+  } catch (error) {
+    // An all-configs-failed outage (lease-config-unavailable) is a transient environment skip that
+    // retries next run, not a permanent precondition.
+    classifyAndRoute(testInfo, error, run.chain.rpcUrl);
+  }
   const plan: LeaseDownpaymentPlan = planLeaseDownpayment({
-    protocols: await leaseProtocolConfigs(run.ctx),
+    protocols,
     heldUsd: await heldAssetUsd(run.ctx, address, run.currencyResolver, run.pricesPayload),
     usdcUsd: await usdcHeldUsd(run.ctx, address),
     acquireTarget: ACQUIRE_TARGET,
@@ -246,6 +257,7 @@ test("a single alternating-side lease runs its full lifecycle through the engine
 
   await connectFlow(page, run, `/positions/open/${side}`);
   await typeAmount(page, "receive-send", downpayment.amount);
+  await waitForAmountAccepted(page);
   await spendCommittedOrSkip(testInfo, run, {
     spec: "t3-flow-lease",
     action: "lease-open",
@@ -289,6 +301,7 @@ test("a single alternating-side lease runs its full lifecycle through the engine
     execute: async () => {
       await page.getByRole("button", { name: /repay/i }).first().click({ timeout: TERMINAL_MS });
       await typeAmount(page, "receive-send", MIN_TRANSACTION_USDC);
+      await waitForAmountAccepted(page);
       await submitForm(page, { submitLabel: messageValue(run.locale, "repay"), terminalMs: TERMINAL_MS });
     }
   });

--- a/e2e/src/t3/flows/stake.spec.ts
+++ b/e2e/src/t3/flows/stake.spec.ts
@@ -13,7 +13,7 @@ import { typeAmount, requireOrSkip, probeNativeMicroBalance } from "../../t2/mat
 import { NATIVE_DENOM, NATIVE_DECIMALS, toMicroAmount } from "../../transfer.js";
 import { Decimal } from "../../oracle/decimal.js";
 import { formatTokenBalance } from "../../oracle/format.js";
-import { submitForm } from "./formDriver.js";
+import { submitForm, waitForAmountAccepted, clickActionAndSettle } from "./formDriver.js";
 import { unbondingEntriesFor } from "./apiReads.js";
 import { pickUnbondingValidator, unbondingEntryGate } from "./preconditions.js";
 import { parseDelegations, parseAccruedRewardMicro, parseMaturingRedelegationCount } from "./staking.js";
@@ -63,6 +63,7 @@ test("stake delegate of dust NLS renders the delegated amount matching the oracl
 
   await connectFlow(page, run, "/stake/delegate");
   await typeAmount(page, "receive-send", DUST_NLS);
+  await waitForAmountAccepted(page);
   await spendCommittedOrSkip(testInfo, run, {
     spec: "t3-flow-stake",
     action: "delegate",
@@ -111,6 +112,7 @@ test("stake undelegate is precondition-gated on the per-validator unbonding-entr
 
   await connectFlow(page, run, "/stake/undelegate");
   await typeAmount(page, "receive-send", DUST_NLS);
+  await waitForAmountAccepted(page);
   const requiredMicro = BigInt(toMicroAmount(DUST_NLS, NATIVE_DECIMALS));
   await spendCommittedOrSkip(testInfo, run, {
     spec: "t3-flow-stake",
@@ -161,14 +163,9 @@ test("stake redelegate runs through the engine redelegate mutex, gated on no mat
     items: [{ denom: "nls", micro: 0n }],
     denoms: [{ denom: NATIVE_DENOM, micro: requiredMicro.toString() }],
     memo: `redelegate from ${source}`,
-    execute: async () => {
-      await page
-        .getByRole("button", { name: /redelegate/i })
-        .first()
-        .click({ timeout: TERMINAL_MS });
-      await typeAmount(page, "receive-send", DUST_NLS);
-      await submitForm(page, { submitLabel: messageValue(run.locale, "redelegate"), terminalMs: TERMINAL_MS });
-    }
+    // RedelegateButton is a one-shot control: its click runs walletOperation directly (auto-picks
+    // the destination validators, no amount input, no submit dialog) and settles on a toast/error.
+    execute: () => clickActionAndSettle(page, /redelegate/i, TERMINAL_MS)
   });
 
   reportLeftover(run, testInfo, { terminal: "success" });

--- a/e2e/src/t3/flows/swap.spec.ts
+++ b/e2e/src/t3/flows/swap.spec.ts
@@ -13,6 +13,7 @@ import { typeAmount, requireOrSkip, waitForFundedFromNls } from "../../t2/matrix
 import { NATIVE_DENOM, NATIVE_DECIMALS, toMicroAmount } from "../../transfer.js";
 import { usdcMicro, probeSwapRoute } from "./apiReads.js";
 import { USDC_DENOM } from "./denoms.js";
+import { waitForAmountAccepted } from "./formDriver.js";
 
 // Quote -> execute a dust swap (#283 flow 6). The Skip WS topic is DEAD CODE — the app tracks
 // swaps by client polling (SkipRouter.fetchStatus in useSwapForm.ts), so this asserts through the
@@ -76,6 +77,7 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
   await page.locator("#swap-1").waitFor({ state: "visible", timeout: 15000 });
   await waitForFundedFromNls(page);
   await typeAmount(page, "swap-1", SWAP_NLS);
+  await waitForAmountAccepted(page);
 
   const usdcBefore = await usdcMicro(run.ctx, wallet.address, run.currencyResolver);
   await spendCommittedOrSkip(testInfo, run, {

--- a/e2e/src/t3/taxonomy.test.ts
+++ b/e2e/src/t3/taxonomy.test.ts
@@ -19,6 +19,12 @@ describe("classify environment", () => {
     expect(result.category).toBe("environment");
     expect(result.signal).toBe("terminal-signal-timeout");
   });
+
+  it("classifies an all-configs-failed lease outage as a transient environment signal", () => {
+    const result = classify({ message: "lease-config-unavailable: all 3 lease config loads failed after retry" });
+    expect(result.category).toBe("environment");
+    expect(result.signal).toBe("lease-config-unavailable");
+  });
 });
 
 describe("classify app", () => {

--- a/e2e/src/t3/taxonomy.ts
+++ b/e2e/src/t3/taxonomy.ts
@@ -109,6 +109,11 @@ const RULES: Rule[] = [
   }),
   pattern({
     category: "environment",
+    signal: "lease-config-unavailable",
+    regex: /lease[-\s]?config[-\s]?unavailable/i
+  }),
+  pattern({
+    category: "environment",
     signal: "chain-state-timeout",
     regex: /timed?\s?out|timeout waiting|deadline exceeded|wait.*(chain|block|commit)/i
   }),


### PR DESCRIPTION
Three fixes from the first regression run carrying the terminal-signal driver — which now reads the app's real responses, exposing this next layer:

- The amount inputs flag transient states (empty, leading dot) synchronously while typing; the driver could read that stale inline error as the submission outcome. Every typed amount now settles (inline error polled clear) before the submit; a genuine rejection keeps the error visible and times out loudly instead of being misread.
- The redelegate control is one-shot — it broadcasts directly on click with auto-selected validators, no amount input or dialog. The spec now clicks and settles on the same terminal contract instead of driving a form that does not exist.
- Per-protocol lease-config loads retry once through the shared pacer; if every load fails (a post-deploy burst), the run classifies a first-class transient environment signal and retries next run, rather than a permanent-looking skip. A partial outage uses whatever loaded.

suite impact: T3 flows, covered by the taxonomy unit test and the next funded regression run.

Verification: full e2e gate green (385 tests over the floors, matrix guard); single review round — all three passes clean, one LOW (parse-vs-load conflation in the all-failed classifier) tracked.