### PR TITLE
fix(e2e): dialog-unmount swap terminal, route gate, disabled-row skip

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -789,10 +789,25 @@ redelegate mutex), and claim on accrued rewards being **above a dust threshold**
   null and Skip finds no route for it. The routability probe runs in the SAME direction as the
   executed swap, the spend is charged against the **USDC cap** (journal action `swap`, `charged` in
   USDC micro), and the post-swap assertion is that the NLS balance strictly increases.
-- **Swap tracking (`skip_tx` is dead code).** The `skip_tx` WS topic is not driven by the app —
-  swaps are tracked by client polling (`SkipRouter.fetchStatus` in `useSwapForm.ts`). `swap.spec.ts`
-  therefore asserts via the UI's polled terminal state and post-swap balances, not a WS event. This
-  is a deliberate deviation from `#283`'s WS-tracked acceptance wording.
+- **Swap tracking (`skip_tx` is dead code) and its real terminal states.** The `skip_tx` WS topic is
+  not driven by the app — swaps are tracked by client polling (`SkipRouter.fetchStatus` in
+  `useSwapForm.ts`). `swap.spec.ts` therefore asserts via the UI's terminal state and post-swap
+  balances, not a WS event (a deliberate deviation from `#283`'s WS-tracked wording). The terminal
+  states are read from `onSwap`, not guessed: SUCCESS calls `onClose()` and the swap dialog UNMOUNTS
+  (there is NO "done/success" text — the earlier text poll could never match, so a swap that actually
+  broadcast timed out), so success = the dialog's `#swap-1` is gone; FAILURE sets `error.value`, so
+  the inline error surface renders while the dialog stays open. Still pending at the (widened, ~3-min)
+  execution window with no commit throws `terminal-signal-timeout` (environment) carrying the observed
+  last state — the reconciliation sweep + balances read catch an untracked commit next run. `onSwap`
+  also early-returns unless the route quote (`route`) is set, so before the submit click the spec
+  waits for the To amount (`#swap-2`, the quote's `amount_out`) to populate; a quote that never
+  settles despite a routable pre-probe is an `environment` skip, not a red.
+- **Disabled currency rows are a precondition skip.** A currency the target protocol won't accept
+  renders its picker row disabled (the AssetItem `<li>` gets a `disabled` class, its clickable parent
+  `pointer-events-none` — confirmed live). `selectCurrencyVariant` returns `"row-disabled"` when the
+  filtered family row exists but is disabled, and the earn/swap specs precondition-skip ("held USDC
+  variant is not suppliable/swappable on the target protocol") — an honest app/staging gap, never a
+  red. An ENABLED row proceeds through the live-proven pick+verify.
 - **Engine journal actions.** `journal.ts`'s `IntentAction` gains `earn-supply`, `earn-withdraw`,
   `stake-claim`, `ibc-transfer`, and `lease-repay` — the value-moving actions these flows introduce
   that the `#284` engine did not yet represent. Additive only; no existing behaviour changes.

--- a/e2e/src/t3/flows/earn.spec.ts
+++ b/e2e/src/t3/flows/earn.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from "./support.js";
 import type { RunContext } from "./support.js";
-import { getRunContext, connectFlow, reportLeftover, skipIfHalted, spendCommittedOrSkip } from "./support.js";
+import {
+  getRunContext,
+  connectFlow,
+  reportLeftover,
+  skipIfHalted,
+  spendCommittedOrSkip,
+  annotateSkipAndStop
+} from "./support.js";
 import { messageValue } from "../../t2/appDriver.js";
 import { typeAmount, requireOrSkip, readString } from "../../t2/matrixHelpers.js";
 import { USDC_DECIMALS } from "../../config.js";
@@ -66,12 +73,15 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
   // select the funded USDC variant so the amount validates against a real balance, not a zero one.
   const heldUsdc = await heldUsdcTicker(run.ctx, wallet.address, run.currencyResolver);
   if (heldUsdc !== undefined) {
-    await selectCurrencyVariant(page, {
+    const picked = await selectCurrencyVariant(page, {
       fieldId: "receive-send",
       search: heldUsdc,
       expectContains: "USDC",
       side: "source"
     });
+    if (picked === "row-disabled") {
+      annotateSkipAndStop(testInfo, "precondition", "held USDC variant is not suppliable on the target protocol");
+    }
   }
   await typeAmount(page, "receive-send", DUST_USDC);
   await waitForAmountAccepted(page);
@@ -95,12 +105,15 @@ test("earn supply then withdraw of dust USDC, rendered total matches the oracle"
   await connectFlow(page, run, "/earn/withdraw");
   // The withdraw options come from the LP positions; select the variant just supplied.
   if (heldUsdc !== undefined) {
-    await selectCurrencyVariant(page, {
+    const picked = await selectCurrencyVariant(page, {
       fieldId: "receive-send",
       search: heldUsdc,
       expectContains: "USDC",
       side: "source"
     });
+    if (picked === "row-disabled") {
+      annotateSkipAndStop(testInfo, "precondition", "supplied USDC variant is not withdrawable on the target protocol");
+    }
   }
   await typeAmount(page, "receive-send", DUST_USDC);
   await waitForAmountAccepted(page);

--- a/e2e/src/t3/flows/formDriver.ts
+++ b/e2e/src/t3/flows/formDriver.ts
@@ -172,6 +172,30 @@ async function pickerBalance(balance: Locator): Promise<number> {
 }
 
 /**
+ * Whether the filtered target row EXISTS but is disabled. Per the AssetItem source (and confirmed
+ * live) a disabled option renders the inner `<li>` with a `disabled` class and its clickable parent
+ * with `pointer-events-none`; the app disables a currency the target protocol won't accept (e.g. a
+ * USDC variant not suppliable on that protocol), so the row is present but can never be picked.
+ * Absent (search matched nothing) is NOT disabled — that path falls through to the loud not-selected error.
+ */
+async function rowExistsButDisabled(row: Locator): Promise<boolean> {
+  await row.waitFor({ state: "attached", timeout: PICKER_ACTION_MS }).catch(() => undefined);
+  if ((await row.count()) === 0) {
+    return false;
+  }
+  const liClass = (await row.getAttribute("class").catch(() => "")) ?? "";
+  const parentClass =
+    (await row
+      .locator("xpath=..")
+      .getAttribute("class")
+      .catch(() => "")) ?? "";
+  return /\bdisabled\b/.test(liClass) || /pointer-events-none/.test(parentClass);
+}
+
+/** Outcome of a variant pick: it landed, or the target row exists but the protocol disabled it. */
+export type VariantSelectResult = "selected" | "row-disabled";
+
+/**
  * Select a funded currency variant in an AdvancedFormControl currency picker before typing, so the
  * amount validates against a real balance, not the zero-balance default option. Selectors were
  * verified LIVE against staging (app-dev), not just read from source:
@@ -186,10 +210,15 @@ async function pickerBalance(balance: Locator): Promise<number> {
  *    rows, never a blind first row.
  * After the pick it VERIFIES: the trigger must show the expected family, and a `source` picker's
  * balance must additionally read positive (see {@link CurrencyVariantSelection.side}). Every action
- * is time-bounded. Retries the whole open→pick once, then FAILS LOUDLY: a pick that didn't take must
- * never let a spec type into the wrong (or zero) asset.
+ * is time-bounded. Returns `"row-disabled"` when the target row exists but the protocol disabled it
+ * (the caller precondition-skips — an honest app/staging gap, never a red). Otherwise retries the
+ * whole open→pick once, then FAILS LOUDLY: a pick that didn't take must never let a spec type into
+ * the wrong (or zero) asset.
  */
-export async function selectCurrencyVariant(page: Page, selection: CurrencyVariantSelection): Promise<void> {
+export async function selectCurrencyVariant(
+  page: Page,
+  selection: CurrencyVariantSelection
+): Promise<VariantSelectResult> {
   const { fieldId, search, expectContains, side } = selection;
   const scope = (await page.locator("#dialog-scroll").count()) > 0 ? page.locator("#dialog-scroll").last() : page;
   const combobox = scope.locator(`button[role="combobox"]#dropdown-btn-${fieldId}`);
@@ -212,13 +241,16 @@ export async function selectCurrencyVariant(page: Page, selection: CurrencyVaria
     // Clear then fill so a retry never types onto a stale term.
     await searchInput.fill("", { timeout: PICKER_ACTION_MS }).catch(() => undefined);
     await searchInput.fill(search, { timeout: PICKER_ACTION_MS }).catch(() => undefined);
+    if (attempt === 0 && (await rowExistsButDisabled(row))) {
+      return "row-disabled";
+    }
     await row.click({ timeout: PICKER_ACTION_MS }).catch(() => undefined);
     try {
       await expect(combobox).toContainText(new RegExp(expectContains, "i"), { timeout: PICKER_ACTION_MS });
       if (side === "source") {
         await expect.poll(() => pickerBalance(balance), { timeout: BALANCE_POLL_MS }).toBeGreaterThan(0);
       }
-      return;
+      return "selected";
     } catch {
       // Selection did not land (default still showing, or balance not yet positive) — re-pick once.
     }

--- a/e2e/src/t3/flows/swap.spec.ts
+++ b/e2e/src/t3/flows/swap.spec.ts
@@ -18,33 +18,54 @@ import { waitForAmountAccepted, selectCurrencyVariant } from "./formDriver.js";
 
 // Quote -> execute a dust swap (#283 flow 6). The Skip WS topic is DEAD CODE — the app tracks
 // swaps by client polling (SkipRouter.fetchStatus in useSwapForm.ts), so this asserts through the
-// UI's polled terminal state and post-swap balances, NOT a WS event. The direction is HELD USDC ->
-// NLS: USDC has real staging value, whereas a unls -> USDC dust has no route (economically null).
-// A no-route answer is a precondition skip (not a red): the route is pre-probed in the SAME
-// direction before executing. No matrix cell. Deviation from #283's WS-tracked wording is in the README.
+// UI's terminal state and post-swap balances, NOT a WS event. The direction is HELD USDC -> NLS:
+// USDC has real staging value, whereas a unls -> USDC dust has no route (economically null). A
+// no-route answer is a precondition skip (not a red): the route is pre-probed in the SAME direction
+// before executing. No matrix cell. Deviation from #283's WS-tracked wording is in the README.
+//
+// Terminal states, read from useSwapForm.ts's `onSwap`: SUCCESS calls `onClose()` and the swap
+// dialog UNMOUNTS (there is NO "done/success" text to poll — the old text poll could never match,
+// which is why runs timed out on a swap that actually broadcast); FAILURE sets `error.value`, so the
+// inline error surface renders while the dialog stays open. `onSwap` also early-returns unless the
+// route quote (`route`) is set, so the To amount must populate before the submit click.
 
 const SWAP_USDC = "1";
 const TERMINAL_MS = 120000;
+// A routed Skip swap (track + fetchStatus) can take a couple of minutes; give the execution its own
+// window, wider than the UI-signal timeout used elsewhere.
+const SWAP_EXEC_MS = 180000;
+const CLICK_MS = 15000;
+const QUOTE_SETTLE_MS = 60000;
+const SWAP_ERROR = "div.text-typography-error";
 
 let run: RunContext;
 
 type SwapTerminal = "success" | "failure" | "pending";
 
-async function swapDialogText(page: Page): Promise<string> {
-  return page
-    .locator("#dialog-scroll")
-    .first()
-    .innerText()
-    .catch(() => "");
+/** The inline error surface text (trimmed), or "" when no error is shown. */
+async function swapErrorText(page: Page): Promise<string> {
+  const error = page.locator(SWAP_ERROR).first();
+  if (!(await error.isVisible().catch(() => false))) {
+    return "";
+  }
+  return (await error.innerText().catch(() => "")).trim();
 }
 
-/** The app's polled swap state — success and failure are both terminal, only failure must not pass. */
+/**
+ * The real swap terminal state. SUCCESS = the dialog closed (`onClose` unmounts the swap form, so
+ * its From input `#swap-1` is gone); FAILURE = the inline error surface is showing; otherwise the
+ * broadcast/track is still in flight (PENDING).
+ */
 async function swapTerminal(page: Page): Promise<SwapTerminal> {
-  const text = (await swapDialogText(page)).toLowerCase();
-  if (/failed|error|rejected/.test(text)) {
+  if ((await swapErrorText(page)).length > 0) {
     return "failure";
   }
-  if (/done|success|completed/.test(text)) {
+  if (
+    !(await page
+      .locator("#swap-1")
+      .isVisible()
+      .catch(() => false))
+  ) {
     return "success";
   }
   return "pending";
@@ -60,7 +81,7 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
   wallet
 }, testInfo) => {
   skipIfHalted(testInfo, run);
-  test.setTimeout(TERMINAL_MS * 2);
+  test.setTimeout(SWAP_EXEC_MS + TERMINAL_MS * 2);
   budget.route = "/assets/swap";
 
   const amountMicro = toMicroAmount(SWAP_USDC, USDC_DECIMALS);
@@ -98,20 +119,45 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
   // Set From = the held USDC variant (source, balance-verified so typing validates against a real,
   // loaded balance) and To = NLS (destination — the To block renders no Balance span, so verified by
   // ticker only).
-  await selectCurrencyVariant(page, {
+  const fromPick = await selectCurrencyVariant(page, {
     fieldId: "swap-1",
     search: usdcTicker,
     expectContains: "USDC",
     side: "source"
   });
-  await selectCurrencyVariant(page, {
+  if (fromPick === "row-disabled") {
+    annotateSkipAndStop(testInfo, "precondition", "held USDC variant is not swappable on the target protocol");
+  }
+  const toPick = await selectCurrencyVariant(page, {
     fieldId: "swap-2",
     search: "NLS",
     expectContains: "NLS",
     side: "destination"
   });
+  if (toPick === "row-disabled") {
+    annotateSkipAndStop(testInfo, "precondition", "NLS is not a swap destination on the target protocol");
+  }
   await typeAmount(page, "swap-1", SWAP_USDC);
   await waitForAmountAccepted(page);
+  // `onSwap` early-returns unless the route quote is set, so wait for it to settle before submitting:
+  // the To amount (#swap-2) populates from the quote's amount_out. Its staying empty is an
+  // environment condition (no quote despite a routable pre-probe), not an app red.
+  try {
+    await expect
+      .poll(
+        async () => {
+          const value = await page
+            .locator("#swap-2")
+            .inputValue()
+            .catch(() => "");
+          return Number(value.replace(/[\s,]/g, "")) || 0;
+        },
+        { message: "the swap route quote should settle (To amount populated)", timeout: QUOTE_SETTLE_MS }
+      )
+      .toBeGreaterThan(0);
+  } catch {
+    annotateSkipAndStop(testInfo, "environment", "swap route quote did not settle (To amount stayed empty)");
+  }
 
   const nlsBefore = await nativeMicro(run.ctx, wallet.address);
   await spendCommittedOrSkip(testInfo, run, {
@@ -123,16 +169,30 @@ test("a dust swap executes and reaches a polled terminal state with settled bala
     denoms: [{ denom: sourceDenom, micro: amountMicro }],
     execute: async () => {
       await run.queue.pace("strict");
-      // The swap runs on the click (no confirmation dialog); track the app's polled terminal state.
-      await page.getByRole("button", { name: /swap/i }).last().click({ timeout: TERMINAL_MS });
-      await expect
-        .poll(() => swapTerminal(page), {
-          message: "swap should reach a polled terminal state",
-          timeout: TERMINAL_MS
-        })
-        .not.toBe("pending");
+      // No confirmation dialog: the swap runs on the click. Poll the REAL terminal states — success
+      // closes the dialog, failure renders the inline error surface.
+      await page.getByRole("button", { name: /swap/i }).last().click({ timeout: CLICK_MS });
+      let lastState: SwapTerminal = "pending";
+      try {
+        await expect
+          .poll(
+            async () => {
+              lastState = await swapTerminal(page);
+              return lastState;
+            },
+            { message: "swap should reach a terminal state (dialog closes on success)", timeout: SWAP_EXEC_MS }
+          )
+          .not.toBe("pending");
+      } catch {
+        // Still pending at the window end and no commit — a broadcast may be mid-flight. Route this
+        // to `environment` (terminal-signal-timeout) with the observed last state, never a red; the
+        // reconciliation sweep + balances read catch an untracked commit next run.
+        throw new Error(
+          `terminal-signal-timeout: swap still pending after ${SWAP_EXEC_MS}ms (last state: ${lastState})`
+        );
+      }
       if ((await swapTerminal(page)) === "failure") {
-        throw new Error(`swap reached a failed terminal state: ${(await swapDialogText(page)).slice(0, 200)}`);
+        throw new Error(`swap reached a failed terminal state: ${(await swapErrorText(page)).slice(0, 200)}`);
       }
     }
   });


### PR DESCRIPTION
Three fixes aligned to the app's real behavior (read from source; the swap lifecycle cannot be exercised without funds, so the funded run adjudicates):

- The swap flow's success path closes the dialog — no success text is ever rendered, which is why every prior terminal poll timed out even when the transaction broadcast. The terminal contract now treats the dialog unmounting as success, the inline error surface as classified failure, and a still-pending state at a realistic 180-second window as an environment signal carrying the last observed state (the reconciliation sweep owns any untracked commit).
- The swap submit is gated on the route quote settling (the To side must read positive — the submit handler early-returns without a route, so an ungated click was a silent no-op); a quote that never settles despite a routable probe skips as environment.
- A currency-picker family row that exists but is protocol-disabled now returns a distinct result and the earn legs skip with an honest reason (held variant not suppliable) instead of failing red — matching the disabled styling observed in the live zero-fund session.

suite impact: T3 flows; source-derived contracts, adjudicated by the next post-deploy regression run.

Verification: full e2e gate green (400 tests over the floors, matrix guard); picker mechanics live-proven in the prior lane, lifecycle contracts traced to the submit handler source.