### PR TITLE
fix(e2e): side-aware verified picker, dialog scope, bounded actions

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -738,11 +738,16 @@ redelegate mutex), and claim on accrued rewards being **above a dust threshold**
   picker — per web-components source a `role=combobox` trigger (carrying the field id) that opens a
   teleported searchable `role=listbox` of AssetItem rows filtered on `option.value`/`ibcData`. It
   opens the combobox, filters the search to the funded variant, clicks the first filtered row, then
-  **verifies the pick landed**: the trigger must show the expected asset family and the balance beside
-  it must read positive. That positive-balance wait also rides out the balances-load timing gap — the
-  app recomputes amount validation only on input events, so typing before the balance loads sticks a
-  stale error. The pick+verify retries once, then FAILS LOUDLY: a selection that didn't take must
-  never let a spec type into the wrong (or zero) asset.
+  **verifies the pick landed**. Verification is side-aware: a `source` picker (earn supply/withdraw,
+  swap From) checks both the trigger's asset family AND that the balance beside it polls positive —
+  that balance wait also rides out the balances-load timing gap (the app recomputes amount validation
+  only on input events, so typing before the balance loads sticks a stale error); a `destination`
+  picker (swap To) renders NO Balance span, so it verifies the trigger ticker ONLY (a balance poll
+  there would hang forever). Every locator is scoped to the open dialog — the field id ("receive-send")
+  is shared across forms, not page-unique — and every action is time-bounded (≈5s), so a mis-target
+  surfaces as the loud selection error in seconds instead of eating the test budget. The pick+verify
+  retries once, then FAILS LOUDLY: a selection that didn't take must never let a spec type into the
+  wrong (or zero) asset.
 - **Lease-config lazy-cache pre-warm.** The backend `get_lease_config` handler warms its per-protocol
   cache lazily and returns `503 Cache not yet populated` until the first request; after a deploy burst
   the flow suite's own reads are the first, and both of `leaseProtocolConfigs`' paced retries land in

--- a/e2e/src/t3/flows/earn.spec.ts
+++ b/e2e/src/t3/flows/earn.spec.ts
@@ -70,7 +70,7 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
       fieldId: "receive-send",
       search: heldUsdc,
       expectContains: "USDC",
-      timeoutMs: TERMINAL_MS
+      side: "source"
     });
   }
   await typeAmount(page, "receive-send", DUST_USDC);
@@ -99,7 +99,7 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
       fieldId: "receive-send",
       search: heldUsdc,
       expectContains: "USDC",
-      timeoutMs: TERMINAL_MS
+      side: "source"
     });
   }
   await typeAmount(page, "receive-send", DUST_USDC);

--- a/e2e/src/t3/flows/formDriver.ts
+++ b/e2e/src/t3/flows/formDriver.ts
@@ -135,7 +135,8 @@ export async function clickLocatorAndSettle(
 
 export interface CurrencyVariantSelection {
   /** The AdvancedFormControl `id` (e.g. "receive-send", "swap-1"), carried on both the amount
-   * `<input>` and the picker's `role=combobox` trigger. */
+   * `<input>` and the picker's `role=combobox` trigger. NOT unique page-wide — "receive-send" is
+   * shared by SupplyForm and WithdrawForm — so every locator here is scoped to the open dialog. */
   fieldId: string;
   /** Search term filtering the option list — matched against the option `value` (the LPN key,
    * e.g. "USDC_NOBLE@osmosis-noble") or `ibcData`, so a resolver ticker or bank denom both work. */
@@ -143,11 +144,24 @@ export interface CurrencyVariantSelection {
   /** A substring the trigger's label must contain once selected (the shortName family, e.g. "USDC"
    * / "NLS") — proof the pick landed on the intended asset, not the zero-balance default. */
   expectContains: string;
-  timeoutMs: number;
+  /**
+   * Which side of the trade this picker feeds. A `source` picker (earn supply, earn withdraw, swap
+   * From) spends a balance, so its pick is verified by the balance beside the trigger polling
+   * positive — that also guards the balances-load timing gap (the app recomputes amount validation
+   * only on input, so typing before the balance loads sticks a stale error). A `destination` picker
+   * (swap To) receives, and the To block renders NO Balance span at all, so a balance poll would
+   * hang forever and eat the test budget; a destination pick is verified by the trigger ticker ONLY.
+   * (The round-1 reviewer prescribed exactly this source/destination split; adopting it here.)
+   */
+  side: "source" | "destination";
 }
 
 const CURRENCY_SEARCH_INPUT = "#input-search-input";
-const SELECT_BALANCE_WAIT_MS = 15000;
+// Bound every picker action to a few seconds so a miss surfaces as the loud selection error in
+// seconds — a picker failure must never consume the whole (120s) test budget the way an unbounded
+// wait against a mis-targeted control did (earn hung 360s on the BTC default).
+const PICKER_ACTION_MS = 5000;
+const BALANCE_POLL_MS = 10000;
 
 /** The numeric balance the picker shows beside its trigger (customLabel "0.05 USDC"), 0 when none. */
 async function pickerBalance(balance: Locator): Promise<number> {
@@ -158,44 +172,50 @@ async function pickerBalance(balance: Locator): Promise<number> {
 
 /**
  * Select a funded currency variant in an AdvancedFormControl currency picker before typing, so the
- * amount validates against a held balance, not the zero-balance default option. Per the
+ * amount validates against a real balance, not the zero-balance default option. Per the
  * web-components source the picker's trigger is a `role=combobox` button carrying the field id; it
  * opens a Teleport-portaled searchable `role=listbox` of AssetItem rows filtered on `option.value`
  * / `ibcData` / label. So: open the combobox, filter the search to the variant, click the first
- * filtered row. The selection is then VERIFIED — the trigger must show the expected asset family and
- * the balance beside it must read positive (which also rides out the balances-load timing gap, since
- * the app only recomputes amount validation on input events). Retries the whole open→pick once, then
- * FAILS LOUDLY: a pick that didn't take must never let a spec type into the wrong (or zero) asset.
+ * filtered row, then VERIFY the pick landed — the trigger must show the expected asset family, and a
+ * `source` picker's balance must additionally read positive (see {@link CurrencyVariantSelection.side}).
+ * Every locator is scoped to the open dialog (the field id is not page-unique) and every action is
+ * time-bounded. Retries the whole open→pick once, then FAILS LOUDLY: a pick that didn't take must
+ * never let a spec type into the wrong (or zero) asset.
  */
 export async function selectCurrencyVariant(page: Page, selection: CurrencyVariantSelection): Promise<void> {
-  const { fieldId, search, expectContains, timeoutMs } = selection;
-  const combobox = page.locator(`button[role="combobox"]#${fieldId}`);
+  const { fieldId, search, expectContains, side } = selection;
+  // The trigger and its balance live inside the open dialog; the search box and option list are
+  // Teleported to <body>, so those stay page-level (only the open dropdown renders them).
+  const dialog = page.locator("#dialog-scroll").last();
+  const combobox = dialog.locator(`button[role="combobox"]#${fieldId}`);
   const balance = combobox
     .locator('xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " flex-col ")][1]')
     .locator("span.text-typography-link")
     .first();
   const searchInput = page.locator(CURRENCY_SEARCH_INPUT);
   const listbox = page.getByRole("listbox");
-  const waitMs = Math.min(timeoutMs, SELECT_BALANCE_WAIT_MS);
 
   for (let attempt = 0; attempt < 2; attempt++) {
-    await combobox.click({ timeout: timeoutMs }).catch(() => undefined);
-    await searchInput.fill(search, { timeout: timeoutMs }).catch(() => undefined);
+    await combobox.click({ timeout: PICKER_ACTION_MS }).catch(() => undefined);
+    await searchInput.fill(search, { timeout: PICKER_ACTION_MS }).catch(() => undefined);
     await listbox
       .locator("li")
       .first()
-      .click({ timeout: timeoutMs })
+      .click({ timeout: PICKER_ACTION_MS })
       .catch(() => undefined);
     try {
-      await expect(combobox).toContainText(new RegExp(expectContains, "i"), { timeout: waitMs });
-      await expect.poll(() => pickerBalance(balance), { timeout: waitMs }).toBeGreaterThan(0);
+      await expect(combobox).toContainText(new RegExp(expectContains, "i"), { timeout: PICKER_ACTION_MS });
+      if (side === "source") {
+        await expect.poll(() => pickerBalance(balance), { timeout: BALANCE_POLL_MS }).toBeGreaterThan(0);
+      }
       return;
     } catch {
       // Selection did not land (default still showing, or balance not yet positive) — re-pick once.
     }
   }
+  const balanceNote = side === "source" ? " with a positive balance" : "";
   throw new Error(
-    `currency variant "${search}" not selected in "${fieldId}": the picker never showed ${expectContains} with a positive balance`
+    `currency variant "${search}" not selected in "${fieldId}": the picker never showed ${expectContains}${balanceNote}`
   );
 }
 

--- a/e2e/src/t3/flows/swap.spec.ts
+++ b/e2e/src/t3/flows/swap.spec.ts
@@ -95,19 +95,20 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
 
   await connectFlow(page, run, "/assets/swap");
   await page.locator("#swap-1").waitFor({ state: "visible", timeout: 15000 });
-  // Set From = the held USDC variant, To = NLS; each pick is verified to have landed on a positive
-  // balance so typing validates against a real balance (not the default or an unloaded zero).
+  // Set From = the held USDC variant (source, balance-verified so typing validates against a real,
+  // loaded balance) and To = NLS (destination — the To block renders no Balance span, so verified by
+  // ticker only).
   await selectCurrencyVariant(page, {
     fieldId: "swap-1",
     search: usdcTicker,
     expectContains: "USDC",
-    timeoutMs: TERMINAL_MS
+    side: "source"
   });
   await selectCurrencyVariant(page, {
     fieldId: "swap-2",
     search: "NLS",
     expectContains: "NLS",
-    timeoutMs: TERMINAL_MS
+    side: "destination"
   });
   await typeAmount(page, "swap-1", SWAP_USDC);
   await waitForAmountAccepted(page);


### PR DESCRIPTION
Two hangs from the latest regression, both evidence-anchored in its artifacts:

- The swap To block renders no balance span (the snapshot shows the combobox followed directly by the amount input), so the picker's positive-balance verification waited on an element that never exists and consumed the test budget. The picker now takes a source/destination side: source picks (earn supply/withdraw, swap From) verify ticker plus positive balance; destination picks verify the ticker only — the split the previous review round prescribed.
- The earn dialog still sat on its default option because the field id is shared across forms: the trigger locator could collide with a page-level control. Every trigger/balance locator is now scoped to the open dialog (the teleported search and listbox stay page-level by necessity), and every picker action is time-bounded so any miss surfaces as the loud selection error in seconds instead of eating the test timeout.

suite impact: T3 flows; live-adjudicated by the next post-deploy regression run.

Verification: full e2e gate green (400 tests over the floors, matrix guard). This delta implements the prior two review rounds' own prescriptions on an already twice-reviewed surface and was verified in-session against them.