### PR TITLE
feat(wallet): solana transaction signing in the phantom/solflare shim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.29.16",
         "@nolus/nolusjs": "^3.7.6",
         "@observablehq/plot": "^0.6.17",
+        "@solana/web3.js": "^1.98.4",
         "cosmjs-types": "^0.11.0",
         "d3": "^7.9.0",
         "dompurify": "^3.4.12",
@@ -171,6 +172,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -2773,6 +2783,100 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@solana/buffer-layout": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "~6.0.3"
+      },
+      "engines": {
+        "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/web3.js": {
+      "version": "1.98.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
+      "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "@solana/codecs-numbers": "^2.1.0",
+        "agentkeepalive": "^4.5.0",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^2.0.2"
+      }
+    },
     "node_modules/@starknet-io/starknet-types-08": {
       "name": "@starknet-io/types-js",
       "version": "0.8.4",
@@ -2788,6 +2892,15 @@
       "integrity": "sha512-vWOc0FVSn+RmabozIEWcEny1I73nDGTvOrLYJsR1x7LGA3AZmqt4i/aW69o/3i2NN5CVP8Ok6G1ayRQJKye3Wg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
@@ -3149,6 +3262,15 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/crypto-js": {
@@ -3547,6 +3669,15 @@
       "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
@@ -4467,6 +4598,18 @@
         "node": ">= 14"
       }
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -4636,6 +4779,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4855,6 +5007,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
@@ -4954,6 +5117,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
     "node_modules/bs58check": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
@@ -4963,24 +5135,6 @@
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/bs58check/node_modules/base-x": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/bs58check/node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.2"
       }
     },
     "node_modules/buffer": {
@@ -5019,6 +5173,20 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "license": "MIT"
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -5115,6 +5283,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/check-error": {
@@ -5985,6 +6165,18 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6279,6 +6471,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
+    "node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
       }
     },
     "node_modules/esbuild": {
@@ -6677,6 +6884,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -6788,6 +7001,14 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6836,6 +7057,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -7040,12 +7267,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/framer-motion/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/fresh": {
       "version": "2.0.0",
@@ -7400,6 +7621,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -7715,6 +7945,44 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jayson": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.3.0.tgz",
+      "integrity": "sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "^3.4.33",
+        "@types/node": "^12.12.54",
+        "@types/ws": "^7.4.4",
+        "commander": "^2.20.3",
+        "delay": "^5.0.0",
+        "es6-promisify": "^5.0.0",
+        "eyes": "^0.1.8",
+        "isomorphic-ws": "^4.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "stream-json": "^1.9.1",
+        "uuid": "^8.3.2",
+        "ws": "^7.5.10"
+      },
+      "bin": {
+        "jayson": "bin/jayson.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jayson/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -7884,6 +8152,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/jsonc-eslint-parser": {
       "version": "2.4.2",
@@ -8637,12 +8911,6 @@
         "vue": ">=3.0.0"
       }
     },
-    "node_modules/motion/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8703,6 +8971,60 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/nopt": {
       "version": "7.2.1",
@@ -9547,6 +9869,86 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rpc-websockets": {
+      "version": "9.3.9",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.9.tgz",
+      "integrity": "sha512-2iQDaTB4g5fDB2ihrTFSJSibCEuxaRi1q7qTW7ZO9/M5/TC+ToHA4D9/ffNLEbAoHNNrcdeP05oATNk44SKZXA==",
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.2.2",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "uuid": "^14.0.0",
+        "ws": "^8.5.0"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/kozjak"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^6.0.0"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/utf-8-validate": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9585,12 +9987,6 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -10011,6 +10407,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -10105,6 +10516,15 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/supports-color": {
@@ -10244,6 +10664,11 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
     "node_modules/tiny-secp256k1": {
       "version": "1.1.7",
@@ -10437,6 +10862,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -10601,6 +11032,21 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10614,6 +11060,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/varuint-bitcoin": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.29.16",
     "@nolus/nolusjs": "^3.7.6",
     "@observablehq/plot": "^0.6.17",
+    "@solana/web3.js": "^1.98.4",
     "cosmjs-types": "^0.11.0",
     "d3": "^7.9.0",
     "dompurify": "^3.4.12",

--- a/src/networks/sol/wallet.test.ts
+++ b/src/networks/sol/wallet.test.ts
@@ -1,4 +1,16 @@
+// @vitest-environment node
+//
+// This suite runs in the node environment (not the project-default jsdom):
+// @solana/web3.js encode/serialize does strict `instanceof Uint8Array` checks,
+// and under jsdom the Node builtin Buffer is not an instance of the realm's
+// Uint8Array, so tx (de)serialization throws. Node's Buffer/Uint8Array share
+// one realm, so web3.js works natively — matching how the production bundle
+// polyfills Buffer. The window slots the shim below provides are all these
+// tests touch of the DOM.
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const globalWindow = globalThis as unknown as { window?: unknown };
+globalWindow.window ??= globalThis;
 
 const stargateConnectMock = vi.fn();
 vi.mock("@cosmjs/stargate", () => ({
@@ -31,9 +43,17 @@ vi.mock("@/config/global", () => ({
   }))
 }));
 
-import { SolanaWallet } from "./wallet";
+import { SolanaWallet, SolanaWalletError } from "./wallet";
 import type { NetworkData } from "@/common/types";
 import { AuthInfo, SignDoc } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { Buffer } from "buffer";
+import {
+  AddressLookupTableAccount,
+  Keypair,
+  SystemProgram,
+  TransactionMessage,
+  VersionedTransaction
+} from "@solana/web3.js";
 
 const ED_PUBKEY_BYTES = new Uint8Array(32);
 for (let i = 0; i < 32; i++) ED_PUBKEY_BYTES[i] = i + 1;
@@ -49,6 +69,7 @@ function makeProvider(overrides: Partial<Record<string, unknown>> = {}) {
     connect: vi.fn().mockResolvedValue(true),
     publicKey,
     signMessage: vi.fn().mockResolvedValue({ signature: new Uint8Array(64) }),
+    signAndSendTransaction: vi.fn().mockResolvedValue({ signature: "SIG_SOLFLARE" }),
     ...overrides
   };
 }
@@ -64,6 +85,7 @@ function makePhantomProvider(overrides: Partial<Record<string, unknown>> = {}) {
     connect: vi.fn().mockResolvedValue(true),
     publicKey,
     signMessage: vi.fn().mockResolvedValue({ signature: new Uint8Array(64) }),
+    signAndSendTransaction: vi.fn().mockResolvedValue({ signature: "SIG_PHANTOM" }),
     ...overrides
   };
 }
@@ -92,6 +114,49 @@ function networkStub(): NetworkData {
   return {
     embedChainInfo: () => ({ bech32Config: { bech32PrefixAccAddr: "nolus" } })
   } as unknown as NetworkData;
+}
+
+// Builds a backend-shaped, unsigned v0 VersionedTransaction that genuinely
+// references an address lookup table, returning both its base64 form (the wire
+// input the shim receives) and its raw bytes (for a byte-exact round-trip
+// assertion against what reaches the provider).
+function buildV0TransactionFixture(): { base64: string; bytes: Uint8Array } {
+  const payer = Keypair.generate();
+  const recipient = Keypair.generate().publicKey;
+  const lookupTable = new AddressLookupTableAccount({
+    key: Keypair.generate().publicKey,
+    state: {
+      deactivationSlot: 2n ** 64n - 1n,
+      lastExtendedSlot: 0,
+      lastExtendedSlotStartIndex: 0,
+      authority: payer.publicKey,
+      addresses: [recipient]
+    }
+  });
+  const instruction = SystemProgram.transfer({
+    fromPubkey: payer.publicKey,
+    toPubkey: recipient,
+    lamports: 1000
+  });
+  const message = new TransactionMessage({
+    payerKey: payer.publicKey,
+    recentBlockhash: Keypair.generate().publicKey.toBase58(),
+    instructions: [instruction]
+  }).compileToV0Message([lookupTable]);
+  if (message.addressTableLookups.length === 0) {
+    throw new Error("fixture did not reference the address lookup table");
+  }
+  const bytes = new VersionedTransaction(message).serialize();
+  return { base64: Buffer.from(bytes).toString("base64"), bytes };
+}
+
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the promise to reject");
 }
 
 describe("SolanaWallet (Solflare provider)", () => {
@@ -562,5 +627,133 @@ describe("SolanaWallet strict guards", () => {
     await expect(Promise.resolve(bound.simulateMultiTx?.([{ msg: {}, msgTypeUrl: "/x" }], ""))).rejects.toThrow(
       /usable fee/
     );
+  });
+});
+
+describe("SolanaWallet.signAndSendTransaction", () => {
+  afterEach(() => {
+    clearSolflare();
+    clearPhantom();
+    vi.restoreAllMocks();
+  });
+
+  it("Solflare: deserializes the base64 v0 tx byte-exactly and returns the provider signature", async () => {
+    const { base64, bytes } = buildV0TransactionFixture();
+    const provider = makeProvider();
+    stubSolflare(provider);
+
+    const sol = new SolanaWallet("solflare");
+    const signature = await sol.signAndSendTransaction(base64);
+
+    expect(signature).toBe("SIG_SOLFLARE");
+    expect(provider.signAndSendTransaction).toHaveBeenCalledTimes(1);
+
+    const call = provider.signAndSendTransaction.mock.calls[0];
+    if (call === undefined) throw new Error("expected signAndSendTransaction to have been called");
+    const received = call[0] as VersionedTransaction;
+    expect(received).toBeInstanceOf(VersionedTransaction);
+    // Confirms it is the v0 message the backend built; the byte-exact check
+    // below proves its lookup tables survived deserialization.
+    expect(received.message.version).toBe(0);
+    // Byte-exact: re-serializing what the provider received reproduces the input.
+    expect(received.serialize()).toEqual(bytes);
+  });
+
+  it("Phantom: deserializes the base64 v0 tx byte-exactly and returns the provider signature", async () => {
+    const { base64, bytes } = buildV0TransactionFixture();
+    const provider = makePhantomProvider();
+    stubPhantom(provider);
+
+    const sol = new SolanaWallet("phantom");
+    const signature = await sol.signAndSendTransaction(base64);
+
+    expect(signature).toBe("SIG_PHANTOM");
+    expect(provider.signAndSendTransaction).toHaveBeenCalledTimes(1);
+
+    const call = provider.signAndSendTransaction.mock.calls[0];
+    if (call === undefined) throw new Error("expected signAndSendTransaction to have been called");
+    const received = call[0] as VersionedTransaction;
+    expect(received.serialize()).toEqual(bytes);
+  });
+
+  it("classifies provider code 4001 as a 'rejected' error preserving the cause", async () => {
+    const cause = { code: 4001, message: "User rejected the request." };
+    const provider = makeProvider({ signAndSendTransaction: vi.fn().mockRejectedValue(cause) });
+    stubSolflare(provider);
+
+    const sol = new SolanaWallet("solflare");
+    const error = await captureRejection(sol.signAndSendTransaction(buildV0TransactionFixture().base64));
+
+    expect(error).toBeInstanceOf(SolanaWalletError);
+    if (!(error instanceof SolanaWalletError)) throw new Error("expected a SolanaWalletError");
+    expect(error.kind).toBe("rejected");
+    expect(error.cause).toBe(cause);
+  });
+
+  it("classifies provider code -32002 as a 'dialog-open' error (Phantom)", async () => {
+    const cause = { code: -32002, message: "Request already pending." };
+    const provider = makePhantomProvider({ signAndSendTransaction: vi.fn().mockRejectedValue(cause) });
+    stubPhantom(provider);
+
+    const sol = new SolanaWallet("phantom");
+    const error = await captureRejection(sol.signAndSendTransaction(buildV0TransactionFixture().base64));
+
+    expect(error).toBeInstanceOf(SolanaWalletError);
+    if (!(error instanceof SolanaWalletError)) throw new Error("expected a SolanaWalletError");
+    expect(error.kind).toBe("dialog-open");
+    expect(error.cause).toBe(cause);
+  });
+
+  it("classifies a missing provider as a 'disconnected' error", async () => {
+    clearSolflare();
+    clearPhantom();
+
+    const sol = new SolanaWallet("solflare");
+    const error = await captureRejection(sol.signAndSendTransaction(buildV0TransactionFixture().base64));
+
+    expect(error).toBeInstanceOf(SolanaWalletError);
+    if (!(error instanceof SolanaWalletError)) throw new Error("expected a SolanaWalletError");
+    expect(error.kind).toBe("disconnected");
+    expect(error.cause).toBeInstanceOf(Error);
+  });
+
+  it("classifies any other provider failure as 'unknown' preserving the original error as cause", async () => {
+    const cause = new Error("network unreachable");
+    const provider = makeProvider({ signAndSendTransaction: vi.fn().mockRejectedValue(cause) });
+    stubSolflare(provider);
+
+    const sol = new SolanaWallet("solflare");
+    const error = await captureRejection(sol.signAndSendTransaction(buildV0TransactionFixture().base64));
+
+    expect(error).toBeInstanceOf(SolanaWalletError);
+    if (!(error instanceof SolanaWalletError)) throw new Error("expected a SolanaWalletError");
+    expect(error.kind).toBe("unknown");
+    expect(error.cause).toBe(cause);
+  });
+
+  it("throws 'unknown' when the provider resolves without a signature string", async () => {
+    const provider = makeProvider({ signAndSendTransaction: vi.fn().mockResolvedValue({}) });
+    stubSolflare(provider);
+
+    const sol = new SolanaWallet("solflare");
+    const error = await captureRejection(sol.signAndSendTransaction(buildV0TransactionFixture().base64));
+
+    expect(error).toBeInstanceOf(SolanaWalletError);
+    if (!(error instanceof SolanaWalletError)) throw new Error("expected a SolanaWalletError");
+    expect(error.kind).toBe("unknown");
+    expect(error.message).toMatch(/signature/i);
+  });
+
+  it("throws 'unknown' when the connected wallet lacks signAndSendTransaction (older version)", async () => {
+    const provider = makeProvider({ signAndSendTransaction: undefined });
+    stubSolflare(provider);
+
+    const sol = new SolanaWallet("solflare");
+    const error = await captureRejection(sol.signAndSendTransaction(buildV0TransactionFixture().base64));
+
+    expect(error).toBeInstanceOf(SolanaWalletError);
+    if (!(error instanceof SolanaWalletError)) throw new Error("expected a SolanaWalletError");
+    expect(error.kind).toBe("unknown");
+    expect(error.message).toMatch(/does not support/i);
   });
 });

--- a/src/networks/sol/wallet.ts
+++ b/src/networks/sol/wallet.ts
@@ -31,6 +31,9 @@ import type { MsgDelegate, MsgUndelegate, MsgBeginRedelegate } from "cosmjs-type
 import type { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1beta1/tx";
 import type { MsgVote } from "cosmjs-types/cosmos/gov/v1beta1/tx";
 import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
+import { VersionedTransaction } from "@solana/web3.js";
+import type { SendOptions } from "@solana/web3.js";
+import { Buffer } from "buffer";
 
 interface SolanaProviderPublicKey {
   toBytes(): Uint8Array;
@@ -40,7 +43,43 @@ interface SolanaProviderPublicKey {
 interface SolanaProvider {
   connect(): Promise<unknown>;
   signMessage(message: Uint8Array): Promise<{ signature: Uint8Array }>;
+  signAndSendTransaction(transaction: VersionedTransaction, options?: SendOptions): Promise<{ signature: string }>;
   publicKey: SolanaProviderPublicKey | null | undefined;
+}
+
+type SolanaWalletErrorKind = "rejected" | "dialog-open" | "disconnected" | "unknown";
+
+export class SolanaWalletError extends Error {
+  readonly kind: SolanaWalletErrorKind;
+
+  constructor(kind: SolanaWalletErrorKind, message: string, cause: unknown) {
+    super(message, { cause });
+    this.name = "SolanaWalletError";
+    this.kind = kind;
+  }
+}
+
+// Standard injected-wallet JSON-RPC error codes (EIP-1193 style), surfaced by
+// both Phantom and Solflare.
+const USER_REJECTED_REQUEST_CODE = 4001;
+const REQUEST_ALREADY_PENDING_CODE = -32002;
+
+function providerErrorCode(error: unknown): number | undefined {
+  if (typeof error === "object" && error !== null && "code" in error && typeof error.code === "number") {
+    return error.code;
+  }
+  return undefined;
+}
+
+function toSolanaWalletError(cause: unknown): SolanaWalletError {
+  const code = providerErrorCode(cause);
+  if (code === USER_REJECTED_REQUEST_CODE) {
+    return new SolanaWalletError("rejected", "The wallet rejected the transaction.", cause);
+  }
+  if (code === REQUEST_ALREADY_PENDING_CODE) {
+    return new SolanaWalletError("dialog-open", "A wallet approval request is already pending.", cause);
+  }
+  return new SolanaWalletError("unknown", "The wallet could not sign and send the transaction.", cause);
 }
 
 function isSolanaProvider(value: unknown): value is SolanaProvider {
@@ -170,6 +209,40 @@ export class SolanaWallet implements Wallet {
     this.address = data.bech32Addr;
     this.chainId = chainId;
     return data;
+  }
+
+  async signAndSendTransaction(transactionBase64: string): Promise<string> {
+    let provider: SolanaProvider;
+    try {
+      provider = this.getProvider();
+    } catch (error) {
+      throw new SolanaWalletError("disconnected", "No Solana wallet provider is available.", error);
+    }
+
+    if (typeof provider.signAndSendTransaction !== "function") {
+      throw new SolanaWalletError(
+        "unknown",
+        "The connected wallet version does not support sending Solana transactions.",
+        undefined
+      );
+    }
+
+    let signature: string;
+    try {
+      const transaction = VersionedTransaction.deserialize(Buffer.from(transactionBase64, "base64"));
+      ({ signature } = await provider.signAndSendTransaction(transaction));
+    } catch (error) {
+      throw toSolanaWalletError(error);
+    }
+
+    if (typeof signature !== "string" || signature.length === 0) {
+      throw new SolanaWalletError(
+        "unknown",
+        "The wallet returned no transaction signature, violating the signAndSendTransaction contract.",
+        undefined
+      );
+    }
+    return signature;
   }
 
   private async getWallet(chainInfo: unknown) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -197,10 +197,10 @@ export default mergeConfig(
             statements: 95
           },
           "src/networks/sol/wallet.ts": {
-            lines: 95,
-            branches: 85,
-            functions: 95,
-            statements: 95
+            lines: 98,
+            branches: 95,
+            functions: 98,
+            statements: 98
           },
           "src/networks/cosm/WalletFactory.ts": {
             lines: 95,


### PR DESCRIPTION
## Summary

Extend the Phantom/Solflare shim with native Solana transaction signing: the shim accepts a base64-encoded unsigned v0 transaction, deserializes it, hands it to the injected provider via signAndSendTransaction, and returns the signature. Transaction building stays backend-side and the wallet broadcasts; the shim never talks to Solana infrastructure. Introduces the codebase's first typed wallet-error convention. Part of #287, closes #290.

## Changes

- `SolanaProvider` and `SolanaWallet` gain `signAndSendTransaction` (deserialization via new dependency `@solana/web3.js`; building stays backend-side per the integration plan).
- New `SolanaWalletError` with a `kind` discriminant (`rejected` for code 4001, `dialog-open` for -32002, `disconnected`, `unknown` with the original error preserved as `cause`). No prior wallet-error convention existed; this is deliberately minimal and local to the shim.
- Provider return shape validated (a non-string or empty signature throws a typed error naming the contract violation) and a call-site presence check covers older wallet builds lacking the method.
- `isSolanaProvider` intentionally unchanged: it gates connect, and requiring the new member would break message-signing-only sessions on older Phantom/Solflare versions. The call-site check covers actual send attempts instead.
- Standard wallet JSON-RPC codes named as constants; per-file coverage floors for the shim ratcheted to 98/95/98/98.
- Scope boundary: the issue mentions handing the signature to a backend tracker; that endpoint is #294's deliverable. The shim returns the signature, nothing else.
- Suite impact: unit tier only (8 new shim tests); no user-facing surface changes yet, the method gains consumers in #294/#296; coverage-matrix unchanged.

## Verification

- Ran the full gate on the final commit: vue-tsc, eslint, lint:style, prettier check, full vitest (1095 passed, 0 failed), production build.
- Shim coverage 100/98.8/100/100 against the new 98/95/98/98 floors; the ed25519 SignDoc path is untouched and its tests pass unchanged.
- Byte-exact round-trip asserted on both providers: the deserialized transaction reaching the provider re-serializes to the exact input bytes (v0 + address-lookup-table fixture).
- Independent review passes: 12-item checklist 12/12, security review clear, project-rule conformance clean.
- Confirmed the provider API shape against Phantom's official docs; the injected Solflare provider is Phantom-compatible (`{ signature }`), distinct from the `@solflare-wallet/sdk` wrapper which returns a bare string; the codebase uses the injected provider.
- npm audit: `@solana/web3.js@1.98.4` introduces 3 moderate advisories via `jayson`/`uuid`, on a code path this change never invokes (deserialize-only; the jayson RPC client is unused). The installed version postdates and is unaffected by the December 2024 web3.js supply-chain incident. Remaining advisories are pre-existing via `@nolus/nolusjs`.
- The new tests run under a per-file node vitest environment (web3.js performs strict `instanceof Uint8Array` checks that fail across jsdom realms); no shared vitest config changed.