### PR TITLE
fix(e2e): accept numeric downpayment mins in the lease ranges parser

### DIFF
--- a/e2e/src/t3/flows/preconditions.test.ts
+++ b/e2e/src/t3/flows/preconditions.test.ts
@@ -86,19 +86,24 @@ describe("isNoRouteFailure", () => {
 });
 
 describe("resolveDownpaymentFloorUsd", () => {
-  it("returns the floor for a named currency from an object map", () => {
-    const payload = { downpayment_ranges: { USDC: { min: "40.0" }, ATOM: { min: "45.0" } } };
+  it("returns the floor for a named currency from the wire's numeric object map", () => {
+    const payload = { downpayment_ranges: { USDC: { min: 40.0, max: 800.0 }, ATOM: { min: 45.0, max: 4000.0 } } };
     expect(resolveDownpaymentFloorUsd(payload, "USDC").toString(2)).toBe("40.00");
   });
 
   it("returns the highest floor across currencies when none is named", () => {
     const payload = {
       downpayment_ranges: [
-        { ticker: "USDC", min: "40.0" },
-        { ticker: "ATOM", min: "45.0" }
+        { ticker: "USDC", min: 40.0 },
+        { ticker: "ATOM", min: 45.0 }
       ]
     };
     expect(resolveDownpaymentFloorUsd(payload).toString(2)).toBe("45.00");
+  });
+
+  it("still accepts string-encoded minimums", () => {
+    const payload = { downpayment_ranges: { USDC: { min: "40.0" } } };
+    expect(resolveDownpaymentFloorUsd(payload, "USDC").toString(2)).toBe("40.00");
   });
 
   it("throws when no ranges parse so a drifted shape is a red", () => {

--- a/e2e/src/t3/flows/preconditions.ts
+++ b/e2e/src/t3/flows/preconditions.ts
@@ -103,6 +103,15 @@ interface DownpaymentRange {
   min: Decimal;
 }
 
+/** The wire serves `min` as a JSON number (backend `DownpaymentRange.min: f64`); accept a
+ * string encoding too so the parser survives a backend move to decimal strings. */
+function readDecimalString(root: unknown, key: string): string | undefined {
+  if (typeof root !== "object" || root === null) return undefined;
+  const value = (root as Record<string, unknown>)[key];
+  if (typeof value === "string") return value;
+  return typeof value === "number" && Number.isFinite(value) ? String(value) : undefined;
+}
+
 function extractRanges(payload: unknown): DownpaymentRange[] {
   const root =
     typeof payload === "object" && payload !== null
@@ -112,14 +121,14 @@ function extractRanges(payload: unknown): DownpaymentRange[] {
   if (Array.isArray(root)) {
     for (const entry of root) {
       const currency = readString(entry, "ticker") ?? readString(entry, "currency");
-      const min = readString(entry, "min");
+      const min = readDecimalString(entry, "min");
       if (currency !== undefined && min !== undefined) {
         ranges.push({ currency, min: Decimal.fromString(min) });
       }
     }
   } else if (typeof root === "object" && root !== null) {
     for (const [currency, value] of Object.entries(root as Record<string, unknown>)) {
-      const min = readString(value, "min");
+      const min = readDecimalString(value, "min");
       if (min !== undefined) {
         ranges.push({ currency, min: Decimal.fromString(min) });
       }


### PR DESCRIPTION
## Summary
Make the t3 lease lifecycle flow able to run at all. The downpayment-ranges parser only accepted string `min` values, but the backend serves them as JSON numbers (`DownpaymentRange.min: f64`), so every protocol parsed as zero ranges and the flow skipped as "no eligible lease protocol" on every run since it shipped — it has never executed in CI. Unit-test fixtures had pinned the string shape, matching the parser instead of the wire.

## Changes
- `readDecimalString` helper accepts finite JSON numbers or string encodings; used for `min` in both the array and object branches of `extractRanges`
- Test fixtures rewritten to the real numeric wire shape; string tolerance kept and pinned by its own test case

## Verification
- Rewrote the fixtures to numbers first and confirmed 2 tests fail against the old parser, then applied the fix; 13/13 in the file, 418/418 suite
- Ran the fixed parser against the live dev payload for `OSMOSIS-OSMOSIS-USDC_NOBLE`: 14 ranges parsed, OSMO floor 40.00
- Confirmed the backend wire type is `f64` (`backend/src/config_store/gated_types.rs:178`)
- Full e2e package gate: tsc, eslint, prettier check, vitest coverage — green

Suite impact: t3 lease flow only — with a funded primary (≥ ~$45 USDC) the lifecycle now executes on regression runs instead of skipping; no coverage-matrix change (its three lease cells already exist and stop reading "not run").

## Follow-ups
- #345 tracks the skip-escalation taxonomy so this class of eternal skip fails loudly under `E2E_EXPECT_FUNDED=1`