### PR TITLE
fix(e2e): verified combobox select, usdc-to-nls swap, no-route class

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -729,7 +729,6 @@ redelegate mutex), and claim on accrued rewards being **above a dust threshold**
 - **Animated figures — assert the aria-label, not innerText.** Rendered money figures count up via
   the app's AnimateNumber, whose `innerText` is the whole digit-roller ladder; the true formatted
   value lives ONLY in the element's `aria-label` (the T1 bridge technique). `renderFigure.ts`
-  (`findAnimatedFigure` / `findAnimatedFigureWithinTolerance` / `findPositiveAnimatedFigure`) reads
   the aria-label, and the pure normalization/compare is `figureText.ts` (unit-tested). The
   stake-delegated total, earn total, and lease detail size + USD all read the aria-label with the
   oracle as the expectation source.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -713,8 +713,11 @@ unit-tested against fixtures shaped like the real responses (hash `symbol`, obje
 Environment / precondition failures are skipped, not failed (`classifyAndRoute`); only `app`
 failures are reds. A swap-route probe distinguishes a genuine no-route (a precondition) from a
 probe **error** (API/network failure → an `environment` skip with its own reason), never silently
-reporting an error as no-route; and every lease-downpayment skip annotates `matrix-skip` with the
-plan reason. The taxonomy is extended with two precondition signals for these flows:
+reporting an error as no-route. Skip signals a routing failure as a non-2xx (a `502` has been
+observed) whose body carries a `SWAP_ROUTE_FAILED` code / "no routes found" message; the pure
+`isNoRouteFailure` (unit-tested) reclassifies that sanitized error text back to a no-route
+precondition rather than an environment flake. Every lease-downpayment skip annotates `matrix-skip`
+with the plan reason. The taxonomy is extended with two precondition signals for these flows:
 `lease-amount-range` (a downpayment below/above the lease range) and `swap-amount-too-small` (a
 dust amount with no Skip route, distinct from a genuine `liquidity` outage). Stake gates: undelegate
 is gated on the **7-entry unbonding cap** per validator (rotating the target when near it via
@@ -728,13 +731,19 @@ redelegate mutex), and claim on accrued rewards being **above a dust threshold**
   value lives ONLY in the element's `aria-label` (the T1 bridge technique). `renderFigure.ts`
   (`findAnimatedFigure` / `findAnimatedFigureWithinTolerance` / `findPositiveAnimatedFigure`) reads
   the aria-label, and the pure normalization/compare is `figureText.ts` (unit-tested). The
-  stake-delegated total, earn total, lease detail size + USD, and the swap From-side NLS balance all
-  read the aria-label with the oracle as the expectation source.
-- **Earn currency-variant selection.** SupplyForm/WithdrawForm list EVERY protocol LPN variant as a
-  currency option and default to one that may hold zero balance, so the amount would validate against
-  an empty variant. Before typing, the spec resolves the funded USDC variant (`heldUsdcTicker`) and
-  `selectCurrencyVariant` drives the AdvancedFormControl picker — a `Dropdown` atom (per web-components
-  source) whose `aria-expanded` trigger opens a teleported searchable AssetItem list — to select it.
+  stake-delegated total, earn total, and lease detail size + USD all read the aria-label with the
+  oracle as the expectation source.
+- **Currency-variant selection is picked AND verified.** SupplyForm/WithdrawForm/SwapForm list EVERY
+  protocol variant as a currency option and default to one that may hold zero balance, so an amount
+  would validate against an empty variant. `selectCurrencyVariant` drives the AdvancedFormControl
+  picker — per web-components source a `role=combobox` trigger (carrying the field id) that opens a
+  teleported searchable `role=listbox` of AssetItem rows filtered on `option.value`/`ibcData`. It
+  opens the combobox, filters the search to the funded variant, clicks the first filtered row, then
+  **verifies the pick landed**: the trigger must show the expected asset family and the balance beside
+  it must read positive. That positive-balance wait also rides out the balances-load timing gap — the
+  app recomputes amount validation only on input events, so typing before the balance loads sticks a
+  stale error. The pick+verify retries once, then FAILS LOUDLY: a selection that didn't take must
+  never let a spec type into the wrong (or zero) asset.
 - **Lease-config lazy-cache pre-warm.** The backend `get_lease_config` handler warms its per-protocol
   cache lazily and returns `503 Cache not yet populated` until the first request; after a deploy burst
   the flow suite's own reads are the first, and both of `leaseProtocolConfigs`' paced retries land in
@@ -768,6 +777,11 @@ redelegate mutex), and claim on accrued rewards being **above a dust threshold**
   genuine no-ranges state) it throws `lease-config-unavailable` — a first-class `environment` signal
   that skips-and-retries next run, rather than returning empty and reporting a permanent-looking
   "no eligible protocol".
+- **Swap direction is held USDC -> NLS.** The dust swap spends ~$1 of the funded USDC variant into
+  NLS, not NLS into USDC: USDC has real staging value, whereas a `unls` -> USDC dust is economically
+  null and Skip finds no route for it. The routability probe runs in the SAME direction as the
+  executed swap, the spend is charged against the **USDC cap** (journal action `swap`, `charged` in
+  USDC micro), and the post-swap assertion is that the NLS balance strictly increases.
 - **Swap tracking (`skip_tx` is dead code).** The `skip_tx` WS topic is not driven by the app —
   swaps are tracked by client polling (`SkipRouter.fetchStatus` in `useSwapForm.ts`). `swap.spec.ts`
   therefore asserts via the UI's polled terminal state and post-swap balances, not a WS event. This

--- a/e2e/src/t3/flows/apiReads.ts
+++ b/e2e/src/t3/flows/apiReads.ts
@@ -7,7 +7,8 @@ import { parseDownpaymentRanges } from "./preconditions.js";
 import type { ProtocolConfig } from "./leasePlan.js";
 import { heldMicro, priceUsdOf, microToUsd, tickersMatching } from "./denomResolver.js";
 import type { ResolvedAsset } from "./denomResolver.js";
-import { hasSwapRoute, buildSwapRouteRequest } from "./preconditions.js";
+import { hasSwapRoute, buildSwapRouteRequest, isNoRouteFailure } from "./preconditions.js";
+import { NATIVE_DENOM, NATIVE_DECIMALS } from "../../transfer.js";
 
 // Node-side, host-resolver-aware reads of the live API used by the flow specs to build the
 // oracle inputs and precondition probes. Coverage-excluded browser/network glue (see
@@ -90,9 +91,19 @@ export async function probeSwapRoute(deps: SwapProbeDeps, args: SwapProbeArgs): 
     await deps.queue.pace("strict");
     payload = await postJson(deps.ctx, `${deps.ctx.origin}/api/swap/route`, body);
   } catch (error) {
-    return { status: "error", reason: error instanceof Error ? error.message : String(error) };
+    const message = error instanceof Error ? error.message : String(error);
+    return isNoRouteFailure(message) ? { status: "no-route" } : { status: "error", reason: message };
   }
   return { status: hasSwapRoute(payload) ? "routable" : "no-route" };
+}
+
+/** The wallet's native NLS micro balance (the swap-into asset for the reversed dust swap). */
+export async function nativeMicro(ctx: OriginContext, address: string): Promise<bigint> {
+  return heldMicro(await fetchBalances(ctx, address), {
+    ticker: "NLS",
+    bankSymbols: [NATIVE_DENOM],
+    decimalDigits: NATIVE_DECIMALS
+  });
 }
 
 /** The first lease enumerated for `address` with `status === "opened"`, or undefined. */

--- a/e2e/src/t3/flows/earn.spec.ts
+++ b/e2e/src/t3/flows/earn.spec.ts
@@ -66,7 +66,12 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
   // select the funded USDC variant so the amount validates against a real balance, not a zero one.
   const heldUsdc = await heldUsdcTicker(run.ctx, wallet.address, run.currencyResolver);
   if (heldUsdc !== undefined) {
-    await selectCurrencyVariant(page, heldUsdc, TERMINAL_MS);
+    await selectCurrencyVariant(page, {
+      fieldId: "receive-send",
+      search: heldUsdc,
+      expectContains: "USDC",
+      timeoutMs: TERMINAL_MS
+    });
   }
   await typeAmount(page, "receive-send", DUST_USDC);
   await waitForAmountAccepted(page);
@@ -90,7 +95,12 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
   await connectFlow(page, run, "/earn/withdraw");
   // The withdraw options come from the LP positions; select the variant just supplied.
   if (heldUsdc !== undefined) {
-    await selectCurrencyVariant(page, heldUsdc, TERMINAL_MS);
+    await selectCurrencyVariant(page, {
+      fieldId: "receive-send",
+      search: heldUsdc,
+      expectContains: "USDC",
+      timeoutMs: TERMINAL_MS
+    });
   }
   await typeAmount(page, "receive-send", DUST_USDC);
   await waitForAmountAccepted(page);

--- a/e2e/src/t3/flows/formDriver.ts
+++ b/e2e/src/t3/flows/formDriver.ts
@@ -133,30 +133,70 @@ export async function clickLocatorAndSettle(
   await awaitTerminal(page, label, terminalMs);
 }
 
+export interface CurrencyVariantSelection {
+  /** The AdvancedFormControl `id` (e.g. "receive-send", "swap-1"), carried on both the amount
+   * `<input>` and the picker's `role=combobox` trigger. */
+  fieldId: string;
+  /** Search term filtering the option list — matched against the option `value` (the LPN key,
+   * e.g. "USDC_NOBLE@osmosis-noble") or `ibcData`, so a resolver ticker or bank denom both work. */
+  search: string;
+  /** A substring the trigger's label must contain once selected (the shortName family, e.g. "USDC"
+   * / "NLS") — proof the pick landed on the intended asset, not the zero-balance default. */
+  expectContains: string;
+  timeoutMs: number;
+}
+
+const CURRENCY_SEARCH_INPUT = "#input-search-input";
+const SELECT_BALANCE_WAIT_MS = 15000;
+
+/** The numeric balance the picker shows beside its trigger (customLabel "0.05 USDC"), 0 when none. */
+async function pickerBalance(balance: Locator): Promise<number> {
+  const text = await balance.innerText().catch(() => "");
+  const match = text.replace(/[\s,]/g, "").match(/-?\d+(\.\d+)?/);
+  return match === null ? 0 : Number(match[0]);
+}
+
 /**
  * Select a funded currency variant in an AdvancedFormControl currency picker before typing, so the
- * amount validates against a held balance instead of the zero-balance default option. Per the
- * web-components source the picker is a `Dropdown` atom: its trigger is a button carrying
- * `aria-expanded`, which opens a (Teleport-portaled) searchable list of AssetItem rows. So: click
- * the collapsed trigger, filter the search to the target variant, then click the matching row. Every
- * step's failure is swallowed so a form that already defaults to the right variant still proceeds.
+ * amount validates against a held balance, not the zero-balance default option. Per the
+ * web-components source the picker's trigger is a `role=combobox` button carrying the field id; it
+ * opens a Teleport-portaled searchable `role=listbox` of AssetItem rows filtered on `option.value`
+ * / `ibcData` / label. So: open the combobox, filter the search to the variant, click the first
+ * filtered row. The selection is then VERIFIED — the trigger must show the expected asset family and
+ * the balance beside it must read positive (which also rides out the balances-load timing gap, since
+ * the app only recomputes amount validation on input events). Retries the whole open→pick once, then
+ * FAILS LOUDLY: a pick that didn't take must never let a spec type into the wrong (or zero) asset.
  */
-export async function selectCurrencyVariant(page: Page, label: string, timeoutMs: number): Promise<void> {
-  await page
-    .getByRole("button", { expanded: false })
-    .first()
-    .click({ timeout: timeoutMs })
-    .catch(() => undefined);
-  await page
-    .getByRole("textbox")
-    .last()
-    .fill(label)
-    .catch(() => undefined);
-  await page
-    .getByText(label, { exact: false })
-    .last()
-    .click({ timeout: timeoutMs })
-    .catch(() => undefined);
+export async function selectCurrencyVariant(page: Page, selection: CurrencyVariantSelection): Promise<void> {
+  const { fieldId, search, expectContains, timeoutMs } = selection;
+  const combobox = page.locator(`button[role="combobox"]#${fieldId}`);
+  const balance = combobox
+    .locator('xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " flex-col ")][1]')
+    .locator("span.text-typography-link")
+    .first();
+  const searchInput = page.locator(CURRENCY_SEARCH_INPUT);
+  const listbox = page.getByRole("listbox");
+  const waitMs = Math.min(timeoutMs, SELECT_BALANCE_WAIT_MS);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    await combobox.click({ timeout: timeoutMs }).catch(() => undefined);
+    await searchInput.fill(search, { timeout: timeoutMs }).catch(() => undefined);
+    await listbox
+      .locator("li")
+      .first()
+      .click({ timeout: timeoutMs })
+      .catch(() => undefined);
+    try {
+      await expect(combobox).toContainText(new RegExp(expectContains, "i"), { timeout: waitMs });
+      await expect.poll(() => pickerBalance(balance), { timeout: waitMs }).toBeGreaterThan(0);
+      return;
+    } catch {
+      // Selection did not land (default still showing, or balance not yet positive) — re-pick once.
+    }
+  }
+  throw new Error(
+    `currency variant "${search}" not selected in "${fieldId}": the picker never showed ${expectContains} with a positive balance`
+  );
 }
 
 /** Open a position/lease detail dialog by its on-chain address and wait for the dialog to render. */

--- a/e2e/src/t3/flows/preconditions.test.ts
+++ b/e2e/src/t3/flows/preconditions.test.ts
@@ -3,6 +3,7 @@ import {
   UNBONDING_ENTRY_CAP,
   buildSwapRouteRequest,
   hasSwapRoute,
+  isNoRouteFailure,
   pickUnbondingValidator,
   remainsAboveMin,
   resolveDownpaymentFloorUsd,
@@ -67,6 +68,20 @@ describe("hasSwapRoute", () => {
     expect(hasSwapRoute({ amount_out: "0" })).toBe(false);
     expect(hasSwapRoute({ amount_out: "none" })).toBe(false);
     expect(hasSwapRoute(null)).toBe(false);
+  });
+});
+
+describe("isNoRouteFailure", () => {
+  it("classifies a Skip routing failure (code or message) as a no-route", () => {
+    expect(isNoRouteFailure('POST /api/swap/route returned HTTP 502: {"code":"SWAP_ROUTE_FAILED"}')).toBe(true);
+    expect(isNoRouteFailure("no routes found for the requested pair")).toBe(true);
+    expect(isNoRouteFailure("Error: no route available")).toBe(true);
+  });
+
+  it("leaves a genuine network/API error as an error", () => {
+    expect(isNoRouteFailure("POST /api/swap/route returned HTTP 500: internal error")).toBe(false);
+    expect(isNoRouteFailure("connect ECONNREFUSED")).toBe(false);
+    expect(isNoRouteFailure("returned a non-JSON body")).toBe(false);
   });
 });
 

--- a/e2e/src/t3/flows/preconditions.ts
+++ b/e2e/src/t3/flows/preconditions.ts
@@ -57,6 +57,17 @@ export function hasSwapRoute(payload: unknown): boolean {
   return BigInt(amountOut) > 0n;
 }
 
+// Skip returns a routing failure as a non-2xx (a 502 has been observed) whose body carries a
+// `SWAP_ROUTE_FAILED` code / "no routes found" message. That is semantically a NO-ROUTE (a
+// precondition to skip), not a network/API error — so the route probe must reclassify it rather
+// than report an environment flake. Matched defensively against the sanitized error text.
+const NO_ROUTE_MARKERS = [/SWAP_ROUTE_FAILED/i, /no\s+routes?\s+found/i, /no\s+route/i];
+
+/** Whether a failed route probe's (sanitized) error text signals a genuine no-route, not an API/network error. */
+export function isNoRouteFailure(message: string): boolean {
+  return NO_ROUTE_MARKERS.some((marker) => marker.test(message));
+}
+
 /** The POST body of a `/api/swap/route` routability probe (backend `RouteRequest`). */
 export interface SwapRouteRequest {
   source_asset_denom: string;

--- a/e2e/src/t3/flows/renderFigure.ts
+++ b/e2e/src/t3/flows/renderFigure.ts
@@ -69,12 +69,3 @@ export async function findAnimatedFigureWithinTolerance(
     (aria) => /^-?\d+(\.\d+)?$/.test(aria) && withinTolerance({ actual: aria, expected, tolerance }).ok
   );
 }
-
-/**
- * Whether some AnimateNumber figure within `scope` settles to a POSITIVE number — matched on its
- * `aria-label`, not the digit-roller `innerText`. Used to confirm a balance figure has loaded and
- * finished counting up (e.g. the swap From-side NLS balance) before typing against it.
- */
-export async function findPositiveAnimatedFigure(scope: Locator, timeoutMs: number = STABLE_TIMEOUT): Promise<boolean> {
-  return pollForFigure(scope, timeoutMs, (aria) => /^\d+(\.\d+)?$/.test(aria) && Number(aria) > 0);
-}

--- a/e2e/src/t3/flows/swap.spec.ts
+++ b/e2e/src/t3/flows/swap.spec.ts
@@ -10,19 +10,20 @@ import {
   annotateSkipAndStop
 } from "./support.js";
 import { typeAmount, requireOrSkip } from "../../t2/matrixHelpers.js";
-import { NATIVE_DENOM, NATIVE_DECIMALS, toMicroAmount } from "../../transfer.js";
-import { usdcMicro, probeSwapRoute, fetchBalances } from "./apiReads.js";
-import { heldUsdcVariant } from "./denomResolver.js";
-import { waitForAmountAccepted } from "./formDriver.js";
-import { findPositiveAnimatedFigure } from "./renderFigure.js";
+import { NATIVE_DENOM, toMicroAmount } from "../../transfer.js";
+import { USDC_DECIMALS } from "../../config.js";
+import { usdcMicro, probeSwapRoute, nativeMicro, heldUsdcTicker } from "./apiReads.js";
+import { bankDenomOf } from "./denomResolver.js";
+import { waitForAmountAccepted, selectCurrencyVariant } from "./formDriver.js";
 
 // Quote -> execute a dust swap (#283 flow 6). The Skip WS topic is DEAD CODE — the app tracks
 // swaps by client polling (SkipRouter.fetchStatus in useSwapForm.ts), so this asserts through the
-// UI's polled terminal state and post-swap balances, NOT a WS event. A dust amount routinely has
-// no route, which is a precondition skip (not a red): the route is pre-probed before executing.
-// No matrix cell. Deviation from #283's acceptance wording (WS-tracked) documented in the README.
+// UI's polled terminal state and post-swap balances, NOT a WS event. The direction is HELD USDC ->
+// NLS: USDC has real staging value, whereas a unls -> USDC dust has no route (economically null).
+// A no-route answer is a precondition skip (not a red): the route is pre-probed in the SAME
+// direction before executing. No matrix cell. Deviation from #283's WS-tracked wording is in the README.
 
-const SWAP_NLS = "0.01";
+const SWAP_USDC = "1";
 const TERMINAL_MS = 120000;
 
 let run: RunContext;
@@ -62,43 +63,63 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
   test.setTimeout(TERMINAL_MS * 2);
   budget.route = "/assets/swap";
 
-  const amountMicro = toMicroAmount(SWAP_NLS, NATIVE_DECIMALS);
-  // Probe (and swap) into the USDC variant the wallet actually holds so the routability answer
-  // matches the balance the post-swap assertion reads; USDC_NOBLE is the fresh-wallet fallback.
-  const destDenom = heldUsdcVariant(run.currencyResolver, await fetchBalances(run.ctx, wallet.address));
-  if (destDenom === undefined) {
+  const amountMicro = toMicroAmount(SWAP_USDC, USDC_DECIMALS);
+  // Spend the USDC variant the wallet actually holds -> NLS, so the routability probe, the cap
+  // charge, and the picked From asset all name the same real balance.
+  const usdcTicker = await heldUsdcTicker(run.ctx, wallet.address, run.currencyResolver);
+  if (usdcTicker === undefined) {
+    annotateSkipAndStop(testInfo, "precondition", "no funded USDC variant to swap from");
+  }
+  const sourceDenom = bankDenomOf(run.currencyResolver, usdcTicker);
+  if (sourceDenom === undefined) {
     annotateSkipAndStop(testInfo, "environment", "USDC bank denom unresolved from /api/currencies");
   }
+  const usdcHeld = await usdcMicro(run.ctx, wallet.address, run.currencyResolver);
+  requireOrSkip(
+    testInfo,
+    run.matrix.expectFunded,
+    usdcHeld > BigInt(amountMicro),
+    `primary holds ${usdcHeld.toString()} micro-USDC, below the ${amountMicro} a $${SWAP_USDC} swap needs`
+  );
+
   const route = await probeSwapRoute(
     { ctx: run.ctx, queue: run.queue, chainId: run.chain.chainId },
-    { sourceDenom: NATIVE_DENOM, destDenom, amountMicro }
+    { sourceDenom, destDenom: NATIVE_DENOM, amountMicro }
   );
   if (route.status === "error") {
     annotateSkipAndStop(testInfo, "environment", `swap route probe failed: ${route.reason}`);
   }
-  requireOrSkip(
-    testInfo,
-    run.matrix.expectFunded,
-    route.status === "routable",
-    "no Skip route for the dust swap amount"
-  );
+  if (route.status !== "routable") {
+    annotateSkipAndStop(testInfo, "precondition", `no Skip route for the $${SWAP_USDC} USDC->NLS swap`);
+  }
 
   await connectFlow(page, run, "/assets/swap");
   await page.locator("#swap-1").waitFor({ state: "visible", timeout: 15000 });
-  // The From-side NLS balance renders via AnimateNumber; wait for a positive value in its aria-label
-  // (not the digit-roller innerText) so typing validates against the funded balance, not a zero read.
-  expect(await findPositiveAnimatedFigure(page.locator("#dialog-scroll").first(), 20000)).toBe(true);
-  await typeAmount(page, "swap-1", SWAP_NLS);
+  // Set From = the held USDC variant, To = NLS; each pick is verified to have landed on a positive
+  // balance so typing validates against a real balance (not the default or an unloaded zero).
+  await selectCurrencyVariant(page, {
+    fieldId: "swap-1",
+    search: usdcTicker,
+    expectContains: "USDC",
+    timeoutMs: TERMINAL_MS
+  });
+  await selectCurrencyVariant(page, {
+    fieldId: "swap-2",
+    search: "NLS",
+    expectContains: "NLS",
+    timeoutMs: TERMINAL_MS
+  });
+  await typeAmount(page, "swap-1", SWAP_USDC);
   await waitForAmountAccepted(page);
 
-  const usdcBefore = await usdcMicro(run.ctx, wallet.address, run.currencyResolver);
+  const nlsBefore = await nativeMicro(run.ctx, wallet.address);
   await spendCommittedOrSkip(testInfo, run, {
     spec: "t3-flow-swap",
     action: "swap",
     walletRole: "primary",
     walletKey: run.primary.key,
-    items: [{ denom: "nls", micro: BigInt(amountMicro) }],
-    denoms: [{ denom: NATIVE_DENOM, micro: amountMicro }],
+    items: [{ denom: "usdc", micro: BigInt(amountMicro) }],
+    denoms: [{ denom: sourceDenom, micro: amountMicro }],
     execute: async () => {
       await run.queue.pace("strict");
       // The swap runs on the click (no confirmation dialog); track the app's polled terminal state.
@@ -116,12 +137,12 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
   });
 
   await expect
-    .poll(() => usdcMicro(run.ctx, wallet.address, run.currencyResolver), {
-      message: "the swapped-to USDC balance should strictly increase after a committed swap",
+    .poll(() => nativeMicro(run.ctx, wallet.address), {
+      message: "the swapped-to NLS balance should strictly increase after a committed swap",
       timeout: TERMINAL_MS,
       intervals: [3000, 5000, 5000, 5000]
     })
-    .toBeGreaterThan(usdcBefore);
+    .toBeGreaterThan(nlsBefore);
 
   reportLeftover(run, testInfo, { terminal: "success" });
 });


### PR DESCRIPTION
Two evidence-anchored fixes from the latest regression artifact (the Supply dialog snapshot showed the default BTC option still selected with a 0.00 balance — the picker helper targeted a button role while the trigger renders as a combobox, and its swallowed errors let the spec type into the wrong asset):

- The currency picker helper now targets the real combobox trigger by field id, drives the teleported search and listbox row, then VERIFIES the selection landed (expected asset family shown, adjacent balance polls positive — which also closes the balances-load timing gap) and throws loudly after one retry. Applied to earn supply/withdraw and both swap sides.
- The dust swap reverses direction to spend ~one dollar of the wallet's held USDC variant into NLS — the old NLS-to-USDC dust was economically null and the router correctly found no route for it. A backend error body carrying the router's no-routes signal now classifies as a no-route precondition skip rather than an environment flake; a bare outage still classifies as an error (unit-tested). The USDC cap is charged gross; the post-swap assertion requires the NLS balance to strictly increase.

An orphaned figure helper left by the reversal is deleted with its doc mention.

suite impact: T3 flows, covered by the no-route classifier unit tests and the next funded regression run.

Verification: full e2e gate green (400 tests over the floors, matrix guard); two review rounds — logic clean throughout, round-two items (orphan, doc sentence) applied.