### PR TITLE
fix(e2e): post swap-route probe, held usdc denoms, report tiers

### DIFF
--- a/e2e/src/http.ts
+++ b/e2e/src/http.ts
@@ -8,7 +8,7 @@ const BODY_TIMEOUT_MS = 30_000;
 const MAX_RESPONSE_BYTES = 5_000_000;
 const ERROR_BODY_PREVIEW_LENGTH = 200;
 
-async function readCappedText(url: string, body: Dispatcher.ResponseData["body"]): Promise<string> {
+async function readCappedText(method: string, url: string, body: Dispatcher.ResponseData["body"]): Promise<string> {
   // Sanctioned assertion: a Node Readable's async iterator is typed as yielding `any`;
   // undici streams Buffer chunks here, so narrowing the iterable lets us bound total
   // bytes without an unchecked `any` binding per chunk.
@@ -18,7 +18,7 @@ async function readCappedText(url: string, body: Dispatcher.ResponseData["body"]
   for await (const chunk of stream) {
     total += chunk.length;
     if (total > MAX_RESPONSE_BYTES) {
-      throw new Error(`GET ${url} response body exceeded ${MAX_RESPONSE_BYTES} bytes`);
+      throw new Error(`${method} ${url} response body exceeded ${MAX_RESPONSE_BYTES} bytes`);
     }
     chunks.push(chunk);
   }
@@ -34,7 +34,7 @@ export async function getJson(url: string, dispatcher: Dispatcher | undefined): 
     ...(dispatcher ? { dispatcher } : {})
   });
 
-  const body = await readCappedText(url, response.body);
+  const body = await readCappedText("GET", url, response.body);
 
   if (response.statusCode < HTTP_OK_MIN || response.statusCode > HTTP_OK_MAX) {
     throw new Error(`GET ${url} returned HTTP ${response.statusCode}: ${body.slice(0, ERROR_BODY_PREVIEW_LENGTH)}`);
@@ -44,5 +44,28 @@ export async function getJson(url: string, dispatcher: Dispatcher | undefined): 
     return JSON.parse(body) as unknown;
   } catch {
     throw new Error(`GET ${url} returned a non-JSON body`);
+  }
+}
+
+export async function postJson(url: string, payload: unknown, dispatcher: Dispatcher | undefined): Promise<unknown> {
+  const response = await request(url, {
+    method: "POST",
+    headers: { accept: "application/json", "content-type": "application/json" },
+    body: JSON.stringify(payload),
+    headersTimeout: HEADERS_TIMEOUT_MS,
+    bodyTimeout: BODY_TIMEOUT_MS,
+    ...(dispatcher ? { dispatcher } : {})
+  });
+
+  const body = await readCappedText("POST", url, response.body);
+
+  if (response.statusCode < HTTP_OK_MIN || response.statusCode > HTTP_OK_MAX) {
+    throw new Error(`POST ${url} returned HTTP ${response.statusCode}: ${body.slice(0, ERROR_BODY_PREVIEW_LENGTH)}`);
+  }
+
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    throw new Error(`POST ${url} returned a non-JSON body`);
   }
 }

--- a/e2e/src/report/aggregate.test.ts
+++ b/e2e/src/report/aggregate.test.ts
@@ -281,3 +281,43 @@ describe("aggregate inputs and passthrough", () => {
     expect(out.failures[0]?.test).not.toContain("10.1.2.3");
   });
 });
+
+describe("aggregate tier attribution by project", () => {
+  it("attributes a mis-filed t3-flows test to t3-flows, never to the t1 source file it landed in", () => {
+    // A t3-flows-project test appears in the t1 source file (the run's JSON output path was not
+    // overridden, so its json defaulted onto playwright-report.json). Its tier must come from its
+    // project, so it counts under t3-flows and never inflates t1.
+    const t1File = pwReport([
+      { projectName: "desktop-light", title: "assets renders", file: "routes.spec.ts", status: "expected" },
+      {
+        projectName: "t3-flows",
+        title: "lease opens",
+        file: "lease.spec.ts",
+        status: "unexpected",
+        error: "expect(x).toBe(y) assertion failed"
+      }
+    ]);
+    const out = aggregate(
+      baseInput([
+        { tier: "t1", source: { kind: "playwright", report: t1File } },
+        { tier: "t3-flows", source: { kind: "absent" } }
+      ]),
+      identity
+    );
+
+    const byTier = new Map(out.tiers.map((tier) => [tier.tier, tier]));
+    expect(byTier.get("t1")).toMatchObject({ status: "present", total: 1, passed: 1, failed: 0 });
+    // t3-flows ran (its tests are present here) even though its own result file was absent.
+    expect(byTier.get("t3-flows")).toMatchObject({ status: "present", total: 1, failed: 1, appBug: 1 });
+    expect(out.failures.map((failure) => [failure.tier, failure.projectName])).toEqual([["t3-flows", "t3-flows"]]);
+  });
+
+  it("keeps an unmapped project on the source-file tier via the fallback", () => {
+    const report = pwReport([
+      { projectName: "some-adhoc-project", title: "custom", file: "x.spec.ts", status: "expected" }
+    ]);
+    const out = aggregate(baseInput([{ tier: "t2", source: { kind: "playwright", report } }]), identity);
+    const byTier = new Map(out.tiers.map((tier) => [tier.tier, tier]));
+    expect(byTier.get("t2")).toMatchObject({ status: "present", total: 1, passed: 1 });
+  });
+});

--- a/e2e/src/report/aggregate.ts
+++ b/e2e/src/report/aggregate.ts
@@ -223,25 +223,24 @@ interface TierResult {
   tests: RunTest[];
 }
 
-function aggregatePlaywrightTier(tier: string, report: unknown, scrub: Scrubber): TierResult {
-  const tests = extractRunTests(report, tier);
-  let totals = emptyTotals(tier, "present");
-  const failures: ClassifiedFailure[] = [];
-  const skips: SkippedTest[] = [];
-  for (const test of tests) {
-    const { failure: fail, skip: skipped } = classifyTest(test, scrub);
-    if (fail !== null) {
-      failures.push(fail);
-      totals = countFailure(totals, fail.failureClass);
-    } else if (skipped !== null) {
-      skips.push(skipped);
-      totals.skipped += 1;
-    } else {
-      totals.passed += 1;
-    }
+interface TierAccumulator {
+  totals: TierTotals;
+  failures: ClassifiedFailure[];
+  skips: SkippedTest[];
+}
+
+/** Classify one test and fold it into its (project-derived) tier accumulator. */
+function classifyInto(acc: TierAccumulator, test: RunTest, scrub: Scrubber): void {
+  const { failure: fail, skip: skipped } = classifyTest(test, scrub);
+  if (fail !== null) {
+    acc.failures.push(fail);
+    acc.totals = countFailure(acc.totals, fail.failureClass);
+  } else if (skipped !== null) {
+    acc.skips.push(skipped);
+    acc.totals.skipped += 1;
+  } else {
+    acc.totals.passed += 1;
   }
-  totals.total = totals.passed + totals.failed + totals.skipped;
-  return { totals, failures, skips, tests };
 }
 
 function aggregateSummaryTier(
@@ -264,16 +263,6 @@ function aggregateSummaryTier(
   totals.failed = failures.length;
   totals.total = totals.passed + totals.failed + totals.skipped;
   return { totals, failures, skips: [], tests: [] };
-}
-
-function aggregateTier(input: TierInput, scrub: Scrubber): TierResult {
-  if (input.source.kind === "playwright") {
-    return aggregatePlaywrightTier(input.tier, input.source.report, scrub);
-  }
-  if (input.source.kind === "summary") {
-    return aggregateSummaryTier(input.tier, input.source, scrub);
-  }
-  return { totals: emptyTotals(input.tier, input.source.kind), failures: [], skips: [], tests: [] };
 }
 
 function basename(path: string): string {
@@ -375,17 +364,103 @@ function leftoverSection(input: LeftoverInput): LeftoverSection {
  * human-facing string is run through the caller's scrubber here, so the emitted `report.json` is
  * already free of the resolver host and any secret before it is ever written or rendered.
  */
+interface CollectedTiers {
+  order: string[];
+  playwrightAcc: Map<string, TierAccumulator>;
+  summaryResults: Map<string, TierResult>;
+  sourceStatus: Map<string, InputStatus>;
+  allTests: RunTest[];
+}
+
+/**
+ * Fold every source into per-tier accumulators keyed by each test's PROJECT-derived tier (not the
+ * file it was read from). `order` keeps the caller's source order, then any extra tier a project
+ * mapped onto that no source declared, in discovery order.
+ */
+function collectTiers(inputs: readonly TierInput[], scrub: Scrubber): CollectedTiers {
+  const order: string[] = [];
+  for (const tierInput of inputs) {
+    if (!order.includes(tierInput.tier)) {
+      order.push(tierInput.tier);
+    }
+  }
+  const collected: CollectedTiers = {
+    order,
+    playwrightAcc: new Map(),
+    summaryResults: new Map(),
+    sourceStatus: new Map(),
+    allTests: []
+  };
+  const ensureAcc = (tier: string): TierAccumulator => {
+    let acc = collected.playwrightAcc.get(tier);
+    if (acc === undefined) {
+      acc = { totals: emptyTotals(tier, "present"), failures: [], skips: [] };
+      collected.playwrightAcc.set(tier, acc);
+      if (!order.includes(tier)) {
+        order.push(tier);
+      }
+    }
+    return acc;
+  };
+  for (const tierInput of inputs) {
+    if (tierInput.source.kind === "playwright") {
+      // Materialize the source tier even when every one of its tests maps elsewhere, so a file
+      // that ran but held only foreign-project tests still reports present with zero of its own.
+      ensureAcc(tierInput.tier);
+      for (const test of extractRunTests(tierInput.source.report, tierInput.tier)) {
+        collected.allTests.push(test);
+        classifyInto(ensureAcc(test.tier), test, scrub);
+      }
+    } else if (tierInput.source.kind === "summary") {
+      collected.summaryResults.set(tierInput.tier, aggregateSummaryTier(tierInput.tier, tierInput.source, scrub));
+    } else {
+      collected.sourceStatus.set(tierInput.tier, tierInput.source.kind);
+    }
+  }
+  return collected;
+}
+
+interface AssembledTiers {
+  tiers: TierTotals[];
+  failures: ClassifiedFailure[];
+  skips: SkippedTest[];
+}
+
+/** Emit the ordered tier totals + flattened failures/skips from the collected accumulators. */
+function assembleTiers(collected: CollectedTiers): AssembledTiers {
+  const assembled: AssembledTiers = { tiers: [], failures: [], skips: [] };
+  for (const tier of collected.order) {
+    const acc = collected.playwrightAcc.get(tier);
+    if (acc !== undefined) {
+      acc.totals.total = acc.totals.passed + acc.totals.failed + acc.totals.skipped;
+      assembled.tiers.push(acc.totals);
+      assembled.failures.push(...acc.failures);
+      assembled.skips.push(...acc.skips);
+      continue;
+    }
+    const summary = collected.summaryResults.get(tier);
+    if (summary !== undefined) {
+      assembled.tiers.push(summary.totals);
+      assembled.failures.push(...summary.failures);
+      assembled.skips.push(...summary.skips);
+      continue;
+    }
+    assembled.tiers.push(emptyTotals(tier, collected.sourceStatus.get(tier) ?? "absent"));
+  }
+  return assembled;
+}
+
 export function aggregate(input: AggregateInput, scrub: Scrubber): RunReport {
-  const tierResults = input.tiers.map((tier) => aggregateTier(tier, scrub));
-  const tests = tierResults.flatMap((result) => result.tests);
+  const collected = collectTiers(input.tiers, scrub);
+  const assembled = assembleTiers(collected);
   return {
     version: RUN_REPORT_VERSION,
     generatedAt: input.generatedAt,
-    tiers: tierResults.map((result) => result.totals),
-    failures: tierResults.flatMap((result) => result.failures),
-    skips: tierResults.flatMap((result) => result.skips),
+    tiers: assembled.tiers,
+    failures: assembled.failures,
+    skips: assembled.skips,
     journal: journalSummary(input.journal),
     leftover: leftoverSection(input.leftover),
-    coverage: coverageSection(input.matrix, tests)
+    coverage: coverageSection(input.matrix, collected.allTests)
   };
 }

--- a/e2e/src/report/playwright.ts
+++ b/e2e/src/report/playwright.ts
@@ -30,6 +30,7 @@ export interface RunTest {
  * source-file tier the caller passed.
  */
 const PROJECT_TIER: Record<string, string> = {
+  fixture: "t1",
   "desktop-light": "t1",
   "desktop-dark": "t1",
   mobile: "t1",

--- a/e2e/src/report/playwright.ts
+++ b/e2e/src/report/playwright.ts
@@ -22,6 +22,32 @@ export interface RunTest {
   errorText: string;
 }
 
+/**
+ * Canonical Playwright project → reporting tier. A single Playwright JSON file can carry tests from
+ * more than one project — or the wrong tier's tests entirely, when a run's `PLAYWRIGHT_JSON_OUTPUT_NAME`
+ * was not set and its json defaulted onto another tier's file — so a test's tier is derived from its
+ * own project name, never from the file it was read out of. An unmapped project falls back to the
+ * source-file tier the caller passed.
+ */
+const PROJECT_TIER: Record<string, string> = {
+  "desktop-light": "t1",
+  "desktop-dark": "t1",
+  mobile: "t1",
+  t2: "t2",
+  ratelimit: "t2",
+  receive: "t2",
+  "t3-engine": "t3-engine",
+  "t3-flows": "t3-flows",
+  "visual-desktop-light": "visual",
+  "visual-desktop-dark": "visual",
+  "visual-mobile-light": "visual",
+  "visual-mobile-dark": "visual"
+};
+
+export function tierForProject(projectName: string): string | undefined {
+  return PROJECT_TIER[projectName];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -70,15 +96,16 @@ function resultsAnnotations(results: unknown[]): RunAnnotation[] {
   return results.flatMap((result) => (isRecord(result) ? annotationsOf(result.annotations) : []));
 }
 
-function testsOf(spec: Record<string, unknown>, file: string, tier: string): RunTest[] {
+function testsOf(spec: Record<string, unknown>, file: string, fallbackTier: string): RunTest[] {
   const title = asString(spec.title);
   return asArray(spec.tests)
     .filter(isRecord)
     .map((test) => {
       const results = asArray(test.results);
+      const projectName = asString(test.projectName);
       return {
-        tier,
-        projectName: asString(test.projectName),
+        tier: tierForProject(projectName) ?? fallbackTier,
+        projectName,
         title,
         file,
         status: statusFrom(asString(test.status)),
@@ -88,22 +115,26 @@ function testsOf(spec: Record<string, unknown>, file: string, tier: string): Run
     });
 }
 
-function walkSuite(suite: unknown, tier: string, parentFile: string): RunTest[] {
+function walkSuite(suite: unknown, fallbackTier: string, parentFile: string): RunTest[] {
   if (!isRecord(suite)) {
     return [];
   }
   const file = asString(suite.file) || parentFile;
   const specTests = asArray(suite.specs)
     .filter(isRecord)
-    .flatMap((spec) => testsOf(spec, asString(spec.file) || file, tier));
-  const childTests = asArray(suite.suites).flatMap((child) => walkSuite(child, tier, file));
+    .flatMap((spec) => testsOf(spec, asString(spec.file) || file, fallbackTier));
+  const childTests = asArray(suite.suites).flatMap((child) => walkSuite(child, fallbackTier, file));
   return [...specTests, ...childTests];
 }
 
-/** Flatten a parsed Playwright JSON report into the per-test rows the reporting tier classifies. */
-export function extractRunTests(report: unknown, tier: string): RunTest[] {
+/**
+ * Flatten a parsed Playwright JSON report into the per-test rows the reporting tier classifies.
+ * `fallbackTier` is the tier of the source file; each test's own tier is resolved from its project
+ * name first (see {@link tierForProject}) so a mis-filed project is still attributed correctly.
+ */
+export function extractRunTests(report: unknown, fallbackTier: string): RunTest[] {
   if (!isRecord(report)) {
     return [];
   }
-  return asArray(report.suites).flatMap((suite) => walkSuite(suite, tier, ""));
+  return asArray(report.suites).flatMap((suite) => walkSuite(suite, fallbackTier, ""));
 }

--- a/e2e/src/t3/flows/apiReads.ts
+++ b/e2e/src/t3/flows/apiReads.ts
@@ -1,12 +1,13 @@
 import type { OriginContext } from "../../t2/appDriver.js";
 import { readString } from "../../t2/matrixHelpers.js";
-import { readJson } from "../runtime.js";
+import { readJson, postJson } from "../runtime.js";
+import type { SerialQueue } from "../serialQueue.js";
 import type { Decimal } from "../../oracle/decimal.js";
 import { parseDownpaymentRanges } from "./preconditions.js";
 import type { ProtocolConfig } from "./leasePlan.js";
 import { heldMicro, priceUsdOf, microToUsd, tickersMatching } from "./denomResolver.js";
 import type { ResolvedAsset } from "./denomResolver.js";
-import { hasSwapRoute } from "./preconditions.js";
+import { hasSwapRoute, buildSwapRouteRequest } from "./preconditions.js";
 
 // Node-side, host-resolver-aware reads of the live API used by the flow specs to build the
 // oracle inputs and precondition probes. Coverage-excluded browser/network glue (see
@@ -48,22 +49,31 @@ export async function usdcMicro(
 
 export type RouteProbe = { status: "routable" } | { status: "no-route" } | { status: "error"; reason: string };
 
+export interface SwapProbeDeps {
+  ctx: OriginContext;
+  queue: SerialQueue;
+  chainId: string;
+}
+
+export interface SwapProbeArgs {
+  sourceDenom: string;
+  destDenom: string;
+  amountMicro: string;
+}
+
 /**
  * Probe a swap route, distinguishing a genuine "no route for this amount" (a precondition) from a
  * probe ERROR (the API/network failed) — the latter must not be silently reported as no-route.
+ * `/api/swap/route` is a POST endpoint (a GET 405s), so the resolved bank denoms + Nolus chain id
+ * are sent as the JSON body, drawn through the strict `/api/swap/*` rate bucket like every other
+ * swap read.
  */
-export async function probeSwapRoute(
-  ctx: OriginContext,
-  fromDenom: string,
-  toTicker: string,
-  amountMicro: string
-): Promise<RouteProbe> {
+export async function probeSwapRoute(deps: SwapProbeDeps, args: SwapProbeArgs): Promise<RouteProbe> {
+  const body = buildSwapRouteRequest({ ...args, chainId: deps.chainId });
   let payload: unknown;
   try {
-    payload = await readJson(
-      ctx,
-      `${ctx.origin}/api/swap/route?from=${encodeURIComponent(fromDenom)}&to=${encodeURIComponent(toTicker)}&amount=${encodeURIComponent(amountMicro)}`
-    );
+    await deps.queue.pace("strict");
+    payload = await postJson(deps.ctx, `${deps.ctx.origin}/api/swap/route`, body);
   } catch (error) {
     return { status: "error", reason: error instanceof Error ? error.message : String(error) };
   }

--- a/e2e/src/t3/flows/denomResolver.test.ts
+++ b/e2e/src/t3/flows/denomResolver.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { heldMicro, microToUsd, parseCurrencyResolver, priceUsdOf, tickersMatching } from "./denomResolver.js";
+import {
+  bankDenomOf,
+  heldMicro,
+  heldUsdcVariant,
+  microToUsd,
+  parseCurrencyResolver,
+  priceUsdOf,
+  tickersMatching
+} from "./denomResolver.js";
 import { Decimal } from "../../oracle/decimal.js";
 
 // Fixtures shaped like the REAL responses: balances `symbol`/`denom` carry the ibc bank hash and
@@ -88,5 +96,29 @@ describe("tickersMatching", () => {
     const resolver = new Map(parseCurrencyResolver(CURRENCIES));
     resolver.set("USDC_AXELAR", { ticker: "USDC_AXELAR", bankSymbols: ["ibc/AX"], decimalDigits: 6 });
     expect(tickersMatching(resolver, "usdc").sort()).toEqual(["USDC_AXELAR", "USDC_NOBLE"]);
+  });
+});
+
+describe("bankDenomOf", () => {
+  it("returns a ticker's first resolved bank denom, or undefined when unknown", () => {
+    const resolver = parseCurrencyResolver(CURRENCIES);
+    expect(bankDenomOf(resolver, "OSMO")).toBe("ibc/OSMOHASH");
+    expect(bankDenomOf(resolver, "NLS")).toBe("unls");
+    expect(bankDenomOf(resolver, "NOPE")).toBeUndefined();
+  });
+});
+
+describe("heldUsdcVariant", () => {
+  const resolver = new Map(parseCurrencyResolver(CURRENCIES));
+  resolver.set("USDC_AXELAR", { ticker: "USDC_AXELAR", bankSymbols: ["ibc/AXHASH"], decimalDigits: 6 });
+
+  it("prefers the USDC variant the wallet actually holds", () => {
+    const holdsAxelar = { balances: [{ denom: "ibc/AXHASH", amount: "1000000" }], total_value_usd: "0" };
+    expect(heldUsdcVariant(resolver, holdsAxelar)).toBe("ibc/AXHASH");
+  });
+
+  it("falls back to the USDC_NOBLE denom when no USDC variant is held", () => {
+    const holdsNone = { balances: [{ denom: "unls", amount: "5000000" }], total_value_usd: "0" };
+    expect(heldUsdcVariant(resolver, holdsNone)).toBe("ibc/USDCHASH");
   });
 });

--- a/e2e/src/t3/flows/denomResolver.ts
+++ b/e2e/src/t3/flows/denomResolver.ts
@@ -87,3 +87,32 @@ export function tickersMatching(resolver: Map<string, ResolvedAsset>, needle: st
   const wanted = needle.toUpperCase();
   return [...resolver.keys()].filter((ticker) => ticker.toUpperCase().includes(wanted));
 }
+
+/**
+ * The resolved bank denom for a ticker — the value a Skip/swap route request must carry, never the
+ * ticker itself. Returns the first `bank_symbol` the resolver holds for the ticker, or undefined
+ * when the ticker is unknown.
+ */
+export function bankDenomOf(resolver: Map<string, ResolvedAsset>, ticker: string): string | undefined {
+  return resolver.get(ticker)?.bankSymbols[0];
+}
+
+/**
+ * The bank denom of the USDC variant the wallet actually holds — the denom a swap will spend or
+ * receive, so a route probe matches the real economy. Prefers the first held USDC-family variant;
+ * when none is held (e.g. a fresh wallet) it falls back to the `USDC_NOBLE` denom (the lease LPN).
+ * Returns undefined only when neither a held variant nor the fallback ticker resolves.
+ */
+export function heldUsdcVariant(
+  resolver: Map<string, ResolvedAsset>,
+  balancesPayload: unknown,
+  fallbackTicker = "USDC_NOBLE"
+): string | undefined {
+  for (const ticker of tickersMatching(resolver, "USDC")) {
+    const resolved = resolver.get(ticker);
+    if (resolved !== undefined && heldMicro(balancesPayload, resolved) > 0n) {
+      return resolved.bankSymbols[0];
+    }
+  }
+  return bankDenomOf(resolver, fallbackTicker);
+}

--- a/e2e/src/t3/flows/lease.spec.ts
+++ b/e2e/src/t3/flows/lease.spec.ts
@@ -23,7 +23,8 @@ import {
   openedLease,
   leaseProtocolConfigs,
   heldAssetUsd,
-  currencies
+  currencies,
+  fetchBalances
 } from "./apiReads.js";
 import { submitForm, openDetailDialog, waitForAmountAccepted } from "./formDriver.js";
 import { remainsAboveMin } from "./preconditions.js";
@@ -33,6 +34,7 @@ import { resolveShortLeaseStable } from "./sideSelection.js";
 import type { LeaseSide } from "./sideSelection.js";
 import { assertNonZeroBasis, assertWithinTolerance } from "./tolerance.js";
 import { USDC_DENOM } from "./denoms.js";
+import { bankDenomOf, heldUsdcVariant } from "./denomResolver.js";
 
 // The alternating-side single-lease lifecycle (#283 flow 1), run same-run on ONE opened lease so
 // the pre-run sweep never sees a cross-run orphan: open → TP/SL create + edit → dust repay
@@ -159,7 +161,17 @@ async function usdcHeldUsd(ctx: RunContext["ctx"], address: string): Promise<Dec
 /** Acquire the downpayment asset by swapping USDC through the engine — capped in USDC, route-gated. */
 async function acquireDownpaymentAsset(page: Page, testInfo: TestInfo, acquireUsd: Decimal): Promise<void> {
   const acquireMicro = toMicroAmount(acquireUsd.toString(USDC_DECIMALS), USDC_DECIMALS);
-  const route = await probeSwapRoute(run.ctx, USDC_DENOM, ACQUIRE_TARGET, acquireMicro);
+  // The acquisition swap spends the USDC the wallet holds, so probe that variant (USDC_NOBLE
+  // fallback for a fresh wallet); the dest is the acquired OSMO downpayment asset.
+  const sourceDenom = heldUsdcVariant(run.currencyResolver, await fetchBalances(run.ctx, run.primary.address));
+  const destDenom = bankDenomOf(run.currencyResolver, ACQUIRE_TARGET);
+  if (sourceDenom === undefined || destDenom === undefined) {
+    annotateSkipAndStop(testInfo, "environment", `swap-route denom unresolved (USDC or ${ACQUIRE_TARGET})`);
+  }
+  const route = await probeSwapRoute(
+    { ctx: run.ctx, queue: run.queue, chainId: run.chain.chainId },
+    { sourceDenom, destDenom, amountMicro: acquireMicro }
+  );
   if (route.status === "error") {
     annotateSkipAndStop(testInfo, "environment", `acquire route probe failed: ${route.reason}`);
   }

--- a/e2e/src/t3/flows/preconditions.test.ts
+++ b/e2e/src/t3/flows/preconditions.test.ts
@@ -1,12 +1,32 @@
 import { describe, expect, it } from "vitest";
 import {
   UNBONDING_ENTRY_CAP,
+  buildSwapRouteRequest,
   hasSwapRoute,
   pickUnbondingValidator,
   remainsAboveMin,
   resolveDownpaymentFloorUsd,
   unbondingEntryGate
 } from "./preconditions.js";
+
+describe("buildSwapRouteRequest", () => {
+  it("builds a forward POST body with both chain ids set to the Nolus chain", () => {
+    expect(
+      buildSwapRouteRequest({
+        sourceDenom: "unls",
+        destDenom: "ibc/ED07",
+        amountMicro: "45000000",
+        chainId: "pirin-1"
+      })
+    ).toEqual({
+      source_asset_denom: "unls",
+      source_asset_chain_id: "pirin-1",
+      dest_asset_denom: "ibc/ED07",
+      dest_asset_chain_id: "pirin-1",
+      amount_in: "45000000"
+    });
+  });
+});
 
 describe("unbondingEntryGate", () => {
   it("has room below the cap and none at or above it", () => {

--- a/e2e/src/t3/flows/preconditions.ts
+++ b/e2e/src/t3/flows/preconditions.ts
@@ -57,6 +57,36 @@ export function hasSwapRoute(payload: unknown): boolean {
   return BigInt(amountOut) > 0n;
 }
 
+/** The POST body of a `/api/swap/route` routability probe (backend `RouteRequest`). */
+export interface SwapRouteRequest {
+  source_asset_denom: string;
+  source_asset_chain_id: string;
+  dest_asset_denom: string;
+  dest_asset_chain_id: string;
+  amount_in: string;
+}
+
+/**
+ * Build the swap-route probe body. `/api/swap/route` is a POST endpoint (a GET 405s); the app's
+ * own `SkipRouter.getRoute` defaults both chain ids to the connected Nolus chain for a same-chain
+ * quote, so a routability probe mirrors that — both ids are the Nolus chain id, and the dust amount
+ * is the forward `amount_in`. Source and dest must be resolved bank denoms, never tickers.
+ */
+export function buildSwapRouteRequest(args: {
+  sourceDenom: string;
+  destDenom: string;
+  amountMicro: string;
+  chainId: string;
+}): SwapRouteRequest {
+  return {
+    source_asset_denom: args.sourceDenom,
+    source_asset_chain_id: args.chainId,
+    dest_asset_denom: args.destDenom,
+    dest_asset_chain_id: args.chainId,
+    amount_in: args.amountMicro
+  };
+}
+
 interface DownpaymentRange {
   currency: string;
   min: Decimal;

--- a/e2e/src/t3/flows/support.ts
+++ b/e2e/src/t3/flows/support.ts
@@ -45,6 +45,7 @@ const LEFTOVER_ANNOTATION = "t3-flow-leftover";
 export interface ChainSettings {
   rpcUrl: string;
   gasPrice: string;
+  chainId: string;
 }
 
 /**
@@ -97,7 +98,11 @@ async function resolveChain(ctx: OriginContext, matrixRpc: string | undefined): 
   if (gasPrice === "") {
     throw new Error(`Nolus gas_price from /api/config is unparseable: "${gasPriceRaw}"`);
   }
-  return { rpcUrl, gasPrice };
+  const chainId = readString(nolus, "chain_id");
+  if (chainId === undefined) {
+    throw new Error("could not resolve the Nolus chain_id from /api/config");
+  }
+  return { rpcUrl, gasPrice, chainId };
 }
 
 /**

--- a/e2e/src/t3/flows/swap.spec.ts
+++ b/e2e/src/t3/flows/swap.spec.ts
@@ -11,8 +11,8 @@ import {
 } from "./support.js";
 import { typeAmount, requireOrSkip, waitForFundedFromNls } from "../../t2/matrixHelpers.js";
 import { NATIVE_DENOM, NATIVE_DECIMALS, toMicroAmount } from "../../transfer.js";
-import { usdcMicro, probeSwapRoute } from "./apiReads.js";
-import { USDC_DENOM } from "./denoms.js";
+import { usdcMicro, probeSwapRoute, fetchBalances } from "./apiReads.js";
+import { heldUsdcVariant } from "./denomResolver.js";
 import { waitForAmountAccepted } from "./formDriver.js";
 
 // Quote -> execute a dust swap (#283 flow 6). The Skip WS topic is DEAD CODE — the app tracks
@@ -62,7 +62,16 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
   budget.route = "/assets/swap";
 
   const amountMicro = toMicroAmount(SWAP_NLS, NATIVE_DECIMALS);
-  const route = await probeSwapRoute(run.ctx, NATIVE_DENOM, USDC_DENOM, amountMicro);
+  // Probe (and swap) into the USDC variant the wallet actually holds so the routability answer
+  // matches the balance the post-swap assertion reads; USDC_NOBLE is the fresh-wallet fallback.
+  const destDenom = heldUsdcVariant(run.currencyResolver, await fetchBalances(run.ctx, wallet.address));
+  if (destDenom === undefined) {
+    annotateSkipAndStop(testInfo, "environment", "USDC bank denom unresolved from /api/currencies");
+  }
+  const route = await probeSwapRoute(
+    { ctx: run.ctx, queue: run.queue, chainId: run.chain.chainId },
+    { sourceDenom: NATIVE_DENOM, destDenom, amountMicro }
+  );
   if (route.status === "error") {
     annotateSkipAndStop(testInfo, "environment", `swap route probe failed: ${route.reason}`);
   }

--- a/e2e/src/t3/runtime.ts
+++ b/e2e/src/t3/runtime.ts
@@ -1,5 +1,5 @@
 import type { OriginContext } from "../t2/appDriver.js";
-import { getJson } from "../http.js";
+import { getJson, postJson as httpPostJson } from "../http.js";
 import { sanitizeRpc } from "../transfer.js";
 import type { SerialQueue } from "./serialQueue.js";
 import type { SweepDeps } from "./reconcile.js";
@@ -20,6 +20,18 @@ const SWAP_PATH = /\/api\/swap\//;
 export async function readJson(ctx: OriginContext, url: string): Promise<unknown> {
   try {
     return await getJson(url, ctx.dispatcher);
+  } catch (error) {
+    const raw = error instanceof Error ? error.message : String(error);
+    // eslint-disable-next-line preserve-caught-error -- cause intentionally dropped: it carries the raw RPC host; message re-thrown through sanitizeRpc
+    throw new Error(sanitizeRpc(raw, ctx.origin));
+  }
+}
+
+/** POST counterpart of {@link readJson}: a host-resolver-aware JSON write whose failures are
+ * stripped of the RPC/target host before they escape (e.g. a `/api/swap/route` routability probe). */
+export async function postJson(ctx: OriginContext, url: string, payload: unknown): Promise<unknown> {
+  try {
+    return await httpPostJson(url, payload, ctx.dispatcher);
   } catch (error) {
     const raw = error instanceof Error ? error.message : String(error);
     // eslint-disable-next-line preserve-caught-error -- cause intentionally dropped: it carries the raw RPC host; message re-thrown through sanitizeRpc


### PR DESCRIPTION
Two fixes the classified regression reports surfaced, plus their hardening:

- The swap routability probe requested GET against the POST /api/swap/route endpoint — every probe answered HTTP 405, silently producing false no-route skips and probe-error flakes in the funded runs. The probe now POSTs the real request body (both chain ids resolved from the live config) through the strict rate bucket, with sanitized errors. Its denoms are now real: the destination and the lease-acquire source resolve the wallet's actually-held USDC-family variant at runtime (static USDC_NOBLE fallback), and OSMO resolves to its bank denom — the placeholder values are gone, so the routability answer finally means something.
- The per-run report attributed t3-flows failures to the t1 tier. Tier attribution now maps every Playwright project to its true tier (with a source-file fallback, and the fixture project pinned explicitly), so tier totals and failure rows read correctly.

suite impact: T3 flows + reporting, covered by the new pure-helper unit tests (request builder, held-variant resolution, tier attribution) and the next funded regression run.

Verification: full e2e gate green on the rebased tree (391 tests over the floors, matrix guard); reviewed post-rebase with the integration of the amount-settle lane explicitly verified on every combined call site.