### PR TITLE
fix(history): read skip route amounts in wire snake_case

### DIFF
--- a/src/common/stores/history/index.test.ts
+++ b/src/common/stores/history/index.test.ts
@@ -120,7 +120,7 @@ function baseReceivePayload() {
     type: HISTORY_ACTIONS.RECEIVE,
     currency: "ibc/USDC",
     fromAddress: "nolus1fromaddressverylong",
-    skipRoute: { ...baseSkipRoute(), amountOut: "1000000" },
+    skipRoute: { ...baseSkipRoute(), amount_out: "1000000" },
     chains: {}
   };
 }
@@ -131,7 +131,7 @@ function baseSendPayload() {
     type: HISTORY_ACTIONS.SEND,
     currency: "ibc/USDC",
     receiverAddress: "nolus1toaddressverylong",
-    skipRoute: { ...baseSkipRoute(), amountIn: "1000000" },
+    skipRoute: { ...baseSkipRoute(), amount_in: "1000000" },
     chains: {}
   };
 }
@@ -263,11 +263,11 @@ describe("HistoryStore", () => {
     );
   });
 
-  it("addPendingTransfer_receive_throws_without_amountOut", () => {
+  it("addPendingTransfer_receive_throws_without_amount_out", () => {
     const store = useHistoryStore();
     expect(() =>
       store.addPendingTransfer({ ...baseReceivePayload(), skipRoute: baseSkipRoute() }, i18nInstance)
-    ).toThrow("amountOut");
+    ).toThrow("amount_out");
   });
 
   it("addPendingTransfer_receive_throws_without_fromAddress", () => {
@@ -277,10 +277,10 @@ describe("HistoryStore", () => {
     );
   });
 
-  it("addPendingTransfer_send_throws_without_amountIn", () => {
+  it("addPendingTransfer_send_throws_without_amount_in", () => {
     const store = useHistoryStore();
     expect(() => store.addPendingTransfer({ ...baseSendPayload(), skipRoute: baseSkipRoute() }, i18nInstance)).toThrow(
-      "amountIn"
+      "amount_in"
     );
   });
 
@@ -314,7 +314,7 @@ describe("HistoryStore", () => {
       {
         ...baseReceivePayload(),
         skipRoute: {
-          amountOut: "1000000",
+          amount_out: "1000000",
           operations: [
             { amount_in: "100", amount_out: "99", transfer: { from_chain_id: "osmosis", to_chain_id: "axelar" } },
             { amount_in: "99", amount_out: "98", cctp_transfer: { from_chain_id: "axelar", to_chain_id: "noble" } }
@@ -352,7 +352,7 @@ describe("HistoryStore", () => {
         {
           ...baseReceivePayload(),
           skipRoute: {
-            amountOut: "1000000",
+            amount_out: "1000000",
             operations: [
               { amount_in: "100", amount_out: "99", transfer: { from_chain_id: "missing", to_chain_id: "gone" } }
             ]
@@ -374,7 +374,7 @@ describe("HistoryStore", () => {
     try {
       const store = useHistoryStore();
       store.addPendingTransfer(
-        { ...baseReceivePayload(), skipRoute: { amountOut: "1000000", operations: ["bogus"] } },
+        { ...baseReceivePayload(), skipRoute: { amount_out: "1000000", operations: ["bogus"] } },
         i18nInstance
       );
       const entry = store.pendingTransfers["1"];
@@ -391,7 +391,7 @@ describe("HistoryStore", () => {
     try {
       const store = useHistoryStore();
       store.addPendingTransfer(
-        { ...baseReceivePayload(), skipRoute: { amountOut: "1000000", operations: [{ swap: {} }] } },
+        { ...baseReceivePayload(), skipRoute: { amount_out: "1000000", operations: [{ swap: {} }] } },
         i18nInstance
       );
       const entry = store.pendingTransfers["1"];
@@ -411,7 +411,7 @@ describe("HistoryStore", () => {
         {
           ...baseReceivePayload(),
           skipRoute: {
-            amountOut: "1000000",
+            amount_out: "1000000",
             operations: [{ amount_out: "99", transfer: { from_chain_id: "osmosis", to_chain_id: "noble" } }]
           },
           chains: {
@@ -438,7 +438,7 @@ describe("HistoryStore", () => {
         {
           ...baseReceivePayload(),
           skipRoute: {
-            amountOut: "1000000",
+            amount_out: "1000000",
             operations: [{ amount_in: "100", transfer: { from_chain_id: "osmosis", to_chain_id: "noble" } }]
           },
           chains: {

--- a/src/common/stores/history/index.ts
+++ b/src/common/stores/history/index.ts
@@ -156,9 +156,9 @@ export const useHistoryStore = defineStore("history", () => {
 
     switch (historyData.type) {
       case HISTORY_ACTIONS.RECEIVE: {
-        const amountOut = skipRoute.amountOut;
+        const amountOut = skipRoute.amount_out;
         if (typeof amountOut !== "string") {
-          throw new Error("receive transfer is missing its amountOut");
+          throw new Error("receive transfer is missing its amount_out");
         }
         const fromAddress = historyData.fromAddress;
         if (typeof fromAddress !== "string") {
@@ -178,9 +178,9 @@ export const useHistoryStore = defineStore("history", () => {
         break;
       }
       case HISTORY_ACTIONS.SEND: {
-        const amountIn = skipRoute.amountIn;
+        const amountIn = skipRoute.amount_in;
         if (typeof amountIn !== "string") {
-          throw new Error("send transfer is missing its amountIn");
+          throw new Error("send transfer is missing its amount_in");
         }
         const receiverAddress = historyData.receiverAddress;
         if (typeof receiverAddress !== "string") {


### PR DESCRIPTION
## Summary
Fix send/receive transfers failing with "send transfer is missing its amountIn" before the transaction is signed. The history store's `addPendingTransfer` read `skipRoute.amountIn`/`amountOut` (camelCase, left over from the removed skip SDK client), while route payloads from the backend swap proxy carry `amount_in`/`amount_out`. The payload-validation refactor turned that silent `undefined` into a thrown error, blocking every transfer on staging.

## Changes
- `addPendingTransfer` RECEIVE/SEND arms read `amount_out`/`amount_in`; thrown-error messages name the wire fields
- Store test fixtures rewritten to the real wire shape (they had pinned the stale camelCase top level while already using snake_case inside `operations`)

## Verification
- Rewrote the fixtures first and confirmed 15 store tests fail against the old reads, then applied the fix; 46/46 store tests pass
- Ran the full frontend gate: vue-tsc, eslint, ts-style grep, prettier check, 1050/1050 vitest
- Swept src/ for any other stale camelCase skip-route field reads — these two were the only ones
- Reviewed the diff against the wire contract in `types/skipRoute/routeResponse.ts` and the existing `assertRouteResponse` guard; no validation weakened

Suite impact: bug fix restoring the existing send/receive pending-transfer flow; covered by `src/common/stores/history/index.test.ts`, no coverage-matrix change (no new route/component/state). The t3 send spec exercises this path end-to-end on regression runs.

## Follow-ups
- `types/skipRoute/messageResponse.ts` still declares camelCase fields (`estimatedFees`, `usdAmount`, `txIndex`) for the /msgs response — worth confirming against the actual wire shape in a separate pass