### PR TITLE
ci: disable live e2e runs pending the suite rework

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -134,51 +134,6 @@ jobs:
             exit 1
           REMOTE
 
-      - name: Post-deploy verification (t0+t1)
-        id: e2e
-        continue-on-error: true
-        env:
-          E2E_BASE_URL: https://${{ inputs.base_domain }}
-          E2E_WS_URL: wss://${{ inputs.base_domain }}/ws
-          E2E_HOST_RESOLVER: ${{ inputs.base_domain }}=${{ vars.DEPLOY_HOST }}
-          E2E_READONLY_ADDRESS: ${{ vars.E2E_READONLY_ADDRESS }}
-          BASE_DOMAIN: ${{ inputs.base_domain }}
-        run: |
-          set -uo pipefail
-          cd e2e || exit 1
-          npm ci
-          npx playwright install chromium
-          t0_rc=0
-          npm run t0 || t0_rc=$?
-          t1_rc=0
-          npm run t1 || t1_rc=$?
-          if [ "$t0_rc" -ne 0 ] || [ "$t1_rc" -ne 0 ]; then
-            failed=""
-            [ "$t0_rc" -ne 0 ] && failed="t0"
-            [ "$t1_rc" -ne 0 ] && failed="${failed:+$failed }t1"
-            echo "::error::post-deploy verification failed ($failed); e2e artifacts uploaded as e2e-${BASE_DOMAIN}"
-            exit 1
-          fi
-
-      - name: Scrub the resolver target from e2e artifacts
-        id: scrub
-        if: always() && steps.e2e.outcome == 'failure'
-        uses: ./.github/actions/scrub-e2e-artifacts
-        with:
-          resolver-target: ${{ vars.DEPLOY_HOST }}
-
-      - name: Upload e2e artifacts
-        if: always() && steps.e2e.outcome == 'failure' && steps.scrub.outcome == 'success'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: e2e-${{ inputs.base_domain }}
-          path: |
-            e2e/results/
-            e2e/playwright-report/
-            e2e/test-results/
-          retention-days: 7
-          if-no-files-found: ignore
-
       - name: Rollback on failure
         if: failure()
         run: |

--- a/.github/workflows/e2e-regression.yaml
+++ b/.github/workflows/e2e-regression.yaml
@@ -1,7 +1,8 @@
-name: E2E regression (post-deploy + manual)
+name: E2E regression (manual)
 
 on:
-  # Ad-hoc: a manual full-suite run against any host.
+  # Manual-only while the suite is reworked (skip-escalation taxonomy #345, fail-open verdict
+  # #348): the automatic post-deploy trigger returns when those land.
   workflow_dispatch:
     inputs:
       base_domain:
@@ -13,12 +14,6 @@ on:
         required: false
         default: false
         type: boolean
-  # Automatic: regression-validate the staging host after a dev deploy completes. The job-level
-  # `if` below gates this path on the deploy having SUCCEEDED (a failed deploy has nothing to
-  # validate). workflow_run has no inputs, so that path resolves the base domain from the repo var.
-  workflow_run:
-    workflows: ["Deploy dev"]
-    types: [completed]
 
 # Serialize with the deploy workflow's live e2e phase on the one per-host rate-limit bucket: a
 # regression run and a second deploy's post-run must never hit the strict bucket at the same time.
@@ -34,8 +29,6 @@ permissions:
 jobs:
   regression:
     name: Regression full suite
-    # Manual dispatch always runs; the post-deploy path runs only when the deploy succeeded.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: [self-hosted, frontend-deploy]
     timeout-minutes: 75
 


### PR DESCRIPTION
## Summary
Temporarily disable all live e2e runs in CI while the suite is reworked. The suite's current results can't be trusted to mean what they say: skips can hide real gaps (#345), the run verdict fails open when tiers produce no results (#348), prod smoke failures alert nobody (#347), and the budget warning can die silently (#349). Until those land, live runs cost deploy time and print misleading green.

## Changes
- `deploy.yaml`: removed the post-deploy verification (t0+t1) step and its scrub/artifact-upload companions
- `e2e-regression.yaml`: removed the automatic post-dev-deploy trigger and its job gate; manual dispatch (with both inputs) remains

Kept: the static e2e job in `pr-validate.yaml` (typecheck, fixture schemas, coverage-matrix guard) so the package can't rot during the rework, and the dispatch-only t3 workflows (already manual).

## Verification
- Confirmed no dangling references to the removed steps or the workflow_run event remain in either file
- Both files parse as valid YAML; job/step structure verified intact
- Confirmed pr-validate.yaml and the e2e-t3 dispatch workflows are untouched

Suite impact: no spec changes; live tiers stop running in CI until re-enabled (revert of this PR + the #345/#348 fixes).