### PR TITLE
fix(stake): remove doubled divider above the delegate button

### DIFF
--- a/src/modules/stake/components/DelegateForm.vue
+++ b/src/modules/stake/components/DelegateForm.vue
@@ -52,7 +52,6 @@
     <hr class="border-border-color" />
   </div>
   <div class="flex flex-1 flex-col justify-end">
-    <hr class="border-border-color" />
     <div class="flex flex-col gap-2 p-6">
       <Button
         size="large"


### PR DESCRIPTION
## Summary
Remove the extra divider above the button on the stake dialog's delegate tab. The footer carried its own `<hr>` on top of the scroll area's trailing one, rendering two stacked lines; no other dialog form (undelegate, supply, withdraw) has the footer divider.

## Verification
- Compared the footer structure against UndelegateForm, SupplyForm, and WithdrawForm — all end the scroll area with a single divider and have none in the button footer
- Ran the pre-commit gate: vue-tsc, eslint, ts-style grep, full vitest suite, build — all green

Suite impact: none — purely visual, one-line template removal; no route/component/state change.