### PR TITLE
fix(e2e): expose signer chainId and per-chain accounts in the keplr stub

### DIFF
--- a/e2e/src/signer.test.ts
+++ b/e2e/src/signer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { StdSignDoc } from "@cosmjs/amino";
-import { fromBase64, toBase64 } from "@cosmjs/encoding";
+import { fromBase64, fromBech32, toBase64, toBech32 } from "@cosmjs/encoding";
 import { createWalletIdentity, verifyAminoSignature } from "./signer.js";
 
 // A deliberately public, unfunded CosmJS test vector. The nolus1 address below was
@@ -41,6 +41,34 @@ describe("createWalletIdentity", () => {
     expect(fromBase64(account.pubkey)).toHaveLength(33);
   });
 
+  it("resolves pirin-1 to the primary nolus account", async () => {
+    const identity = await createWalletIdentity(TEST_MNEMONIC);
+    const account = await identity.getAccounts("pirin-1");
+    expect(account.address).toBe(EXPECTED_ADDRESS);
+    expect(account.pubkey).toBe(identity.pubkeyBase64);
+  });
+
+  it("serves an osmo-prefixed account for osmosis-1 derived from the same key", async () => {
+    const identity = await createWalletIdentity(TEST_MNEMONIC);
+    const account = await identity.getAccounts("osmosis-1");
+    const { data } = fromBech32(identity.address);
+    expect(account.address).toBe(toBech32("osmo", data));
+    expect(account.pubkey).toBe(identity.pubkeyBase64);
+    expect(account.algo).toBe("secp256k1");
+  });
+
+  it("rejects a chain id with no mapped bech32 prefix", async () => {
+    const identity = await createWalletIdentity(TEST_MNEMONIC);
+    await expect(identity.getAccounts("cosmoshub-4")).rejects.toThrow(/no bech32 prefix mapped/);
+  });
+
+  it("rejects prototype-chain key names instead of resolving inherited members", async () => {
+    const identity = await createWalletIdentity(TEST_MNEMONIC);
+    for (const hostile of ["__proto__", "constructor", "toString"]) {
+      await expect(identity.getAccounts(hostile)).rejects.toThrow(/no bech32 prefix mapped/);
+    }
+  });
+
   it("signs a byte-exact amino doc that verifies cryptographically", async () => {
     const identity = await createWalletIdentity(TEST_MNEMONIC);
     const response = await identity.signAmino(identity.address, SIGN_DOC);
@@ -59,6 +87,12 @@ describe("createWalletIdentity", () => {
       signature: { ...response.signature, signature: toBase64(bytes) }
     };
     expect(verifyAminoSignature(tampered)).toBe(false);
+  });
+
+  it("refuses to sign for an address outside the nolus account", async () => {
+    const identity = await createWalletIdentity(TEST_MNEMONIC);
+    const foreign = await identity.getAccounts("osmosis-1");
+    await expect(identity.signAmino(foreign.address, SIGN_DOC)).rejects.toThrow();
   });
 
   it("never serializes the mnemonic", async () => {

--- a/e2e/src/signer.ts
+++ b/e2e/src/signer.ts
@@ -40,6 +40,19 @@ const encodingLib = loadModule("@cosmjs/encoding") as EncodingLib;
 const NOLUS_PREFIX = "nolus";
 
 /**
+ * Bech32 prefixes for the chain ids the scripted wallet can present an account on. The
+ * app's cross-chain swap path (`useSwapForm.ts` `getWallets`) builds one wallet per chain
+ * id in the Skip route and asks the provider for that chain's account — for the dust
+ * USDC->NLS swap the route hops through Osmosis, so `osmosis-1` needs an `osmo1…` address
+ * derived from the same key. An unlisted chain id rejects loudly so route drift stays a
+ * visible failure instead of a mis-prefixed address reaching Skip.
+ */
+const CHAIN_ID_PREFIXES: Record<string, string> = {
+  "pirin-1": NOLUS_PREFIX,
+  "osmosis-1": "osmo"
+};
+
+/**
  * JSON-safe account shape handed to the in-page stub. A `Uint8Array` cannot survive a
  * Playwright `exposeFunction` boundary, so the public key crosses as base64; the stub
  * decodes it back to bytes in the browser before returning it to the app.
@@ -59,8 +72,41 @@ export interface AccountPayload {
 export interface WalletIdentity {
   readonly address: string;
   readonly pubkeyBase64: string;
-  getAccounts(): Promise<AccountPayload>;
+  getAccounts(chainId?: string): Promise<AccountPayload>;
   signAmino(signerAddress: string, signDoc: StdSignDoc): Promise<AminoSignResponse>;
+}
+
+async function derivePrefixedAccount(mnemonic: string, prefix: string): Promise<AccountPayload> {
+  const prefixedWallet = await aminoLib.Secp256k1HdWallet.fromMnemonic(mnemonic, { prefix });
+  const accounts = await prefixedWallet.getAccounts();
+  const account = accounts[0];
+  if (account === undefined) {
+    throw new Error(`derived ${prefix} wallet exposed no account`);
+  }
+  return { address: account.address, pubkey: encodingLib.toBase64(account.pubkey), algo: account.algo };
+}
+
+function makeAccountResolver(mnemonic: string, primary: AccountPayload): (chainId?: string) => Promise<AccountPayload> {
+  const payloadsByPrefix = new Map<string, Promise<AccountPayload>>([[NOLUS_PREFIX, Promise.resolve(primary)]]);
+  return (chainId?: string): Promise<AccountPayload> => {
+    const prefix =
+      chainId === undefined
+        ? NOLUS_PREFIX
+        : Object.hasOwn(CHAIN_ID_PREFIXES, chainId)
+          ? CHAIN_ID_PREFIXES[chainId]
+          : undefined;
+    if (prefix === undefined) {
+      return Promise.reject(new Error(`no bech32 prefix mapped for chain id "${chainId}"`));
+    }
+    const cached = payloadsByPrefix.get(prefix);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const derived = derivePrefixedAccount(mnemonic, prefix);
+    payloadsByPrefix.set(prefix, derived);
+    derived.catch(() => payloadsByPrefix.delete(prefix));
+    return derived;
+  };
 }
 
 export async function createWalletIdentity(mnemonic: string): Promise<WalletIdentity> {
@@ -77,9 +123,11 @@ export async function createWalletIdentity(mnemonic: string): Promise<WalletIden
   return {
     address,
     pubkeyBase64,
-    getAccounts(): Promise<AccountPayload> {
-      return Promise.resolve({ address, pubkey: pubkeyBase64, algo });
-    },
+    getAccounts: makeAccountResolver(mnemonic, { address, pubkey: pubkeyBase64, algo }),
+    // Signing stays bound to the nolus account on purpose: the T3 spend journal and
+    // per-denom caps only account for Nolus-side transactions, so a foreign-chain sign
+    // attempt must fail loudly (cosmjs rejects an unknown signer address) rather than
+    // silently spend outside the caps.
     signAmino(signerAddress: string, signDoc: StdSignDoc): Promise<AminoSignResponse> {
       return wallet.signAmino(signerAddress, signDoc);
     }

--- a/e2e/src/t2/keplr.test.ts
+++ b/e2e/src/t2/keplr.test.ts
@@ -18,6 +18,17 @@ describe("buildKeplrInitScript", () => {
     }
   });
 
+  it("pins the getter's chain id onto the signer (the app's signer.chainId read)", () => {
+    expect(script).toContain("const makeAminoSigner = (chainId) => ({");
+    expect(script).toContain("chainId,");
+    expect(script).toContain("getOfflineSignerOnlyAmino: (chainId) => makeAminoSigner(chainId)");
+    expect(script).toContain("getOfflineSignerAuto: (chainId) => Promise.resolve(makeAminoSigner(chainId))");
+  });
+
+  it("threads the signer's chain id into the account binding for per-chain addresses", () => {
+    expect(script).toMatch(/window\.__e2eWalletGetAccounts\(chainId\)/);
+  });
+
   it("exposes no isKeplr identity marker (the #155 pin)", () => {
     expect(script).not.toContain("isKeplr");
   });

--- a/e2e/src/t2/keplr.ts
+++ b/e2e/src/t2/keplr.ts
@@ -9,7 +9,7 @@ import type { AccountPayload, WalletIdentity } from "../signer.js";
  * app calls and nothing else — `getKey`, `signArbitrary`, `defaultOptions` and friends
  * have zero call sites in `src/` and are deliberately omitted so drift stays visible.
  *
- * App call sites (verified against main @ 9394cceb):
+ * App call sites (verified against main @ afa8bfb3):
  *   - `enable(chainId)`
  *       src/common/stores/wallet/actions/connectKeplrLike.ts:46
  *       src/networks/cosm/WalletFactory.ts:89
@@ -20,6 +20,16 @@ import type { AccountPayload, WalletIdentity } from "../signer.js";
  *       src/common/stores/wallet/actions/connectKeplrLike.ts:22 (presence), :48-49 (call)
  *   - `getOfflineSignerAuto(chainId)`  (Path B — cross-chain external wallet)
  *       src/networks/cosm/WalletFactory.ts:69 (presence), :92 (call)
+ *
+ * Beyond the four methods, the app also reads two things OFF the returned signer:
+ *   - `signer.chainId` — `useSwapForm.ts` `getWallets` resolves the native chain from the
+ *     connected wallet's signer and throws "Native chain id not available" when absent
+ *     (real Keplr's `CosmJSOfflineSigner` carries a public `chainId` field). Every signer
+ *     this stub returns therefore pins the `chainId` it was created for.
+ *   - `getAccounts()` per chain — the cross-chain swap path builds one wallet per Skip
+ *     route hop and needs a chain-appropriate bech32 address (e.g. `osmo1…` on
+ *     `osmosis-1`), so the account binding threads the signer's chain id to Node where
+ *     the identity derives the right prefix.
  *
  * The signer object returned by the two getters intentionally omits `signDirect`:
  * CosmJS's `isOfflineDirectSigner` is literally `signer.signDirect !== undefined`
@@ -46,9 +56,10 @@ export function buildKeplrInitScript(): string {
     for (let i = 0; i < binary.length; i++) { bytes[i] = binary.charCodeAt(i); }
     return bytes;
   };
-  const makeAminoSigner = () => ({
+  const makeAminoSigner = (chainId) => ({
+    chainId,
     getAccounts: async () => {
-      const account = await window.${GET_ACCOUNTS_BINDING}();
+      const account = await window.${GET_ACCOUNTS_BINDING}(chainId);
       return [{ address: account.address, pubkey: decodePubkey(account.pubkey), algo: account.algo }];
     },
     signAmino: (signerAddress, signDoc) => window.${SIGN_AMINO_BINDING}(signerAddress, signDoc)
@@ -56,8 +67,8 @@ export function buildKeplrInitScript(): string {
   window.keplr = {
     enable: (chainId) => { window.${LAST_CHAIN_ID_VAR} = chainId; return Promise.resolve(); },
     experimentalSuggestChain: () => Promise.resolve(),
-    getOfflineSignerOnlyAmino: () => makeAminoSigner(),
-    getOfflineSignerAuto: () => Promise.resolve(makeAminoSigner())
+    getOfflineSignerOnlyAmino: (chainId) => makeAminoSigner(chainId),
+    getOfflineSignerAuto: (chainId) => Promise.resolve(makeAminoSigner(chainId))
   };
 })();`;
 }
@@ -69,7 +80,9 @@ export function buildKeplrInitScript(): string {
  * pair, both of which survive the `exposeFunction` boundary untouched.
  */
 export async function installKeplrStub(page: Page, identity: WalletIdentity): Promise<void> {
-  await page.exposeFunction(GET_ACCOUNTS_BINDING, (): Promise<AccountPayload> => identity.getAccounts());
+  await page.exposeFunction(GET_ACCOUNTS_BINDING, (chainId?: string): Promise<AccountPayload> =>
+    identity.getAccounts(chainId)
+  );
   await page.exposeFunction(
     SIGN_AMINO_BINDING,
     (signerAddress: string, signDoc: StdSignDoc): Promise<AminoSignResponse> =>


### PR DESCRIPTION
Fixes the failure that has turned every `e2e-regression` run red since the T3 flows landed (latest: run 29625286291): the dust-swap flow dies ~150 ms after the Swap click with `swap reached a failed terminal state: Unexpected error`.

## Root cause

`useSwapForm.ts` `getWallets()` resolves the native chain by reading `signer.chainId` off the connected wallet's signer and **throws synchronously** ("Native chain id not available from wallet signer") when the field is absent. Real Keplr's `CosmJSOfflineSigner` carries a public `chainId` field; the e2e scripted `window.keplr` provider returned bare `{ getAccounts, signAmino }` signers — so under the stub, `onSwap` threw before issuing a single network request, `classifyError` mapped the plain `Error` to `message.unexpected-error`, and the spec's terminal poll read the inline error surface as the swap's terminal state.

Evidence trail that pinned it:

- The journaled failure lands ~150 ms after the intent — far too fast for any broadcast round-trip.
- The failure screenshot shows a fully populated, healthy quote (To amount, price impact, fee) *and* the error surface simultaneously — the quote request had succeeded.
- The deploy-host access logs show exactly one browser `POST /api/swap/route` (200) in the window and **zero** further API traffic between the quote settling and the failure — ruling out every network-failure path and leaving only a synchronous local throw inside `onSwap`.
- The Skip route for the $1 USDC→NLS swap is multi-hop (`pirin-1 → osmosis-1 → pirin-1`), which is what sends `getWallets` down the per-chain wallet path in the first place.

This is a suite bug (stub–app drift), not an app bug — real users with the actual extension are unaffected.

## Fix

- `e2e/src/t2/keplr.ts` — both signer getters now pin the `chainId` they were called with onto the returned signer (mirroring real Keplr), and the account binding threads that chain id from the page to Node. Stub docblock updated with the newly verified app call sites.
- `e2e/src/signer.ts` — `WalletIdentity.getAccounts(chainId?)` serves per-chain bech32 accounts derived lazily from the same key via a chain-id→prefix map (`pirin-1`→`nolus`, `osmosis-1`→`osmo`), so the cross-chain hop gets a correct `osmo1…` intermediate address. Unmapped chain ids reject loudly (own-property lookup, so prototype-chain key names like `__proto__` also reject) to keep route drift visible. **Signing stays bound to the nolus account** — a foreign-chain sign attempt fails loudly instead of spending outside the T3 caps.
- Tests: 6 new cases across `signer.test.ts` / `keplr.test.ts` (per-chain derivation, unmapped/hostile chain-id rejection, foreign-address sign rejection, script chainId wiring).

## Validation

- e2e package gate green: typecheck, lint, format:check, vitest (45 files / 407 tests), coverage.
- Real-browser check against staging with a throwaway unfunded mnemonic: the T2 connect suite drives the changed stub through the app's actual connect flow — passes (the only failures seen were environmental: per-IP rate-limit 429s when batching specs from one host, and one expected failure when the primary mnemonic was deliberately set equal to the public fallback identity).
- Full confirmation needs a funded run: dispatch `e2e-regression` after merge and confirm the dust-swap spec goes green.

suite impact: t3-flows (dust-swap spec unblocked); no app code touched, no coverage-matrix change.

## Review ceremonies

<details><summary>Diff review — PASS (full 12-item checklist)</summary>

1. No debug prints, logging leftovers, or commented-out code — PASS. No console.*, no commented-out code; added block comments are genuine why-comments.
2. No off-by-one errors in loops, slices, or ranges — PASS. Only index is `accounts[0]`, guarded by undefined check; unchanged byte-decode loop untouched.
3. All match/enum arms handled — PASS. Prefix lookup exhaustive: undefined→nolus, mapped→prefix, unmapped→explicit reject.
4. Error paths return meaningful errors — PASS. Unmapped id rejects `no bech32 prefix mapped for chain id "<id>"`; empty derivation throws `derived <prefix> wallet exposed no account`. The cache-eviction `.catch` only marks the promise handled; the caller still receives the rejection — no silent swallow.
5. Boundary conditions — PASS. Empty accounts handled; undefined chainId defaults nolus; unmapped rejects; nolus primary pre-seeded so never re-derives.
6. Async: no held locks across await, no missing await — PASS. Resolver intentionally returns promises unawaited (lazy resolver); eviction `.catch` is deliberate fire-and-forget.
7. No resource leaks — PASS. Failed derivations evicted so a transient failure retries rather than caching a rejected promise.
8. SQL: parameterized queries only — PASS. N/A, no SQL.
9. New public functions/endpoints have test coverage — PASS. `getAccounts(chainId?)` covered by new tests (pirin-1→nolus, osmosis-1→osmo derived, unmapped rejects, foreign-address sign rejects); init-script changes covered by new keplr.test.ts assertions.
10. No logic inversions — PASS.
11. Types: no unnecessary clones/copies — PASS.
12. Concurrency: shared state properly guarded — PASS. Promise cached before first await, so concurrent same-prefix callers share the in-flight promise.

Extra scrutiny: (a) no unhandled-rejection risk from the eviction pattern; (b) generated in-page script syntactically valid and consistent with the binding signature change (including `buildSignAminoScript`'s use of the Path-A getter); (c) the only consumer of `WalletIdentity.getAccounts` is the stub binding, updated in this diff — `broadcast.ts` uses its own local interface, unaffected; the optional param is backward-compatible.

Verdict: PASS — all 12 items, all acceptance criteria met.

</details>

<details><summary>Security review — CLEAR (one LOW, fixed in this PR)</summary>

1. Mnemonic/secret leakage — PASS. Mnemonic stays captured only in Node-side closures, never a serializable property; account payloads carry only `{address, pubkey(base64), algo}`; the init script still takes no arguments and can never embed a secret; the "never serializes the mnemonic" test still guards it.
2. Signing authority — PASS (not widened). `signAmino` unchanged, still proxies to the single nolus-prefixed wallet; chainId is threaded only into `getAccounts`, never the signing path; the per-prefix wallet is a throwaway used solely to compute an address. cosmjs rejects a signer address outside the nolus account (pinned by test).
3. Injection into the init script — PASS. Script assembled purely from string/constant literals; the added chainId is a JS parameter name inside the template, never interpolated data.
4. Page-supplied chainId trusted in Node — one LOW: the original bracket lookup on a plain object walked the prototype chain, so `"__proto__"`/`"constructor"`/`"toString"` would bypass the intended reject and flow a non-string into the derivation. Not exploitable for secret leakage, but it blunted the "reject loudly" guarantee. **Fixed in this PR** via `Object.hasOwn` gating + a regression test over hostile key names.

Informational: the resolver closure retains the plaintext mnemonic for the identity's lifetime (previously only the derived wallet object was held) — no new serialization/egress surface; acceptable for a Node test harness.

Verdict: CLEAR to merge.

</details>

Security classification: crypto/key-handling category hit (scripted wallet identity) → security review ran; findings above.
