### PR TITLE
feat(backend): solana chain client with balances and transfer params

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,6 +23,20 @@ OSMOSIS_RPC_URL=https://rpc.osmosis.zone
 NEUTRON_RPC_URL=https://rpc-kralum.neutron-1.neutron.org
 
 # =============================================================================
+# Solana RPC (Optional - Solana endpoints return 503 until configured)
+# =============================================================================
+
+# Operator's Solana JSON-RPC endpoint. Backs GET /api/solana/balances/{address}
+# and GET /api/solana/transfer-params. No default: when unset, those endpoints
+# fail visibly with 503 rather than falling back to a public RPC.
+SOLANA_RPC_URL=
+
+# Max concurrent outbound Solana RPC requests (default: 256). Separate from
+# CHAIN_MAX_CONCURRENT_QUERIES — Solana RPC and the Nolus LCD saturate
+# independently.
+# SOLANA_MAX_CONCURRENT_QUERIES=256
+
+# =============================================================================
 # External API URLs (Required)
 # =============================================================================
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -42,6 +42,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,7 +106,7 @@ checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "axum-macros",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -161,6 +173,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -176,6 +194,15 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bip32"
@@ -201,6 +228,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,12 +269,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "sha2 0.10.9",
+ "tinyvec",
 ]
 
 [[package]]
@@ -234,10 +309,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "bv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8834bb1d8ee5dc048ee3124f2c7c1afcc6bc9aed03f11e9dfd8c69470a5db340"
+dependencies = [
+ "feature-probe",
+ "serde",
+]
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -345,6 +447,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,9 +464,21 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e23f6ab56d5f031cde05b8b82a5fefd3a1a223595c79e32317a97189e612bc"
 dependencies = [
- "prost",
+ "prost 0.12.6",
  "prost-types",
- "tendermint-proto",
+ "tendermint-proto 0.35.0",
+]
+
+[[package]]
+name = "cosmos-sdk-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "462e1f6a8e005acc8835d32d60cbd7973ed65ea2a8d8473830e675f050956427"
+dependencies = [
+ "informalsystems-pbjson",
+ "prost 0.13.5",
+ "serde",
+ "tendermint-proto 0.40.4",
 ]
 
 [[package]]
@@ -368,7 +488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d184abb7b0039cc64f282dfa5b34165e4c5a7410ab46804636d53f4d09aee44"
 dependencies = [
  "bip32",
- "cosmos-sdk-proto",
+ "cosmos-sdk-proto 0.21.1",
  "ecdsa",
  "eyre",
  "k256",
@@ -377,7 +497,7 @@ dependencies = [
  "serde_json",
  "signature",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.35.0",
  "thiserror 1.0.69",
 ]
 
@@ -386,6 +506,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -415,6 +544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +572,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rand_core 0.6.4",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +610,40 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle-ng",
  "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -483,6 +680,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "data-types-macros"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "ibc-core-host-types",
+ "tendermint 0.40.4",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,11 +718,43 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -661,6 +899,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "feature-probe"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,10 +915,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "five8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
+dependencies = [
+ "five8_core",
+]
+
+[[package]]
+name = "five8_const"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
+dependencies = [
+ "five8_core",
+]
+
+[[package]]
+name = "five8_core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059c31d7d36c43fe39d89e55711858b4da8be7eb6dabac23c7289b1a19489406"
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "static_assertions",
+]
 
 [[package]]
 name = "flate2"
@@ -1039,7 +1322,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1078,6 +1361,417 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "ibc-app-transfer"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "ibc-app-transfer-types",
+ "ibc-core",
+ "serde-json-wasm",
+]
+
+[[package]]
+name = "ibc-app-transfer-types"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core",
+ "ibc-proto",
+ "primitive-types",
+ "serde",
+ "uint",
+]
+
+[[package]]
+name = "ibc-client-tendermint"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "ibc-client-tendermint-types",
+ "ibc-core-client",
+ "ibc-core-commitment-types",
+ "ibc-core-handler-types",
+ "ibc-core-host",
+ "ibc-primitives",
+ "serde",
+ "tendermint 0.40.4",
+ "tendermint-light-client-verifier",
+]
+
+[[package]]
+name = "ibc-client-tendermint-types"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "borsh",
+ "displaydoc",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
+ "serde",
+ "tendermint 0.40.4",
+ "tendermint-light-client-verifier",
+ "tendermint-proto 0.40.4",
+]
+
+[[package]]
+name = "ibc-core"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "ibc-core-channel",
+ "ibc-core-client",
+ "ibc-core-commitment-types",
+ "ibc-core-connection",
+ "ibc-core-handler",
+ "ibc-core-host",
+ "ibc-core-router",
+ "ibc-derive",
+ "ibc-primitives",
+]
+
+[[package]]
+name = "ibc-core-channel"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "ibc-core-channel-types",
+ "ibc-core-client",
+ "ibc-core-commitment-types",
+ "ibc-core-connection",
+ "ibc-core-handler-types",
+ "ibc-core-host",
+ "ibc-core-router",
+ "ibc-primitives",
+]
+
+[[package]]
+name = "ibc-core-channel-types"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "borsh",
+ "data-types-macros",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-connection-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
+ "serde",
+ "sha2 0.10.9",
+ "subtle-encoding",
+ "tendermint 0.40.4",
+]
+
+[[package]]
+name = "ibc-core-client"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "ibc-core-client-context",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-handler-types",
+ "ibc-core-host",
+ "ibc-primitives",
+]
+
+[[package]]
+name = "ibc-core-client-context"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-handler-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "subtle-encoding",
+ "tendermint 0.40.4",
+]
+
+[[package]]
+name = "ibc-core-client-types"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "borsh",
+ "data-types-macros",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-commitment-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
+ "serde",
+ "subtle-encoding",
+ "tendermint 0.40.4",
+]
+
+[[package]]
+name = "ibc-core-commitment-types"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
+ "ics23",
+ "prost 0.13.5",
+ "serde",
+ "subtle-encoding",
+]
+
+[[package]]
+name = "ibc-core-connection"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "ibc-core-client",
+ "ibc-core-connection-types",
+ "ibc-core-handler-types",
+ "ibc-core-host",
+ "ibc-primitives",
+]
+
+[[package]]
+name = "ibc-core-connection-types"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "borsh",
+ "data-types-macros",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
+ "serde",
+ "subtle-encoding",
+ "tendermint 0.40.4",
+]
+
+[[package]]
+name = "ibc-core-handler"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "ibc-core-channel",
+ "ibc-core-client",
+ "ibc-core-commitment-types",
+ "ibc-core-connection",
+ "ibc-core-handler-types",
+ "ibc-core-host",
+ "ibc-core-router",
+ "ibc-primitives",
+]
+
+[[package]]
+name = "ibc-core-handler-types"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-channel-types",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-connection-types",
+ "ibc-core-host-types",
+ "ibc-core-router-types",
+ "ibc-primitives",
+ "ibc-proto",
+ "serde",
+ "subtle-encoding",
+ "tendermint 0.40.4",
+]
+
+[[package]]
+name = "ibc-core-host"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-channel-types",
+ "ibc-core-client-context",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-connection-types",
+ "ibc-core-handler-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "subtle-encoding",
+]
+
+[[package]]
+name = "ibc-core-host-types"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "base64 0.22.1",
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-primitives",
+ "prost 0.13.5",
+ "serde",
+]
+
+[[package]]
+name = "ibc-core-router"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router-types",
+ "ibc-primitives",
+ "subtle-encoding",
+]
+
+[[package]]
+name = "ibc-core-router-types"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
+ "serde",
+ "subtle-encoding",
+ "tendermint 0.40.4",
+]
+
+[[package]]
+name = "ibc-derive"
+version = "0.10.1"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ibc-primitives"
+version = "0.57.0"
+source = "git+https://github.com/nolus-protocol/ibc-rs.git?rev=0178f6e9e039000fd040781f03bff67c13d5c040#0178f6e9e039000fd040781f03bff67c13d5c040"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-proto",
+ "prost 0.13.5",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "ibc-proto"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b70f517162e74e2d35875b8b94bf4d1e45f2c69ef3de452dc855944455d33ca"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cosmos-sdk-proto 0.26.1",
+ "flex-error",
+ "ics23",
+ "informalsystems-pbjson",
+ "prost 0.13.5",
+ "serde",
+ "subtle-encoding",
+ "tendermint-proto 0.40.4",
+]
+
+[[package]]
+name = "ibc-solray"
+version = "0.0.1"
+source = "git+https://github.com/nolus-protocol/ibc-solray?rev=0462fb326b9b2b4d51b831c729893cc86192518f#0462fb326b9b2b4d51b831c729893cc86192518f"
+dependencies = [
+ "borsh",
+ "ibc-app-transfer",
+ "ibc-app-transfer-types",
+ "ibc-client-tendermint",
+ "ibc-core-channel",
+ "ibc-core-channel-types",
+ "ibc-core-client",
+ "ibc-core-client-context",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-connection",
+ "ibc-core-connection-types",
+ "ibc-core-handler-types",
+ "ibc-core-host",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-primitives",
+ "serde",
+ "serde_json",
+ "solana-account-info",
+ "solana-address 2.6.1",
+ "solana-address-lookup-table-interface",
+ "solana-cpi",
+ "solana-hash 4.5.0",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey 4.2.0",
+ "solana-rent",
+ "solana-sha256-hasher",
+ "solana-system-interface 3.2.0",
+ "solana-sysvar",
+ "spl-associated-token-account-interface",
+ "spl-token-interface",
+ "tendermint 0.35.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ics23"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b17f1a5bd7d12ad30a21445cfa5f52fd7651cb3243ba866f9916b1ec112f12"
+dependencies = [
+ "anyhow",
+ "blake2",
+ "blake3",
+ "bytes",
+ "hex",
+ "informalsystems-pbjson",
+ "prost 0.13.5",
+ "ripemd",
+ "serde",
+ "sha2 0.10.9",
+ "sha3",
 ]
 
 [[package]]
@@ -1162,6 +1856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-serde"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1907,16 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "informalsystems-pbjson"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa4a0980c8379295100d70854354e78df2ee1c6ca0f96ffe89afeb3140e3a3d"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
 ]
 
 [[package]]
@@ -1247,7 +1966,7 @@ version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -1265,7 +1984,18 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "once_cell",
  "sha2 0.10.9",
+ "signature",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1335,6 +2065,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,7 +2139,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bech32",
  "chrono",
  "cosmrs",
@@ -1409,14 +2148,16 @@ dependencies = [
  "futures",
  "governor",
  "http-body-util",
+ "ibc-solray",
  "jsonwebtoken",
  "lazy_static",
  "mini-moka",
- "prost",
+ "prost 0.12.6",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
+ "solana-pubkey 4.2.0",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -1458,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
@@ -1499,6 +2240,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1543,12 +2306,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -1611,6 +2380,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "impl-serde",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,7 +2415,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -1643,12 +2442,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -1734,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1859,7 +2671,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -1929,6 +2741,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2058,6 +2879,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-json-wasm"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05da0d153dd4595bdffd5099dc0e9ce425b205ee648eb93437ff7302af8c9a5"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,7 +2971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -2153,7 +2983,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -2165,8 +2995,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -2260,6 +3106,697 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-account-info"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
+dependencies = [
+ "bincode",
+ "serde_core",
+ "solana-address 2.6.1",
+ "solana-program-error",
+ "solana-program-memory",
+]
+
+[[package]]
+name = "solana-address"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
+dependencies = [
+ "solana-address 2.6.1",
+]
+
+[[package]]
+name = "solana-address"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c93e262f671bf402e1040e4a7e40b05d81da5956c7681948c975a0997517bb"
+dependencies = [
+ "borsh",
+ "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek",
+ "five8",
+ "five8_const",
+ "serde",
+ "serde_derive",
+ "sha2-const-stable",
+ "solana-atomic-u64",
+ "solana-define-syscall 5.1.0",
+ "solana-program-error",
+ "solana-sanitize",
+ "solana-sha256-hasher",
+ "wincode",
+]
+
+[[package]]
+name = "solana-address-lookup-table-interface"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115b4f773acc4f3f3cb986b0d335e9845c0368c82b0940410935bc11ae065578"
+dependencies = [
+ "bincode",
+ "bytemuck",
+ "serde",
+ "serde_derive",
+ "solana-clock",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-pubkey 4.2.0",
+ "solana-sdk-ids",
+ "solana-slot-hashes",
+]
+
+[[package]]
+name = "solana-atomic-u64"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "085db4906d89324cef2a30840d59eaecf3d4231c560ec7c9f6614a93c652f501"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "solana-big-mod-exp"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "solana-define-syscall 3.0.0",
+]
+
+[[package]]
+name = "solana-blake3-hasher"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7116e1d942a2432ca3f514625104757ab8a56233787e95144c93950029e31176"
+dependencies = [
+ "blake3",
+ "solana-define-syscall 4.0.1",
+ "solana-hash 4.5.0",
+]
+
+[[package]]
+name = "solana-borsh"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04abbae16f57178a163125805637b8a076175bb5c0002fb04f4792bea901cf7"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
+name = "solana-clock"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0acdace90d96e2c9e70d681465b4fe888b6bcf27c354ae9774e9f8a3b72923d"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-get-sysvar",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-cpi"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dea26709d867aada85d0d3617db0944215c8bb28d3745b912de7db13a23280c"
+dependencies = [
+ "solana-account-info",
+ "solana-define-syscall 4.0.1",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 4.2.0",
+ "solana-stable-layout",
+]
+
+[[package]]
+name = "solana-define-syscall"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
+
+[[package]]
+name = "solana-define-syscall"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
+
+[[package]]
+name = "solana-define-syscall"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
+
+[[package]]
+name = "solana-epoch-rewards"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf7eb4986b0b1d6f562b21f75a836f1a6df6e00c275efcef50aab5c144dc59e"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-get-sysvar",
+ "solana-hash 4.5.0",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-epoch-schedule"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8116e6ffa6002237d5ab5edcbda17f9ba66b6742c45a89c9fb40a94dbacd4c1d"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-get-sysvar",
+ "solana-program-error",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-epoch-stake"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027e6d0b9e7daac5b2ac7c3f9ca1b727861121d9ef05084cf435ff736051e7c2"
+dependencies = [
+ "solana-define-syscall 5.1.0",
+ "solana-pubkey 4.2.0",
+]
+
+[[package]]
+name = "solana-example-mocks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978855d164845c1b0235d4b4d101cadc55373fffaf0b5b6cfa2194d25b2ed658"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-address-lookup-table-interface",
+ "solana-clock",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-keccak-hasher",
+ "solana-message",
+ "solana-nonce",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-system-interface 2.0.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "solana-fee-calculator"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef67f01cc6a0c72e99a08d0d484683f995de4c80e9568728fa77d1537f9b7e09"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-get-sysvar"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef3bc859fc036ed490146793557386cbfae614ebba4adc704c37d94350824ed4"
+dependencies = [
+ "solana-address 2.6.1",
+ "solana-define-syscall 5.1.0",
+ "solana-program-error",
+]
+
+[[package]]
+name = "solana-hash"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
+dependencies = [
+ "solana-hash 4.5.0",
+]
+
+[[package]]
+name = "solana-hash"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f4c847893a2ea50b4ae3ca723b124e07cd0544fecea3598f785168f9b78333f"
+dependencies = [
+ "borsh",
+ "bytemuck",
+ "bytemuck_derive",
+ "five8",
+ "serde",
+ "serde_derive",
+ "solana-atomic-u64",
+ "solana-sanitize",
+]
+
+[[package]]
+name = "solana-instruction"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
+dependencies = [
+ "bincode",
+ "borsh",
+ "serde",
+ "serde_derive",
+ "solana-define-syscall 5.1.0",
+ "solana-instruction-error",
+ "solana-pubkey 4.2.0",
+]
+
+[[package]]
+name = "solana-instruction-error"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7d34343838343a3755b7dfb1e438d94c6db2263b519cfe3c2257af932b6e93"
+dependencies = [
+ "num-traits",
+ "solana-program-error",
+]
+
+[[package]]
+name = "solana-instructions-sysvar"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0732294560e88ecdb2bbc656e67383e9f88c78ec09469cef172f0d28cd1bcd"
+dependencies = [
+ "bitflags",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-program-error",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-serialize-utils",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-keccak-hasher"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed1c0d16d6fdeba12291a1f068cdf0d479d9bff1141bf44afd7aa9d485f65ef8"
+dependencies = [
+ "sha3",
+ "solana-define-syscall 4.0.1",
+ "solana-hash 4.5.0",
+]
+
+[[package]]
+name = "solana-last-restart-slot"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22474b83d3c7c318e1c3a725784fc2d1d03b728e36369e58ce48769a61ed85e"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-get-sysvar",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-message"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0448b1fd891c5f46491e5dc7d9986385ba3c852c340db2911dd29faa01d2b08d"
+dependencies = [
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-address 2.6.1",
+ "solana-hash 4.5.0",
+ "solana-instruction",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-short-vec",
+ "solana-transaction-error",
+]
+
+[[package]]
+name = "solana-msg"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
+dependencies = [
+ "solana-define-syscall 5.1.0",
+]
+
+[[package]]
+name = "solana-native-token"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
+
+[[package]]
+name = "solana-nonce"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4172d5b33a0a38fcdb2af8f84406570dd51567267da96c28ad0f31fc11621c0"
+dependencies = [
+ "solana-fee-calculator",
+ "solana-hash 4.5.0",
+ "solana-pubkey 4.2.0",
+ "solana-sha256-hasher",
+]
+
+[[package]]
+name = "solana-program"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91b12305dd81045d705f427acd0435a2e46444b65367d7179d7bdcfc3bc5f5eb"
+dependencies = [
+ "memoffset",
+ "solana-account-info",
+ "solana-big-mod-exp",
+ "solana-blake3-hasher",
+ "solana-borsh",
+ "solana-clock",
+ "solana-cpi",
+ "solana-define-syscall 3.0.0",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-epoch-stake",
+ "solana-example-mocks",
+ "solana-fee-calculator",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-instructions-sysvar",
+ "solana-keccak-hasher",
+ "solana-last-restart-slot",
+ "solana-msg",
+ "solana-native-token",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-secp256k1-recover",
+ "solana-serde-varint",
+ "solana-serialize-utils",
+ "solana-sha256-hasher",
+ "solana-short-vec",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-stable-layout",
+ "solana-sysvar",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-program-entrypoint"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c9b0a1ff494e05f503a08b3d51150b73aa639544631e510279d6375f290997"
+dependencies = [
+ "solana-account-info",
+ "solana-define-syscall 4.0.1",
+ "solana-program-error",
+ "solana-pubkey 4.2.0",
+]
+
+[[package]]
+name = "solana-program-error"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
+dependencies = [
+ "borsh",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-program-memory"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4068648649653c2c50546e9a7fb761791b5ab0cda054c771bb5808d3a4b9eb52"
+dependencies = [
+ "solana-define-syscall 4.0.1",
+]
+
+[[package]]
+name = "solana-program-option"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a88006a9b8594088cec9027ab77caaaa258a2aaa2083d3f086c44b42e50aeab"
+
+[[package]]
+name = "solana-program-pack"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7701cb15b90667ae1c89ef4ac35a59c61e66ce58ddee13d729472af7f41d59"
+dependencies = [
+ "solana-program-error",
+]
+
+[[package]]
+name = "solana-pubkey"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
+dependencies = [
+ "solana-address 1.1.0",
+]
+
+[[package]]
+name = "solana-pubkey"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
+dependencies = [
+ "solana-address 2.6.1",
+]
+
+[[package]]
+name = "solana-rent"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e860d5499a705369778647e97d760f7670adfb6fc8419dd3d568deccd46d5487"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-sanitize"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
+
+[[package]]
+name = "solana-sdk-ids"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
+dependencies = [
+ "solana-address 2.6.1",
+]
+
+[[package]]
+name = "solana-sdk-macro"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8765316242300c48242d84a41614cb3388229ec353ba464f6fe62a733e41806f"
+dependencies = [
+ "bs58",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "solana-secp256k1-recover"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a1ad3ed7846631c88c71c5d2f21a2ecb6b61da333d9be173b6b061b35609ae"
+dependencies = [
+ "k256",
+ "solana-define-syscall 5.1.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "solana-serde-varint"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950e5b83e839dc0f92c66afc124bb8f40e89bc90f0579e8ec5499296d27f54e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "solana-serialize-utils"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761357b0853c9623bf12c1d2314b3d6160a85b087b84c45224fb85766d22616b"
+dependencies = [
+ "solana-instruction-error",
+ "solana-pubkey 4.2.0",
+ "solana-sanitize",
+]
+
+[[package]]
+name = "solana-sha256-hasher"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
+dependencies = [
+ "sha2 0.10.9",
+ "solana-define-syscall 4.0.1",
+ "solana-hash 4.5.0",
+]
+
+[[package]]
+name = "solana-short-vec"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8250a4495aad49ad20556a607da53bdcb20de78da10b65afbf918b7f1de647"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "solana-slot-hashes"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7ce2b4b8911bf2db3de7b6266e67bfc21a6a9f8c566fb096d9782ca2ad16ee"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-get-sysvar",
+ "solana-hash 4.5.0",
+ "solana-sdk-ids",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-slot-history"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40427c04d3e808493cb5e3d1a97cef84d7c15cb6f89b15c5684d0d4027105600"
+dependencies = [
+ "bv",
+ "serde",
+ "serde_derive",
+ "solana-get-sysvar",
+ "solana-sdk-ids",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-stable-layout"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9f6a291ba063a37780af29e7db14bdd3dc447584d8ba5b3fc4b88e2bbc982fa"
+dependencies = [
+ "solana-instruction",
+ "solana-pubkey 4.2.0",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1790547bfc3061f1ee68ea9d8dc6c973c02a163697b24263a8e9f2e6d4afa2"
+dependencies = [
+ "num-traits",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b54965bf0b76fa8e2b35376583efddd4d916618cfe595bf48c7d7b55a9e628"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-address 2.6.1",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+]
+
+[[package]]
+name = "solana-sysvar"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6690d3dd88f15c21edff68eb391ef8800df7a1f5cec84ee3e8d1abf05affdf74"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "bytemuck",
+ "bytemuck_derive",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-account-info",
+ "solana-clock",
+ "solana-define-syscall 4.0.1",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
+ "solana-hash 4.5.0",
+ "solana-instruction",
+ "solana-last-restart-slot",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-pubkey 4.2.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-sysvar-id"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
+dependencies = [
+ "solana-address 2.6.1",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-transaction-error"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a949797bc1ac31836d0070e791083028a8c2e0d493fa4cf51c0bed7a04c65c22"
+dependencies = [
+ "solana-instruction-error",
+ "solana-sanitize",
+]
+
+[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,10 +3816,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-associated-token-account-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6433917b60441d68d99a17e121d9db0ea15a9a69c0e5afa34649cf5ba12612f"
+dependencies = [
+ "solana-instruction",
+ "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "spl-token-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c564ac05a7c8d8b12e988a37d82695b5ba4db376d07ea98bc4882c81f96c7f3"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2307,9 +3886,9 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2370,7 +3949,7 @@ dependencies = [
  "k256",
  "num-traits",
  "once_cell",
- "prost",
+ "prost 0.12.6",
  "prost-types",
  "ripemd",
  "serde",
@@ -2381,9 +3960,50 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.35.0",
  "time",
  "zeroize",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc997743ecfd4864bbca8170d68d9b2bee24653b034210752c2d883ef4b838b1"
+dependencies = [
+ "bytes",
+ "digest 0.10.7",
+ "ed25519",
+ "ed25519-consensus",
+ "flex-error",
+ "futures",
+ "num-traits",
+ "once_cell",
+ "prost 0.13.5",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.10.9",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto 0.40.4",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint-light-client-verifier"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548421907264a3a580634d71459a6ceda0dc569f24c9675adfab17465edf8511"
+dependencies = [
+ "derive_more 0.99.20",
+ "flex-error",
+ "serde",
+ "tendermint 0.40.4",
+ "time",
 ]
 
 [[package]]
@@ -2396,8 +4016,24 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost",
+ "prost 0.12.6",
  "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c40e13d39ca19082d8a7ed22de7595979350319833698f8b1080f29620a094"
+dependencies = [
+ "borsh",
+ "bytes",
+ "flex-error",
+ "prost 0.13.5",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -2455,30 +4091,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde_core",
+ "serde",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2586,6 +4222,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -2779,6 +4445,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,6 +4467,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3036,6 +4720,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "wincode"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror 2.0.18",
+ "wincode-derive",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ab90b719560d0fda79c74550ad1c948d17b118765942838055ebaf34d67071"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,13 +4960,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -64,6 +64,18 @@ cosmrs = { version = "0.16", features = ["cosmwasm"] }
 base64 = "0.22"
 prost = "0.12"
 
+# Solana IBC SDK: PDA/ATA derivation, instruction builders, packet-PDA
+# decoders. Pinned by commit rev (upstream cuts no semver tags); `sdk` feature
+# only — `engine-jupiter` would pull `remote_lease_wire`, whose rustc >= 1.94
+# floor conflicts with Solana's bundled BPF toolchain and which the webapp
+# never touches (relayer-gated path).
+ibc-solray = { git = "https://github.com/nolus-protocol/ibc-solray", rev = "0462fb326b9b2b4d51b831c729893cc86192518f", default-features = false, features = ["sdk"] }
+
+# Solana public-key type: base58/ed25519-pubkey validation and PDA derivation.
+# Version pinned to match the one `ibc-solray` resolves so their `Pubkey` types
+# unify.
+solana-pubkey = "4"
+
 # Regex for placeholder validation (translations)
 regex = "1"
 lazy_static = "1"

--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -3030,6 +3030,111 @@
         }
       }
     },
+    "/api/solana/balances/{address}": {
+      "get": {
+        "tags": [
+          "solana"
+        ],
+        "summary": "Get Solana wallet balances",
+        "description": "Returns the native SOL balance plus SPL balances for the SOLANA protocol's\ncurrency set (mints resolved from each currency's `dex_symbol`), keyed by a\nbase58 wallet address. A funded wallet returns its holdings; an unfunded\nwallet returns a zero SOL balance and an empty token list. Only a malformed\naddress returns a typed error.",
+        "operationId": "get_solana_balances",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "description": "Base58 Solana wallet address",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Solana wallet balances",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SolanaBalancesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Solana RPC error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Solana RPC unconfigured or cache cold",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/solana/transfer-params": {
+      "get": {
+        "tags": [
+          "solana"
+        ],
+        "summary": "Get Solana transfer-timeout parameters",
+        "description": "Serves the fresh current slot and epoch a client needs to build a height-\nbased `MsgTransfer` timeout, plus the program's lifetime bound. The Solana\nprogram rejects timestamp-only timeouts, so a client must set a\n`timeout_height` with `revision_number = revision_number` and\n`revision_height` in `(slot, max_timeout_height]`. Never cached.",
+        "operationId": "get_solana_transfer_params",
+        "responses": {
+          "200": {
+            "description": "Fresh Solana transfer-timeout parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SolanaTransferParamsResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Solana RPC error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Solana RPC unconfigured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/staking/claim-rewards": {
       "post": {
         "tags": [
@@ -7497,6 +7602,107 @@
         ],
         "description": "One transaction in a Skip messages response. A cosmos transaction is typed;\nother transaction kinds (e.g. `evm_tx`) and extra fields ride in `additional`."
       },
+      "SolanaBalanceInfo": {
+        "type": "object",
+        "description": "A single Solana balance entry.",
+        "required": [
+          "symbol",
+          "amount",
+          "decimal_digits"
+        ],
+        "properties": {
+          "key": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Currency key (`TICKER@PROTOCOL`) when the balance maps to a provisioned\nSOLANA-protocol currency; `None` for native SOL."
+          },
+          "symbol": {
+            "type": "string",
+            "description": "Human ticker/symbol (e.g. `SOL`, `USDC`)."
+          },
+          "mint": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "SPL mint address; `None` for native SOL."
+          },
+          "amount": {
+            "type": "string",
+            "description": "Raw on-chain amount in base units (lamports for SOL), as a string."
+          },
+          "decimal_digits": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Decimal places for the base-unit amount.",
+            "minimum": 0
+          }
+        }
+      },
+      "SolanaBalancesResponse": {
+        "type": "object",
+        "description": "SOL + SPL balances for a Solana wallet.",
+        "required": [
+          "address",
+          "sol",
+          "tokens"
+        ],
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "The queried base58 wallet address, echoed back."
+          },
+          "sol": {
+            "$ref": "#/components/schemas/SolanaBalanceInfo",
+            "description": "Native SOL balance (lamports; 9 decimals)."
+          },
+          "tokens": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SolanaBalanceInfo"
+            },
+            "description": "SPL balances for the SOLANA-protocol currency set. Empty when the wallet\nholds none of the provisioned mints — a legitimate result, not an error."
+          }
+        }
+      },
+      "SolanaTransferParamsResponse": {
+        "type": "object",
+        "description": "Fresh Solana height data for building an IBC `MsgTransfer` timeout height.",
+        "required": [
+          "slot",
+          "revision_number",
+          "max_lifetime_slots",
+          "max_timeout_height"
+        ],
+        "properties": {
+          "slot": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Current absolute Solana slot — the `revision_height` reference a client\nbases its `timeout_height` on. Fetched fresh per request (never cached);\na stale slot would silently shorten the usable timeout window.",
+            "minimum": 0
+          },
+          "revision_number": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Current Solana epoch — the `revision_number` the program's host height\ncarries. A packet `timeout_height` must use this revision number.",
+            "minimum": 0
+          },
+          "max_lifetime_slots": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum slots past the current slot a packet `timeout_height` may extend\nbefore the recv chokepoint rejects it (~24h at 2 slots/s).",
+            "minimum": 0
+          },
+          "max_timeout_height": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Convenience upper bound: `slot + max_lifetime_slots`. A client may set its\ntimeout height's `revision_height` up to this value (inclusive).",
+            "minimum": 0
+          }
+        }
+      },
       "StakingParams": {
         "type": "object",
         "required": [
@@ -8332,6 +8538,10 @@
     {
       "name": "balances",
       "description": "Wallet balances"
+    },
+    {
+      "name": "solana",
+      "description": "Solana balances and transfer-timeout parameters"
     },
     {
       "name": "protocols",

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -85,6 +85,11 @@ pub struct ExternalApiConfig {
     pub nolus_rpc_url: String,
     pub nolus_rest_url: String,
 
+    // Solana RPC (optional): the operator's Solana JSON-RPC endpoint. Unset ->
+    // Solana endpoints (balances, transfer-params) fail visibly with 503; no
+    // silent fallback URL.
+    pub solana_rpc_url: Option<String>,
+
     // Authenticated APIs - Referral
     pub referral_api_url: String,
     pub referral_api_token: String,
@@ -225,6 +230,13 @@ impl AppConfig {
                 .push("Skip API key not configured - swap routing may be rate limited".to_string());
         }
 
+        if self.external.solana_rpc_url.is_none() {
+            warnings.push(
+                "Solana RPC not configured - Solana balance/transfer-params endpoints will return 503"
+                    .to_string(),
+            );
+        }
+
         ValidationResult { errors, warnings }
     }
 
@@ -264,6 +276,9 @@ impl AppConfig {
             // Chain RPCs & REST (only Nolus required)
             nolus_rpc_url,
             nolus_rest_url,
+
+            // Solana RPC (optional — no default; absent means Solana disabled)
+            solana_rpc_url: env::var("SOLANA_RPC_URL").ok().filter(|v| !v.is_empty()),
 
             // Authenticated - Referral
             referral_api_url: env::var("REFERRAL_API_URL").unwrap_or_else(|_err| String::new()),
@@ -331,6 +346,7 @@ mod tests {
                 skip_api_key: None,
                 nolus_rpc_url: "https://rpc.nolus.network".to_string(),
                 nolus_rest_url: "https://lcd.nolus.network".to_string(),
+                solana_rpc_url: Some("https://solana-rpc.example.com".to_string()),
                 referral_api_url: String::new(),
                 referral_api_token: String::new(),
                 zero_interest_api_url: String::new(),

--- a/backend/src/external/mod.rs
+++ b/backend/src/external/mod.rs
@@ -4,4 +4,5 @@ pub mod etl;
 pub mod intercom;
 pub mod referral;
 pub mod skip;
+pub mod solana;
 pub mod zero_interest;

--- a/backend/src/external/solana.rs
+++ b/backend/src/external/solana.rs
@@ -1,0 +1,934 @@
+//! Solana JSON-RPC client for direct queries against the operator's Solana RPC.
+//!
+//! Solana RPC is JSON-RPC 2.0 (all-POST, `method` + `params` body), so it does
+//! not fit the [`crate::external::base_client::ExternalApiClient`]
+//! GET/endpoint-string trait. It instead mirrors [`crate::external::chain`]'s
+//! bespoke shape: its own bounded-concurrency semaphore, its own 429/503 retry
+//! with exponential backoff, and typed [`AppError`] mapping. Solana RPC and the
+//! Nolus LCD are independent upstreams, so this client keeps a *separate*
+//! semaphore/env var rather than sharing the chain client's. No raw RPC proxy
+//! is exposed to the frontend.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::Client;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tokio::sync::Semaphore;
+use tracing::warn;
+
+use crate::error::AppError;
+
+/// Chain label embedded in `AppError::ChainRpc` for Solana upstream failures.
+const CHAIN: &str = "solana";
+
+/// Commitment level requested on every read. `confirmed` trades a small
+/// freshness lag for far fewer rollbacks than `processed`, matching the read
+/// semantics the balances and transfer-params endpoints need.
+const COMMITMENT: &str = "confirmed";
+
+/// Default cap on concurrent outbound Solana RPC requests. Prevents burst
+/// overload on cold start and refresh cycles. Override with
+/// `SOLANA_MAX_CONCURRENT_QUERIES`.
+const DEFAULT_MAX_CONCURRENT_SOLANA_QUERIES: usize = 256;
+
+/// Maximum retries for transient HTTP errors (429, 503).
+const MAX_RETRIES: u32 = 3;
+
+/// Initial backoff delay in milliseconds before the first retry.
+const INITIAL_BACKOFF_MS: u64 = 100;
+
+/// HTTP status codes that trigger retry with backoff.
+const RETRYABLE_STATUS_CODES: [u16; 2] = [429, 503];
+
+/// Milliseconds per second, for `Retry-After` (seconds) → millisecond conversion.
+const MS_PER_SEC: u64 = 1000;
+
+/// Cap on upstream error text embedded in a `ChainRpc` message. RPC error
+/// messages and bodies can echo request input (e.g. an address carried in
+/// `params`), so an unbounded copy would flow uncapped into the client error
+/// envelope and server logs.
+const ERROR_BODY_MAX_CHARS: usize = 256;
+
+/// Read `SOLANA_MAX_CONCURRENT_QUERIES`, falling back to the default. Mirrors
+/// [`crate::external::chain`]'s concurrency reader.
+fn solana_query_concurrency() -> usize {
+    std::env::var("SOLANA_MAX_CONCURRENT_QUERIES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_MAX_CONCURRENT_SOLANA_QUERIES)
+}
+
+/// Cap `body` at `ERROR_BODY_MAX_CHARS` characters, cutting on a char boundary.
+fn truncate_error_body(body: &str) -> &str {
+    body.char_indices()
+        .nth(ERROR_BODY_MAX_CHARS)
+        .map_or(body, |(boundary, _char)| &body[..boundary])
+}
+
+/// Jitter using system-time nanoseconds (no `rand` crate). Mirrors
+/// [`crate::external::chain`]'s jitter helper so the two clients share retry
+/// behavior without one depending on the other's internals.
+fn rand_jitter(max: u64) -> u64 {
+    if max == 0 {
+        return 0;
+    }
+    let nanos = u64::from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos(),
+    );
+    nanos % max
+}
+
+/// Filter for `getTokenAccountsByOwner`: exactly one of a specific mint or an
+/// owning token program, per the RPC's `RpcTokenAccountsFilter`.
+pub enum TokenAccountsFilter {
+    /// Match token accounts holding this mint (finds the account regardless of
+    /// which token program owns it — classic SPL Token or Token-2022).
+    Mint(String),
+    /// Match all token accounts owned by this token program.
+    ProgramId(String),
+}
+
+/// A parsed SPL token balance from `getTokenAccountsByOwner`.
+#[derive(Debug, Clone)]
+pub struct SolanaTokenBalance {
+    pub mint: String,
+    /// Raw amount in the mint's base units, as a decimal string.
+    pub amount: String,
+    pub decimals: u8,
+}
+
+/// `getLatestBlockhash` value.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SolanaLatestBlockhash {
+    pub blockhash: String,
+    #[serde(rename = "lastValidBlockHeight")]
+    pub last_valid_block_height: u64,
+}
+
+/// `getEpochInfo` result. Carries the current absolute slot and epoch in one
+/// atomic call — the transfer-params endpoint needs both fresh together.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SolanaEpochInfo {
+    #[serde(rename = "absoluteSlot")]
+    pub absolute_slot: u64,
+    pub epoch: u64,
+}
+
+/// A Solana account as returned by `getAccountInfo` with `base64` encoding.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SolanaAccount {
+    pub lamports: u64,
+    pub owner: String,
+    pub executable: bool,
+    /// `[base64_payload, "base64"]` under the `base64` encoding.
+    pub data: Vec<String>,
+}
+
+/// `simulateTransaction` value.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SolanaSimulationResult {
+    /// `None` on success; a structured transaction error otherwise.
+    pub err: Option<Value>,
+    pub logs: Option<Vec<String>>,
+    #[serde(rename = "unitsConsumed")]
+    pub units_consumed: Option<u64>,
+}
+
+/// A single entry from `getSignatureStatuses`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SolanaSignatureStatus {
+    pub slot: u64,
+    pub confirmations: Option<u64>,
+    #[serde(rename = "confirmationStatus")]
+    pub confirmation_status: Option<String>,
+    pub err: Option<Value>,
+}
+
+/// JSON-RPC 2.0 client for the operator's Solana RPC endpoint.
+#[derive(Clone)]
+pub struct SolanaClient {
+    /// `None` when `SOLANA_RPC_URL` is unset — every call then fails visibly
+    /// with `AppError::ServiceUnavailable` rather than a silent fallback.
+    rpc_url: Option<String>,
+    client: Client,
+    query_semaphore: Arc<Semaphore>,
+}
+
+/// The context wrapper Solana wraps most read results in: `{context, value}`.
+#[derive(Deserialize)]
+struct RpcContextValue<T> {
+    value: T,
+}
+
+/// JSON-RPC error object.
+#[derive(Deserialize)]
+struct RpcError {
+    code: i64,
+    message: String,
+}
+
+/// JSON-RPC 2.0 response envelope.
+#[derive(Deserialize)]
+struct RpcEnvelope<T> {
+    result: Option<T>,
+    error: Option<RpcError>,
+}
+
+impl SolanaClient {
+    pub fn new(rpc_url: Option<String>, client: Client) -> Self {
+        Self {
+            rpc_url,
+            client,
+            query_semaphore: Arc::new(Semaphore::new(solana_query_concurrency())),
+        }
+    }
+
+    /// Whether a Solana RPC endpoint is configured. When `false`, every query
+    /// returns `AppError::ServiceUnavailable`.
+    pub const fn is_configured(&self) -> bool {
+        self.rpc_url.is_some()
+    }
+
+    /// Execute a JSON-RPC call and return the raw `result`.
+    ///
+    /// Acquires a semaphore permit held across the full retry chain; retries
+    /// 429/503 with exponential backoff + jitter (honoring `Retry-After`); maps
+    /// transport failures, non-2xx responses, and JSON-RPC `error` objects to
+    /// typed [`AppError::ChainRpc`].
+    async fn request<R: DeserializeOwned>(
+        &self,
+        method: &str,
+        params: Value,
+    ) -> Result<R, AppError> {
+        let url = self
+            .rpc_url
+            .as_deref()
+            .ok_or_else(|| AppError::ServiceUnavailable {
+                message: "Solana RPC not configured (set SOLANA_RPC_URL)".to_string(),
+            })?;
+
+        let _permit = self
+            .query_semaphore
+            .acquire()
+            .await
+            .map_err(|e| AppError::Internal(format!("Semaphore closed: {e}")))?;
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params,
+        });
+
+        let mut backoff_ms = INITIAL_BACKOFF_MS;
+
+        for attempt in 0..=MAX_RETRIES {
+            let response = self
+                .client
+                .post(url)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| AppError::ChainRpc {
+                    chain: CHAIN.to_string(),
+                    message: format!("Request failed: {e}"),
+                })?;
+
+            let status = response.status().as_u16();
+
+            if !RETRYABLE_STATUS_CODES.contains(&status) {
+                return Self::parse_envelope(response, method).await;
+            }
+
+            if attempt == MAX_RETRIES {
+                let body_text = response.text().await.unwrap_or_default();
+                return Err(AppError::ChainRpc {
+                    chain: CHAIN.to_string(),
+                    message: format!(
+                        "{method}: HTTP {status} after {MAX_RETRIES} retries: {}",
+                        truncate_error_body(&body_text)
+                    ),
+                });
+            }
+
+            let retry_after_ms = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(|secs| secs * MS_PER_SEC);
+
+            let wait_ms = retry_after_ms.unwrap_or(backoff_ms);
+            let actual_wait = wait_ms + rand_jitter(wait_ms / 4);
+
+            warn!(
+                "Solana RPC {} got HTTP {}, retry {}/{} after {}ms",
+                method,
+                status,
+                attempt + 1,
+                MAX_RETRIES,
+                actual_wait
+            );
+
+            tokio::time::sleep(Duration::from_millis(actual_wait)).await;
+            backoff_ms *= 2;
+        }
+
+        // The `attempt == MAX_RETRIES` branch returns on the final iteration, so
+        // this is only reached if the retry invariant is ever broken.
+        Err(AppError::ChainRpc {
+            chain: CHAIN.to_string(),
+            message: format!("{method}: retry loop exhausted after {MAX_RETRIES} retries"),
+        })
+    }
+
+    /// Parse a non-retryable response into `R`, mapping HTTP and JSON-RPC-level
+    /// failures to typed errors.
+    async fn parse_envelope<R: DeserializeOwned>(
+        response: reqwest::Response,
+        method: &str,
+    ) -> Result<R, AppError> {
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(AppError::ChainRpc {
+                chain: CHAIN.to_string(),
+                message: format!("{method}: HTTP {status}: {}", truncate_error_body(&body)),
+            });
+        }
+
+        let envelope: RpcEnvelope<R> = response.json().await.map_err(|e| AppError::ChainRpc {
+            chain: CHAIN.to_string(),
+            message: format!("{method}: failed to parse response: {e}"),
+        })?;
+
+        if let Some(err) = envelope.error {
+            return Err(AppError::ChainRpc {
+                chain: CHAIN.to_string(),
+                message: format!(
+                    "{method}: RPC error {}: {}",
+                    err.code,
+                    truncate_error_body(&err.message)
+                ),
+            });
+        }
+
+        envelope.result.ok_or_else(|| AppError::ChainRpc {
+            chain: CHAIN.to_string(),
+            message: format!("{method}: response missing both result and error"),
+        })
+    }
+
+    /// Current epoch info (absolute slot + epoch), fetched atomically.
+    pub async fn get_epoch_info(&self) -> Result<SolanaEpochInfo, AppError> {
+        self.request("getEpochInfo", json!([{ "commitment": COMMITMENT }]))
+            .await
+    }
+
+    /// Native SOL balance, in lamports.
+    pub async fn get_balance(&self, address: &str) -> Result<u64, AppError> {
+        let wrapped: RpcContextValue<u64> = self
+            .request("getBalance", json!([address, { "commitment": COMMITMENT }]))
+            .await?;
+        Ok(wrapped.value)
+    }
+
+    /// Latest blockhash and its last valid block height.
+    pub async fn get_latest_blockhash(&self) -> Result<SolanaLatestBlockhash, AppError> {
+        let wrapped: RpcContextValue<SolanaLatestBlockhash> = self
+            .request("getLatestBlockhash", json!([{ "commitment": COMMITMENT }]))
+            .await?;
+        Ok(wrapped.value)
+    }
+
+    /// SPL token balances owned by `owner` matching `filter`, parsed via the
+    /// RPC's `jsonParsed` encoding.
+    pub async fn get_token_accounts_by_owner(
+        &self,
+        owner: &str,
+        filter: &TokenAccountsFilter,
+    ) -> Result<Vec<SolanaTokenBalance>, AppError> {
+        let filter_json = match filter {
+            TokenAccountsFilter::Mint(mint) => json!({ "mint": mint }),
+            TokenAccountsFilter::ProgramId(program_id) => json!({ "programId": program_id }),
+        };
+
+        #[derive(Deserialize)]
+        struct Accounts {
+            account: AccountData,
+        }
+        #[derive(Deserialize)]
+        struct AccountData {
+            data: ParsedData,
+        }
+        #[derive(Deserialize)]
+        struct ParsedData {
+            parsed: Parsed,
+        }
+        #[derive(Deserialize)]
+        struct Parsed {
+            info: TokenInfo,
+        }
+        #[derive(Deserialize)]
+        struct TokenInfo {
+            mint: String,
+            #[serde(rename = "tokenAmount")]
+            token_amount: TokenAmount,
+        }
+        #[derive(Deserialize)]
+        struct TokenAmount {
+            amount: String,
+            decimals: u8,
+        }
+
+        let wrapped: RpcContextValue<Vec<Accounts>> = self
+            .request(
+                "getTokenAccountsByOwner",
+                json!([
+                    owner,
+                    filter_json,
+                    { "encoding": "jsonParsed", "commitment": COMMITMENT },
+                ]),
+            )
+            .await?;
+
+        Ok(wrapped
+            .value
+            .into_iter()
+            .map(|entry| SolanaTokenBalance {
+                mint: entry.account.data.parsed.info.mint,
+                amount: entry.account.data.parsed.info.token_amount.amount,
+                decimals: entry.account.data.parsed.info.token_amount.decimals,
+            })
+            .collect())
+    }
+
+    /// Fetch an account (base64 encoding). `None` when the account does not
+    /// exist — the token-account-existence (ATA) check.
+    pub async fn get_account_info(&self, address: &str) -> Result<Option<SolanaAccount>, AppError> {
+        let wrapped: RpcContextValue<Option<SolanaAccount>> = self
+            .request(
+                "getAccountInfo",
+                json!([address, { "encoding": "base64", "commitment": COMMITMENT }]),
+            )
+            .await?;
+        Ok(wrapped.value)
+    }
+
+    /// Fetch the raw account bytes of an address-lookup-table account. `None`
+    /// when the ALT account does not exist. Decoding the table into its address
+    /// list is left to the versioned-transaction builder that will consume it.
+    pub async fn get_address_lookup_table(
+        &self,
+        address: &str,
+    ) -> Result<Option<Vec<u8>>, AppError> {
+        let Some(account) = self.get_account_info(address).await? else {
+            return Ok(None);
+        };
+        let encoded = account.data.first().ok_or_else(|| AppError::ChainRpc {
+            chain: CHAIN.to_string(),
+            message: "address lookup table account carries no data".to_string(),
+        })?;
+        let bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, encoded)
+            .map_err(|e| AppError::ChainRpc {
+                chain: CHAIN.to_string(),
+                message: format!("failed to decode ALT account data: {e}"),
+            })?;
+        Ok(Some(bytes))
+    }
+
+    /// Simulate a base64-encoded transaction without broadcasting it.
+    pub async fn simulate_transaction(
+        &self,
+        transaction_base64: &str,
+    ) -> Result<SolanaSimulationResult, AppError> {
+        let wrapped: RpcContextValue<SolanaSimulationResult> = self
+            .request(
+                "simulateTransaction",
+                json!([
+                    transaction_base64,
+                    { "encoding": "base64", "commitment": COMMITMENT },
+                ]),
+            )
+            .await?;
+        Ok(wrapped.value)
+    }
+
+    /// Broadcast a base64-encoded signed transaction, returning its signature.
+    /// The fallback submission path when a client cannot broadcast directly.
+    pub async fn send_raw_transaction(&self, transaction_base64: &str) -> Result<String, AppError> {
+        self.request(
+            "sendTransaction",
+            json!([transaction_base64, { "encoding": "base64" }]),
+        )
+        .await
+    }
+
+    /// Confirmation status for each requested signature (`None` per entry when
+    /// the signature is unknown to the node).
+    pub async fn get_signature_statuses(
+        &self,
+        signatures: &[String],
+    ) -> Result<Vec<Option<SolanaSignatureStatus>>, AppError> {
+        let wrapped: RpcContextValue<Vec<Option<SolanaSignatureStatus>>> = self
+            .request(
+                "getSignatureStatuses",
+                json!([signatures, { "searchTransactionHistory": false }]),
+            )
+            .await?;
+        Ok(wrapped.value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{body_partial_json, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn client_for(server: &MockServer) -> SolanaClient {
+        SolanaClient::new(Some(server.uri()), Client::new())
+    }
+
+    /// Mount a JSON-RPC response for a specific `method`, matched on the request
+    /// body so multiple methods can coexist on one mock server.
+    async fn mount_result(server: &MockServer, rpc_method: &str, result: Value) {
+        Mock::given(method("POST"))
+            .and(body_partial_json(json!({ "method": rpc_method })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": result,
+            })))
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn unconfigured_client_fails_visibly() {
+        let client = SolanaClient::new(None, Client::new());
+        assert!(!client.is_configured());
+        match client.get_epoch_info().await {
+            Err(AppError::ServiceUnavailable { message }) => {
+                assert!(message.contains("SOLANA_RPC_URL"), "message was: {message}");
+            }
+            other => panic!("expected ServiceUnavailable for unconfigured client, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_epoch_info_carries_slot_and_epoch() {
+        let server = MockServer::start().await;
+        mount_result(
+            &server,
+            "getEpochInfo",
+            json!({ "absoluteSlot": 250_000_000_u64, "epoch": 579, "blockHeight": 1 }),
+        )
+        .await;
+        let info = client_for(&server)
+            .get_epoch_info()
+            .await
+            .expect("epoch info");
+        assert_eq!(info.absolute_slot, 250_000_000);
+        assert_eq!(info.epoch, 579);
+    }
+
+    #[tokio::test]
+    async fn get_balance_unwraps_context_value() {
+        let server = MockServer::start().await;
+        mount_result(
+            &server,
+            "getBalance",
+            json!({ "context": { "slot": 1 }, "value": 42_000_000_u64 }),
+        )
+        .await;
+        let lamports = client_for(&server)
+            .get_balance("So11111111111111111111111111111111111111112")
+            .await
+            .expect("balance");
+        assert_eq!(lamports, 42_000_000);
+    }
+
+    #[tokio::test]
+    async fn get_token_accounts_parses_json_parsed_amounts() {
+        let server = MockServer::start().await;
+        mount_result(
+            &server,
+            "getTokenAccountsByOwner",
+            json!({
+                "context": { "slot": 1 },
+                "value": [
+                    {
+                        "pubkey": "AtaAddr1111111111111111111111111111111111111",
+                        "account": {
+                            "data": {
+                                "program": "spl-token",
+                                "parsed": {
+                                    "type": "account",
+                                    "info": {
+                                        "mint": "MintAddr11111111111111111111111111111111111",
+                                        "owner": "OwnerAddr1111111111111111111111111111111111",
+                                        "tokenAmount": {
+                                            "amount": "1500000",
+                                            "decimals": 6,
+                                            "uiAmountString": "1.5"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }),
+        )
+        .await;
+
+        let filter =
+            TokenAccountsFilter::Mint("MintAddr11111111111111111111111111111111111".into());
+        let balances = client_for(&server)
+            .get_token_accounts_by_owner("OwnerAddr1111111111111111111111111111111111", &filter)
+            .await
+            .expect("token accounts");
+        assert_eq!(balances.len(), 1);
+        assert_eq!(
+            balances[0].mint,
+            "MintAddr11111111111111111111111111111111111"
+        );
+        assert_eq!(balances[0].amount, "1500000");
+        assert_eq!(balances[0].decimals, 6);
+    }
+
+    #[tokio::test]
+    async fn get_account_info_maps_absent_account_to_none() {
+        let server = MockServer::start().await;
+        mount_result(
+            &server,
+            "getAccountInfo",
+            json!({ "context": { "slot": 1 }, "value": null }),
+        )
+        .await;
+        let account = client_for(&server)
+            .get_account_info("MissingAddr11111111111111111111111111111111")
+            .await
+            .expect("account info");
+        assert!(account.is_none());
+    }
+
+    #[tokio::test]
+    async fn json_rpc_error_object_maps_to_chain_rpc() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": { "code": -32602, "message": "Invalid params: bad address" },
+            })))
+            .mount(&server)
+            .await;
+
+        match client_for(&server).get_epoch_info().await {
+            Err(AppError::ChainRpc { chain, message }) => {
+                assert_eq!(chain, "solana");
+                assert!(message.contains("-32602"), "message was: {message}");
+                assert!(message.contains("Invalid params"), "message was: {message}");
+            }
+            other => panic!("expected ChainRpc for a JSON-RPC error object, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn retryable_status_exhausts_to_typed_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        match client_for(&server).get_epoch_info().await {
+            Err(AppError::ChainRpc { chain, message }) => {
+                assert_eq!(chain, "solana");
+                assert!(
+                    message.contains(&format!("{MAX_RETRIES} retries")),
+                    "expected retry count in message, got: {message}"
+                );
+            }
+            other => panic!("expected ChainRpc after retry exhaustion, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_then_success_recovers() {
+        // First response 503, then a good result: the bounded retry loop must
+        // recover rather than surface the transient failure.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        mount_result(
+            &server,
+            "getEpochInfo",
+            json!({ "absoluteSlot": 7_u64, "epoch": 1 }),
+        )
+        .await;
+
+        let info = client_for(&server)
+            .get_epoch_info()
+            .await
+            .expect("epoch info after retry");
+        assert_eq!(info.absolute_slot, 7);
+    }
+
+    /// Mount a JSON-RPC error object for `rpc_method`.
+    async fn mount_error(server: &MockServer, rpc_method: &str, code: i64, msg: &str) {
+        Mock::given(method("POST"))
+            .and(body_partial_json(json!({ "method": rpc_method })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": { "code": code, "message": msg },
+            })))
+            .mount(server)
+            .await;
+    }
+
+    /// Assert a result is a Solana `ChainRpc` error carrying `needle`.
+    fn assert_chain_rpc<T: std::fmt::Debug>(result: Result<T, AppError>, needle: &str) {
+        match result {
+            Err(AppError::ChainRpc { chain, message }) => {
+                assert_eq!(chain, "solana");
+                assert!(message.contains(needle), "message was: {message}");
+            }
+            other => panic!("expected ChainRpc carrying {needle:?}, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_latest_blockhash_parses_value() {
+        let server = MockServer::start().await;
+        mount_result(
+            &server,
+            "getLatestBlockhash",
+            json!({
+                "context": { "slot": 1 },
+                "value": { "blockhash": "Hash11111111111111111111111111111111111111", "lastValidBlockHeight": 321 },
+            }),
+        )
+        .await;
+        let latest = client_for(&server)
+            .get_latest_blockhash()
+            .await
+            .expect("blockhash");
+        assert_eq!(
+            latest.blockhash,
+            "Hash11111111111111111111111111111111111111"
+        );
+        assert_eq!(latest.last_valid_block_height, 321);
+    }
+
+    #[tokio::test]
+    async fn get_latest_blockhash_maps_rpc_error() {
+        let server = MockServer::start().await;
+        mount_error(&server, "getLatestBlockhash", -32000, "node behind").await;
+        assert_chain_rpc(
+            client_for(&server).get_latest_blockhash().await,
+            "node behind",
+        );
+    }
+
+    #[tokio::test]
+    async fn get_address_lookup_table_returns_decoded_bytes() {
+        let server = MockServer::start().await;
+        // "AQID" is base64 for [1, 2, 3].
+        mount_result(
+            &server,
+            "getAccountInfo",
+            json!({
+                "context": { "slot": 1 },
+                "value": {
+                    "lamports": 10,
+                    "owner": "AddressLookupTab1e1111111111111111111111111",
+                    "executable": false,
+                    "rentEpoch": 0,
+                    "data": ["AQID", "base64"],
+                },
+            }),
+        )
+        .await;
+        let bytes = client_for(&server)
+            .get_address_lookup_table("Tab1e11111111111111111111111111111111111111")
+            .await
+            .expect("alt fetch")
+            .expect("alt present");
+        assert_eq!(bytes, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn get_address_lookup_table_maps_rpc_error() {
+        let server = MockServer::start().await;
+        mount_error(&server, "getAccountInfo", -32000, "alt unavailable").await;
+        assert_chain_rpc(
+            client_for(&server)
+                .get_address_lookup_table("Tab1e11111111111111111111111111111111111111")
+                .await,
+            "alt unavailable",
+        );
+    }
+
+    #[tokio::test]
+    async fn simulate_transaction_parses_value() {
+        let server = MockServer::start().await;
+        mount_result(
+            &server,
+            "simulateTransaction",
+            json!({
+                "context": { "slot": 1 },
+                "value": { "err": null, "logs": ["Program log: ok"], "unitsConsumed": 4200 },
+            }),
+        )
+        .await;
+        let sim = client_for(&server)
+            .simulate_transaction("AQAB")
+            .await
+            .expect("simulation");
+        assert!(sim.err.is_none());
+        assert_eq!(sim.units_consumed, Some(4200));
+        assert_eq!(
+            sim.logs.as_deref(),
+            Some(&["Program log: ok".to_string()][..])
+        );
+    }
+
+    #[tokio::test]
+    async fn simulate_transaction_maps_rpc_error() {
+        let server = MockServer::start().await;
+        mount_error(&server, "simulateTransaction", -32602, "bad transaction").await;
+        assert_chain_rpc(
+            client_for(&server).simulate_transaction("AQAB").await,
+            "bad transaction",
+        );
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_returns_signature() {
+        let server = MockServer::start().await;
+        mount_result(
+            &server,
+            "sendTransaction",
+            json!("Sig1111111111111111111111111111111111111111"),
+        )
+        .await;
+        let signature = client_for(&server)
+            .send_raw_transaction("AQAB")
+            .await
+            .expect("signature");
+        assert_eq!(signature, "Sig1111111111111111111111111111111111111111");
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_maps_rpc_error() {
+        let server = MockServer::start().await;
+        mount_error(&server, "sendTransaction", -32003, "blockhash not found").await;
+        assert_chain_rpc(
+            client_for(&server).send_raw_transaction("AQAB").await,
+            "blockhash not found",
+        );
+    }
+
+    #[tokio::test]
+    async fn get_signature_statuses_parses_present_and_absent() {
+        let server = MockServer::start().await;
+        mount_result(
+            &server,
+            "getSignatureStatuses",
+            json!({
+                "context": { "slot": 1 },
+                "value": [
+                    { "slot": 100, "confirmations": 5, "confirmationStatus": "confirmed", "err": null },
+                    null,
+                ],
+            }),
+        )
+        .await;
+        let statuses = client_for(&server)
+            .get_signature_statuses(&["Sig1".to_string(), "Sig2".to_string()])
+            .await
+            .expect("statuses");
+        assert_eq!(statuses.len(), 2);
+        let present = statuses[0].as_ref().expect("first status present");
+        assert_eq!(present.slot, 100);
+        assert_eq!(present.confirmation_status.as_deref(), Some("confirmed"));
+        assert!(statuses[1].is_none());
+    }
+
+    #[tokio::test]
+    async fn get_signature_statuses_maps_rpc_error() {
+        let server = MockServer::start().await;
+        mount_error(
+            &server,
+            "getSignatureStatuses",
+            -32602,
+            "too many signatures",
+        )
+        .await;
+        assert_chain_rpc(
+            client_for(&server)
+                .get_signature_statuses(&["Sig1".to_string()])
+                .await,
+            "too many signatures",
+        );
+    }
+}
+
+/// Known-answer tests for the pinned `ibc-solray` SDK's PDA derivation.
+///
+/// These lock the pinned rev's on-chain address math: given the deployed Solray
+/// program id, deriving the Program and Vault-Authority PDAs through the SDK
+/// must yield these exact base58 addresses. A future pin bump that alters
+/// derivation (seed layout, program id) fails here rather than silently
+/// mis-addressing accounts. The vectors were produced by the pinned rev itself,
+/// so this both proves the `sdk`-feature build works off-chain and pins its
+/// output. A live-on-chain smoke test is a deploy-time concern needing a funded
+/// RPC; these fixed vectors cover the offline gate.
+#[cfg(test)]
+mod sdk_pin_tests {
+    use ibc_solray::api::{self, Id};
+    use solana_pubkey::Pubkey;
+    use std::str::FromStr as _;
+
+    /// The deployed Solray program id (base58), the derivation root for its PDAs.
+    const SOLRAY_PROGRAM_ID: &str = "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFF";
+    /// Program PDA derived from `SOLRAY_PROGRAM_ID` via `api::this_program_id`.
+    const EXPECTED_PROGRAM_PDA: &str = "2qoPsUrY5p5Khb1RninSiPuYBYDrrm4HqGsHKNW6yc9B";
+    /// Vault-Authority PDA derived from `SOLRAY_PROGRAM_ID`.
+    const EXPECTED_VAULT_AUTHORITY: &str = "FB9sB7fATJbiRETQw7gg497tipiHaMmdbhsxvCP8YVUY";
+
+    fn program() -> Pubkey {
+        Pubkey::from_str(SOLRAY_PROGRAM_ID).expect("solray program id parses")
+    }
+
+    #[test]
+    fn program_pda_matches_known_vector() {
+        let id = Id::find(program(), api::this_program_id());
+        let derived = id.derive_address();
+        assert_eq!(derived.to_string(), EXPECTED_PROGRAM_PDA);
+        // Round-trip: the found bump re-derives the same address off the seeds.
+        assert!(id.point_to(&derived));
+    }
+
+    #[test]
+    fn vault_authority_pda_matches_known_vector() {
+        let id = Id::find(program(), api::vault_authority_id());
+        let derived = id.derive_address();
+        assert_eq!(derived.to_string(), EXPECTED_VAULT_AUTHORITY);
+        assert!(id.point_to(&derived));
+    }
+}

--- a/backend/src/handlers/etl_proxy.rs
+++ b/backend/src/handlers/etl_proxy.rs
@@ -490,6 +490,7 @@ mod tests {
             etl_client,
             skip_client,
             chain_client,
+            solana_client: crate::external::solana::SolanaClient::new(None, http_client.clone()),
             referral_client,
             zero_interest_client,
             data_cache: crate::data_cache::AppDataCache::new(),

--- a/backend/src/handlers/governance.rs
+++ b/backend/src/handlers/governance.rs
@@ -691,6 +691,7 @@ mod tests {
             etl_client,
             skip_client,
             chain_client,
+            solana_client: crate::external::solana::SolanaClient::new(None, http_client.clone()),
             referral_client,
             zero_interest_client,
             data_cache: crate::data_cache::AppDataCache::new(),

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -15,6 +15,7 @@ pub mod locales;
 pub mod openapi;
 pub mod protocols;
 pub mod referral;
+pub mod solana;
 pub mod spa;
 pub mod staking;
 pub mod swap;

--- a/backend/src/handlers/openapi.rs
+++ b/backend/src/handlers/openapi.rs
@@ -19,8 +19,8 @@ use crate::error::{ErrorBody, ErrorResponse};
 use crate::external;
 use crate::handlers::{
     admin, common_types, config, currencies, earn, etl_proxy, fees, gated_assets, gated_networks,
-    gated_protocols, governance, leases, locales, protocols, referral, staking, swap, transactions,
-    zero_interest,
+    gated_protocols, governance, leases, locales, protocols, referral, solana, staking, swap,
+    transactions, zero_interest,
 };
 
 #[derive(OpenApi)]
@@ -51,6 +51,9 @@ use crate::handlers::{
         currencies::get_currency,
         currencies::get_prices,
         currencies::get_balances,
+        // Solana (balances + transfer-timeout params)
+        solana::get_solana_balances,
+        solana::get_solana_transfer_params,
         // Protocols
         protocols::get_protocols,
         protocols::get_active_protocols,
@@ -160,6 +163,10 @@ use crate::handlers::{
         currencies::PriceInfo,
         currencies::BalancesResponse,
         currencies::BalanceInfo,
+        // Solana
+        solana::SolanaBalancesResponse,
+        solana::SolanaBalanceInfo,
+        solana::SolanaTransferParamsResponse,
         // Protocols
         protocols::Protocol,
         protocols::ProtocolsResponse,
@@ -314,6 +321,7 @@ use crate::handlers::{
         (name = "currencies", description = "Supported currencies catalog"),
         (name = "prices", description = "Oracle price feeds"),
         (name = "balances", description = "Wallet balances"),
+        (name = "solana", description = "Solana balances and transfer-timeout parameters"),
         (name = "protocols", description = "Nolus DeFi sub-protocol registry"),
         (name = "locales", description = "Translation blobs for the frontend"),
         (name = "fees", description = "Gas fee configuration"),

--- a/backend/src/handlers/referral.rs
+++ b/backend/src/handlers/referral.rs
@@ -651,6 +651,7 @@ mod tests {
                 skip_api_key: None,
                 nolus_rpc_url: "http://127.0.0.1:1/".to_string(),
                 nolus_rest_url: "http://127.0.0.1:1/".to_string(),
+                solana_rpc_url: Some("http://127.0.0.1:1/".to_string()),
                 referral_api_url: "http://127.0.0.1:1/".to_string(),
                 referral_api_token: "".to_string(),
                 zero_interest_api_url: "http://127.0.0.1:1/".to_string(),

--- a/backend/src/handlers/solana.rs
+++ b/backend/src/handlers/solana.rs
@@ -1,0 +1,488 @@
+//! Solana balance and transfer-parameter handlers.
+//!
+//! Both endpoints are read-class (standard rate limit). They query the
+//! operator's Solana RPC through [`crate::external::solana::SolanaClient`] and
+//! surface typed [`AppError`]s: `400` for a malformed address, `502` for an RPC
+//! failure, `503` when Solana RPC is unconfigured or a cache is cold.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+use utoipa::ToSchema;
+
+use crate::error::AppError;
+use crate::external::solana::{SolanaEpochInfo, SolanaTokenBalance, TokenAccountsFilter};
+use crate::handlers::currencies::CurrencyInfo;
+use crate::AppState;
+
+/// Chain label embedded in `AppError::ChainRpc` for Solana upstream failures.
+const CHAIN: &str = "solana";
+
+/// Native SOL has 9 decimal places (1 SOL = 1e9 lamports).
+const SOL_DECIMALS: u8 = 9;
+
+/// Symbol reported for the native SOL balance entry.
+const SOL_SYMBOL: &str = "SOL";
+
+/// Network prefix in the `NETWORK-DEX-LPN` protocol identifier that marks a
+/// currency as belonging to the SOLANA protocol set.
+const SOLANA_PROTOCOL_PREFIX: &str = "SOLANA";
+
+/// Conservative upper bound, in Solana slots, on how far past the current slot
+/// an incoming packet's `timeout_height` may extend: 24h at the program's
+/// floored 2 slots/s (`24 * 3600 * 2`).
+///
+/// Mirrors ibc-solray's `api::timeout::MAX_LIFETIME_BLOCKS`, which is gated
+/// behind that crate's `program` feature and so is not importable by SDK
+/// consumers. The recv chokepoint rejects a packet whose `timeout_height`
+/// exceeds `host_height + MAX_LIFETIME_BLOCKS`, so a client must keep its chosen
+/// timeout height within this many slots of the current slot.
+const RECV_TIMEOUT_LIFETIME_SLOTS: u64 = 172_800;
+
+/// SOL + SPL balances for a Solana wallet.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct SolanaBalancesResponse {
+    /// The queried base58 wallet address, echoed back.
+    pub address: String,
+    /// Native SOL balance (lamports; 9 decimals).
+    pub sol: SolanaBalanceInfo,
+    /// SPL balances for the SOLANA-protocol currency set. Empty when the wallet
+    /// holds none of the provisioned mints — a legitimate result, not an error.
+    pub tokens: Vec<SolanaBalanceInfo>,
+}
+
+/// A single Solana balance entry.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SolanaBalanceInfo {
+    /// Currency key (`TICKER@PROTOCOL`) when the balance maps to a provisioned
+    /// SOLANA-protocol currency; `None` for native SOL.
+    pub key: Option<String>,
+    /// Human ticker/symbol (e.g. `SOL`, `USDC`).
+    pub symbol: String,
+    /// SPL mint address; `None` for native SOL.
+    pub mint: Option<String>,
+    /// Raw on-chain amount in base units (lamports for SOL), as a string.
+    pub amount: String,
+    /// Decimal places for the base-unit amount.
+    pub decimal_digits: u8,
+}
+
+/// Fresh Solana height data for building an IBC `MsgTransfer` timeout height.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct SolanaTransferParamsResponse {
+    /// Current absolute Solana slot — the `revision_height` reference a client
+    /// bases its `timeout_height` on. Fetched fresh per request (never cached);
+    /// a stale slot would silently shorten the usable timeout window.
+    pub slot: u64,
+    /// Current Solana epoch — the `revision_number` the program's host height
+    /// carries. A packet `timeout_height` must use this revision number.
+    pub revision_number: u64,
+    /// Maximum slots past the current slot a packet `timeout_height` may extend
+    /// before the recv chokepoint rejects it (~24h at 2 slots/s).
+    pub max_lifetime_slots: u64,
+    /// Convenience upper bound: `slot + max_lifetime_slots`. A client may set its
+    /// timeout height's `revision_height` up to this value (inclusive).
+    pub max_timeout_height: u64,
+}
+
+/// Get Solana wallet balances
+///
+/// Returns the native SOL balance plus SPL balances for the SOLANA protocol's
+/// currency set (mints resolved from each currency's `dex_symbol`), keyed by a
+/// base58 wallet address. A funded wallet returns its holdings; an unfunded
+/// wallet returns a zero SOL balance and an empty token list. Only a malformed
+/// address returns a typed error.
+#[utoipa::path(
+    get,
+    path = "/api/solana/balances/{address}",
+    tag = "solana",
+    params(
+        ("address" = String, Path, description = "Base58 Solana wallet address"),
+    ),
+    responses(
+        (status = 200, description = "Solana wallet balances", body = SolanaBalancesResponse),
+        (status = 400, description = "Invalid address", body = crate::error::ErrorResponse),
+        (status = 502, description = "Solana RPC error", body = crate::error::ErrorResponse),
+        (status = 503, description = "Solana RPC unconfigured or cache cold", body = crate::error::ErrorResponse),
+    ),
+)]
+pub async fn get_solana_balances(
+    State(state): State<Arc<AppState>>,
+    Path(address): Path<String>,
+) -> Result<Json<SolanaBalancesResponse>, AppError> {
+    debug!("Fetching Solana balances");
+
+    // Validate first: a malformed address is the only typed-error path.
+    crate::validation::validate_solana_address(&address, "address")?;
+
+    // Native SOL. 503 when Solana RPC is unconfigured; 502 on an RPC failure.
+    let lamports = state.solana_client.get_balance(&address).await?;
+    let sol = SolanaBalanceInfo {
+        key: None,
+        symbol: SOL_SYMBOL.to_string(),
+        mint: None,
+        amount: lamports.to_string(),
+        decimal_digits: SOL_DECIMALS,
+    };
+
+    // SPL balances for the SOLANA-protocol currency set. Cold cache -> 503.
+    let currencies = state
+        .data_cache
+        .currencies
+        .load_or_unavailable("Currencies")?;
+
+    // Fan out one getTokenAccountsByOwner per SOLANA-protocol mint concurrently;
+    // the client's own semaphore bounds actual egress. try_join_all fails fast on
+    // the first RPC error (502).
+    let solana_client = &state.solana_client;
+    let owner = address.as_str();
+    let token_futures = currencies
+        .currencies
+        .values()
+        .filter(|currency| {
+            is_solana_protocol(&currency.protocol) && !currency.dex_symbol.is_empty()
+        })
+        .map(|currency| async move {
+            let filter = TokenAccountsFilter::Mint(currency.dex_symbol.clone());
+            let accounts = solana_client
+                .get_token_accounts_by_owner(owner, &filter)
+                .await?;
+            fold_token_balance(currency, &accounts)
+        });
+    let tokens: Vec<SolanaBalanceInfo> = futures::future::try_join_all(token_futures)
+        .await?
+        .into_iter()
+        .flatten()
+        .collect();
+
+    Ok(Json(SolanaBalancesResponse {
+        address,
+        sol,
+        tokens,
+    }))
+}
+
+/// Get Solana transfer-timeout parameters
+///
+/// Serves the fresh current slot and epoch a client needs to build a height-
+/// based `MsgTransfer` timeout, plus the program's lifetime bound. The Solana
+/// program rejects timestamp-only timeouts, so a client must set a
+/// `timeout_height` with `revision_number = revision_number` and
+/// `revision_height` in `(slot, max_timeout_height]`. Never cached.
+#[utoipa::path(
+    get,
+    path = "/api/solana/transfer-params",
+    tag = "solana",
+    responses(
+        (status = 200, description = "Fresh Solana transfer-timeout parameters", body = SolanaTransferParamsResponse),
+        (status = 502, description = "Solana RPC error", body = crate::error::ErrorResponse),
+        (status = 503, description = "Solana RPC unconfigured", body = crate::error::ErrorResponse),
+    ),
+)]
+pub async fn get_solana_transfer_params(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<SolanaTransferParamsResponse>, AppError> {
+    let epoch_info = state.solana_client.get_epoch_info().await?;
+    Ok(Json(transfer_params_from_epoch(&epoch_info)))
+}
+
+/// Whether a `NETWORK-DEX-LPN` protocol identifier belongs to the SOLANA
+/// network. Case-insensitive on the network prefix.
+fn is_solana_protocol(protocol: &str) -> bool {
+    protocol
+        .to_ascii_uppercase()
+        .starts_with(SOLANA_PROTOCOL_PREFIX)
+}
+
+/// Sum a currency's SPL token accounts into one balance entry, or `None` when
+/// the wallet holds no account for the mint (omitted, mirroring the Nolus
+/// balances handler which lists only held denoms). A token amount the RPC
+/// returns that does not parse is an upstream failure, surfaced as a typed
+/// `ChainRpc` error naming the mint rather than silently under-reporting.
+fn fold_token_balance(
+    currency: &CurrencyInfo,
+    accounts: &[SolanaTokenBalance],
+) -> Result<Option<SolanaBalanceInfo>, AppError> {
+    let Some(first) = accounts.first() else {
+        return Ok(None);
+    };
+    let decimals = first.decimals;
+
+    let mut total: u128 = 0;
+    for account in accounts {
+        let amount = account
+            .amount
+            .parse::<u128>()
+            .map_err(|_err| AppError::ChainRpc {
+                chain: CHAIN.to_string(),
+                message: format!(
+                    "unparseable token amount for mint {}: {}",
+                    account.mint, account.amount
+                ),
+            })?;
+        total = total.saturating_add(amount);
+    }
+
+    Ok(Some(SolanaBalanceInfo {
+        key: Some(currency.key.clone()),
+        symbol: currency.symbol.clone(),
+        mint: Some(currency.dex_symbol.clone()),
+        amount: total.to_string(),
+        decimal_digits: decimals,
+    }))
+}
+
+/// Build the transfer-params payload from fresh epoch info. Pure so the lifetime
+/// arithmetic (and its saturation guard) is unit-testable without an RPC.
+fn transfer_params_from_epoch(epoch_info: &SolanaEpochInfo) -> SolanaTransferParamsResponse {
+    SolanaTransferParamsResponse {
+        slot: epoch_info.absolute_slot,
+        revision_number: epoch_info.epoch,
+        max_lifetime_slots: RECV_TIMEOUT_LIFETIME_SLOTS,
+        max_timeout_height: epoch_info
+            .absolute_slot
+            .saturating_add(RECV_TIMEOUT_LIFETIME_SLOTS),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use serde_json::json;
+    use wiremock::matchers::{body_partial_json, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::handlers::currencies::CurrenciesResponse;
+
+    /// AppState whose Solana client targets `solana_url` with a real-timeout HTTP
+    /// client so handler tests can drive it against a mock server.
+    async fn state_with_solana(solana_url: &str) -> Arc<AppState> {
+        let mut config = crate::test_utils::test_config();
+        config.external.solana_rpc_url = Some(solana_url.to_string());
+        crate::test_utils::test_app_state_with_config_and_client(config, reqwest::Client::new())
+            .await
+    }
+
+    /// Mount a `{context, value}` JSON-RPC success for `rpc_method`.
+    async fn mount_value(server: &MockServer, rpc_method: &str, value: serde_json::Value) {
+        Mock::given(method("POST"))
+            .and(body_partial_json(json!({ "method": rpc_method })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": { "context": { "slot": 1 }, "value": value },
+            })))
+            .mount(server)
+            .await;
+    }
+
+    fn currency(key: &str, protocol: &str, dex_symbol: &str) -> CurrencyInfo {
+        CurrencyInfo {
+            key: key.to_string(),
+            ticker: "USDC".to_string(),
+            symbol: "USDC".to_string(),
+            name: "USD Coin".to_string(),
+            short_name: "USDC".to_string(),
+            decimal_digits: 6,
+            bank_symbol: String::new(),
+            dex_symbol: dex_symbol.to_string(),
+            icon: String::new(),
+            native: false,
+            coingecko_id: None,
+            protocol: protocol.to_string(),
+            group: "lease".to_string(),
+            is_active: true,
+        }
+    }
+
+    fn token(mint: &str, amount: &str, decimals: u8) -> SolanaTokenBalance {
+        SolanaTokenBalance {
+            mint: mint.to_string(),
+            amount: amount.to_string(),
+            decimals,
+        }
+    }
+
+    #[test]
+    fn is_solana_protocol_matches_solana_network_only() {
+        assert!(is_solana_protocol("SOLANA-JUPITER-USDC"));
+        assert!(is_solana_protocol("solana-jupiter-usdc"));
+        assert!(!is_solana_protocol("OSMOSIS-OSMOSIS-USDC_NOBLE"));
+        assert!(!is_solana_protocol("NEUTRON-ASTROPORT-USDC"));
+        assert!(!is_solana_protocol(""));
+    }
+
+    #[test]
+    fn fold_token_balance_is_none_for_no_accounts() {
+        let currency = currency("USDC@SOLANA-JUPITER-USDC", "SOLANA-JUPITER-USDC", "Mint1");
+        assert!(fold_token_balance(&currency, &[])
+            .expect("no rpc error")
+            .is_none());
+    }
+
+    #[test]
+    fn fold_token_balance_sums_multiple_accounts() {
+        let currency = currency("USDC@SOLANA-JUPITER-USDC", "SOLANA-JUPITER-USDC", "MintX");
+        let accounts = [token("MintX", "1500000", 6), token("MintX", "2500000", 6)];
+        let info = fold_token_balance(&currency, &accounts)
+            .expect("no rpc error")
+            .expect("held balance");
+        assert_eq!(info.amount, "4000000");
+        assert_eq!(info.decimal_digits, 6);
+        assert_eq!(info.key.as_deref(), Some("USDC@SOLANA-JUPITER-USDC"));
+        assert_eq!(info.mint.as_deref(), Some("MintX"));
+    }
+
+    #[test]
+    fn fold_token_balance_errors_on_unparseable_amount() {
+        let currency = currency("USDC@SOLANA-JUPITER-USDC", "SOLANA-JUPITER-USDC", "MintX");
+        let accounts = [token("MintX", "not-a-number", 6)];
+        match fold_token_balance(&currency, &accounts) {
+            Err(AppError::ChainRpc { chain, message }) => {
+                assert_eq!(chain, "solana");
+                assert!(message.contains("MintX"), "message was: {message}");
+            }
+            other => panic!("expected ChainRpc for an unparseable amount, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transfer_params_bounds_timeout_by_lifetime() {
+        let epoch_info = SolanaEpochInfo {
+            absolute_slot: 250_000_000,
+            epoch: 579,
+        };
+        let params = transfer_params_from_epoch(&epoch_info);
+        assert_eq!(params.slot, 250_000_000);
+        assert_eq!(params.revision_number, 579);
+        assert_eq!(params.max_lifetime_slots, RECV_TIMEOUT_LIFETIME_SLOTS);
+        assert_eq!(params.max_timeout_height, 250_000_000 + 172_800);
+    }
+
+    #[test]
+    fn transfer_params_saturates_at_slot_ceiling() {
+        let epoch_info = SolanaEpochInfo {
+            absolute_slot: u64::MAX,
+            epoch: 1,
+        };
+        let params = transfer_params_from_epoch(&epoch_info);
+        assert_eq!(params.max_timeout_height, u64::MAX);
+    }
+
+    /// A malformed address is rejected before any RPC or cache access, as the
+    /// 400-mapped `Validation` error — matching the Nolus balances contract.
+    #[tokio::test]
+    async fn get_solana_balances_rejects_invalid_address() {
+        let state = crate::test_utils::test_app_state().await;
+        let err = super::get_solana_balances(
+            axum::extract::State(state),
+            axum::extract::Path("not-a-solana-address".to_string()),
+        )
+        .await
+        .expect_err("invalid address must be rejected");
+        match err {
+            AppError::Validation { field, .. } => {
+                assert_eq!(field, Some("address".to_string()));
+            }
+            other => panic!("expected Validation for an invalid address, got {other:?}"),
+        }
+    }
+
+    /// Happy path: native SOL plus one held SPL entry from the SOLANA-protocol
+    /// currency set, resolved through mocked RPC and a provisioned currency.
+    #[tokio::test]
+    async fn get_solana_balances_returns_sol_and_held_spl() {
+        let owner = "So11111111111111111111111111111111111111112";
+        let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+        let server = MockServer::start().await;
+        mount_value(&server, "getBalance", json!(2_000_000_000_u64)).await;
+        mount_value(
+            &server,
+            "getTokenAccountsByOwner",
+            json!([
+                {
+                    "account": {
+                        "data": {
+                            "parsed": {
+                                "info": {
+                                    "mint": mint,
+                                    "tokenAmount": { "amount": "5000000", "decimals": 6 },
+                                }
+                            }
+                        }
+                    }
+                }
+            ]),
+        )
+        .await;
+
+        let state = state_with_solana(&server.uri()).await;
+        let mut currencies = HashMap::new();
+        currencies.insert(
+            "USDC@SOLANA-JUPITER-USDC".to_string(),
+            currency("USDC@SOLANA-JUPITER-USDC", "SOLANA-JUPITER-USDC", mint),
+        );
+        state.data_cache.currencies.store(CurrenciesResponse {
+            currencies,
+            lpn: Vec::new(),
+            lease_currencies: Vec::new(),
+            map: HashMap::new(),
+        });
+
+        let response = super::get_solana_balances(
+            axum::extract::State(state),
+            axum::extract::Path(owner.to_string()),
+        )
+        .await
+        .expect("balances")
+        .0;
+
+        assert_eq!(response.address, owner);
+        assert_eq!(response.sol.amount, "2000000000");
+        assert_eq!(response.sol.decimal_digits, 9);
+        assert_eq!(response.tokens.len(), 1);
+        assert_eq!(response.tokens[0].amount, "5000000");
+        assert_eq!(response.tokens[0].decimal_digits, 6);
+        assert_eq!(response.tokens[0].mint.as_deref(), Some(mint));
+        assert_eq!(
+            response.tokens[0].key.as_deref(),
+            Some("USDC@SOLANA-JUPITER-USDC")
+        );
+    }
+
+    /// The transfer-params handler serves the full response shape from a freshly
+    /// fetched epoch, with the timeout bound applied.
+    #[tokio::test]
+    async fn get_solana_transfer_params_returns_full_shape() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(body_partial_json(json!({ "method": "getEpochInfo" })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": { "absoluteSlot": 300_000_000_u64, "epoch": 700 },
+            })))
+            .mount(&server)
+            .await;
+
+        let state = state_with_solana(&server.uri()).await;
+        let response = super::get_solana_transfer_params(axum::extract::State(state))
+            .await
+            .expect("transfer params")
+            .0;
+
+        assert_eq!(response.slot, 300_000_000);
+        assert_eq!(response.revision_number, 700);
+        assert_eq!(response.max_lifetime_slots, RECV_TIMEOUT_LIFETIME_SLOTS);
+        assert_eq!(response.max_timeout_height, 300_000_000 + 172_800);
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -54,6 +54,7 @@ pub struct AppState {
     pub etl_client: external::etl::EtlClient,
     pub skip_client: external::skip::SkipClient,
     pub chain_client: external::chain::ChainClient,
+    pub solana_client: external::solana::SolanaClient,
     pub referral_client: external::referral::ReferralClient,
     pub zero_interest_client: external::zero_interest::ZeroInterestClient,
     pub data_cache: data_cache::AppDataCache,
@@ -133,6 +134,13 @@ async fn main() -> anyhow::Result<()> {
         http_client.clone(),
     );
 
+    // Initialize Solana JSON-RPC client (unconfigured when SOLANA_RPC_URL unset —
+    // Solana endpoints then return 503 rather than falling back silently)
+    let solana_client = external::solana::SolanaClient::new(
+        config.external.solana_rpc_url.clone(),
+        http_client.clone(),
+    );
+
     // Initialize data cache (empty — populated by background refresh tasks)
     let data_cache = data_cache::AppDataCache::new();
 
@@ -175,6 +183,7 @@ async fn main() -> anyhow::Result<()> {
         etl_client,
         skip_client,
         chain_client,
+        solana_client,
         referral_client,
         zero_interest_client,
         data_cache,
@@ -379,6 +388,15 @@ fn create_router(state: Arc<AppState>) -> Router {
         .route("/currencies/{key}", get(handlers::currencies::get_currency))
         .route("/prices", get(handlers::currencies::get_prices))
         .route("/balances", get(handlers::currencies::get_balances))
+        // Solana (read) — balances + fresh transfer-timeout parameters
+        .route(
+            "/solana/balances/{address}",
+            get(handlers::solana::get_solana_balances),
+        )
+        .route(
+            "/solana/transfer-params",
+            get(handlers::solana::get_solana_transfer_params),
+        )
         // Leases (read)
         .route("/leases", get(handlers::leases::get_leases))
         .route(

--- a/backend/src/refresh.rs
+++ b/backend/src/refresh.rs
@@ -1526,6 +1526,7 @@ mod tests {
             etl_client,
             skip_client,
             chain_client,
+            solana_client: crate::external::solana::SolanaClient::new(None, http_client.clone()),
             referral_client,
             zero_interest_client,
             data_cache: AppDataCache::new(),

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -39,6 +39,7 @@ pub fn test_config() -> AppConfig {
             skip_api_key: None,
             nolus_rpc_url: "http://127.0.0.1:1/".to_string(),
             nolus_rest_url: "http://127.0.0.1:1/".to_string(),
+            solana_rpc_url: Some("http://127.0.0.1:1/".to_string()),
             referral_api_url: "http://127.0.0.1:1/".to_string(),
             referral_api_token: "stub".to_string(),
             zero_interest_api_url: "http://127.0.0.1:1/".to_string(),
@@ -79,7 +80,16 @@ pub async fn test_app_state_with_config(config: AppConfig) -> Arc<AppState> {
         .timeout(std::time::Duration::from_millis(1))
         .build()
         .expect("reqwest client builder cannot fail with only a timeout set");
+    test_app_state_with_config_and_client(config, http_client).await
+}
 
+/// Build an AppState with the given config and a caller-supplied HTTP client.
+/// Handler tests that must hit a mock server pass a real-timeout client here;
+/// the default factory passes the 1ms stub client.
+pub async fn test_app_state_with_config_and_client(
+    config: AppConfig,
+    http_client: reqwest::Client,
+) -> Arc<AppState> {
     let etl_client =
         external::etl::EtlClient::new(config.external.etl_api_url.clone(), http_client.clone());
     let skip_client = external::skip::SkipClient::new(
@@ -89,6 +99,10 @@ pub async fn test_app_state_with_config(config: AppConfig) -> Arc<AppState> {
     );
     let chain_client = external::chain::ChainClient::new(
         config.external.nolus_rest_url.clone(),
+        http_client.clone(),
+    );
+    let solana_client = external::solana::SolanaClient::new(
+        config.external.solana_rpc_url.clone(),
         http_client.clone(),
     );
     let referral_client = external::referral::ReferralClient::new(&config, http_client.clone());
@@ -125,6 +139,7 @@ pub async fn test_app_state_with_config(config: AppConfig) -> Arc<AppState> {
         etl_client,
         skip_client,
         chain_client,
+        solana_client,
         referral_client,
         zero_interest_client,
         data_cache: AppDataCache::new(),

--- a/backend/src/validation.rs
+++ b/backend/src/validation.rs
@@ -1,5 +1,9 @@
 //! Input validation utilities for handler boundaries
 
+use std::str::FromStr as _;
+
+use solana_pubkey::Pubkey;
+
 use crate::error::AppError;
 
 /// Validate that a string is a valid bech32 address.
@@ -27,6 +31,38 @@ pub fn validate_bech32_address(address: &str, field_name: &str) -> Result<(), Ap
 /// construction — a caller may then interpolate the result into an LCD path.
 pub fn is_valid_nolus_address(address: &str) -> bool {
     matches!(bech32::decode(address), Ok((hrp, _)) if hrp.as_str() == "nolus")
+}
+
+/// Validate that a string is a valid base58 Solana address (an ed25519 public
+/// key: exactly 32 bytes, base58-encoded). Returns `AppError::Validation` if
+/// empty or malformed.
+pub fn validate_solana_address(address: &str, field_name: &str) -> Result<(), AppError> {
+    if address.is_empty() {
+        return Err(AppError::Validation {
+            message: format!("{} is required", field_name),
+            field: Some(field_name.to_string()),
+            details: None,
+        });
+    }
+    if !is_valid_solana_address(address) {
+        return Err(AppError::Validation {
+            message: format!("Invalid {} format", field_name),
+            field: Some(field_name.to_string()),
+            details: None,
+        });
+    }
+    Ok(())
+}
+
+/// Returns `true` only for a valid base58 Solana address (decodes to exactly 32
+/// bytes).
+///
+/// `Pubkey::from_str` rejects any character outside the base58 alphabet, so
+/// `/ ? # %`, whitespace, and the ambiguous `0 O I l` glyphs all fail by
+/// construction, as does any string that does not decode to 32 bytes — a caller
+/// may then interpolate the result into an RPC `params` field.
+pub fn is_valid_solana_address(address: &str) -> bool {
+    Pubkey::from_str(address).is_ok()
 }
 
 #[cfg(test)]
@@ -97,5 +133,56 @@ mod tests {
             "nolus1{}",
             "q".repeat(120)
         )));
+    }
+
+    /// Canonical valid Solana addresses: the wrapped-SOL mint (44 chars) and the
+    /// System program (32 `1`s = 32 zero bytes).
+    #[test]
+    fn test_valid_solana_address() {
+        assert!(
+            validate_solana_address("So11111111111111111111111111111111111111112", "address")
+                .is_ok()
+        );
+        assert!(validate_solana_address("11111111111111111111111111111111", "address").is_ok());
+    }
+
+    #[test]
+    fn test_empty_solana_address() {
+        let err = validate_solana_address("", "address").unwrap_err();
+        match err {
+            AppError::Validation { message, field, .. } => {
+                assert_eq!(message, "address is required");
+                assert_eq!(field, Some("address".to_string()));
+            }
+            _ => panic!("Expected Validation error"),
+        }
+    }
+
+    #[test]
+    fn test_invalid_solana_address() {
+        let err = validate_solana_address("not-a-solana-address", "owner").unwrap_err();
+        match err {
+            AppError::Validation { message, field, .. } => {
+                assert_eq!(message, "Invalid owner format");
+                assert_eq!(field, Some("owner".to_string()));
+            }
+            _ => panic!("Expected Validation error"),
+        }
+    }
+
+    /// Path-traversal, query, fragment, percent, uppercase (introduces the
+    /// out-of-alphabet `O`), whitespace, empty, and wrong-length inputs must all
+    /// fail — none may reach an RPC `params` field.
+    #[test]
+    fn test_is_valid_solana_address_rejects_hostile_inputs() {
+        let valid = "So11111111111111111111111111111111111111112";
+        assert!(!is_valid_solana_address(&format!("{valid}/../../foo")));
+        assert!(!is_valid_solana_address(&format!("{valid}?x=1")));
+        assert!(!is_valid_solana_address(&format!("{valid}#frag")));
+        assert!(!is_valid_solana_address("So1111%2e%2e"));
+        assert!(!is_valid_solana_address(&valid.to_uppercase()));
+        assert!(!is_valid_solana_address("So1111 111"));
+        assert!(!is_valid_solana_address(""));
+        assert!(!is_valid_solana_address(&"1".repeat(120)));
     }
 }


### PR DESCRIPTION
## Summary

Add the backend Solana foundation for the Solana epic: the ibc-solray sdk crate pin, a bespoke Solana JSON-RPC client mirroring the existing chain-client pattern, base58/ed25519 address validation, and two read-class endpoints (wallet balances, transfer timeout parameters). This is the foundation issue; #293/#294 consume the client surface next. Part of #287, closes #291.

## Changes

- `ibc-solray` pinned by git rev `0462fb32` with `default-features = false, features = ["sdk"]`. No release tags exist upstream, so a rev pin replaces the planned tag pin; `engine-jupiter` is deliberately excluded (pulls a rustc 1.94 dependency conflicting with Solana's toolchain, and the webapp never touches the relayer-gated path). PDA derivation is locked by known-answer tests.
- New `external/solana.rs`: JSON-RPC client with its own concurrency semaphore (`SOLANA_MAX_CONCURRENT_QUERIES`, default 256), 429/503 retry with jittered backoff, typed error mapping, and the full RPC surface the epic's build/track issues consume (blockhash, simulate, send-raw, signature statuses, balances, token accounts, account info, lookup tables, epoch info).
- `SOLANA_RPC_URL` is optional at startup by design: existing deploys keep booting, a startup warning fires when unset, and the Solana endpoints return 503 until configured.
- `GET /api/solana/balances/{address}`: validates the address first (400 on malformed), returns native SOL plus held-only SPL balances resolved from the SOLANA-protocol currency set (empty today; auto-populates once a SOLANA protocol lands in the currencies cache). Per-mint lookups fan out concurrently via try_join_all bounded by the client semaphore; the first RPC failure short-circuits to 502. USD fields are deliberately omitted until an oracle feed exists; uniformly-zero USD would be silently wrong.
- `GET /api/solana/transfer-params`: never cached, fresh epoch info per request; returns the current slot, the epoch as the revision number (per the ibc-solray timeout contract), the 172,800-slot recv lifetime, and the max timeout height. Serves height-based MsgTransfer timeout construction; the receive side rejects timestamp-only packets.
- Unparseable token amounts from the RPC fail visibly as a typed 502 naming the mint rather than being skipped.
- Suite impact: backend unit tier (33 new tests: client mock-server happy+error paths, handler contracts, hostile-input address validation, PDA known-answer vectors); no user-facing UI surface in this PR, so the e2e coverage matrix is unchanged.

## Verification

- Ran the backend gate at HEAD: cargo build, fmt check, clippy with -D warnings (CI invocation), scripts/style-check.sh, cargo test: 557 passed, 0 failed.
- Verified the first commit builds standalone (pin + client alone) so bisect works across the two-commit slice.
- Independent review passes: 12-item checklist 12/12, security review clear, project-rule conformance clean.
- cargo audit: the pin forces `time` down from 0.3.47 to 0.3.37 (RUSTSEC-2026-0009, DoS via stack exhaustion) because the nolus ibc-rs fork caps `time < 0.3.38`. Not fixable in this repo; exposure is low (the vulnerable untrusted time-string parsing path is unreached; the webapp uses chrono). Accepting requires the cap lifted upstream then a re-pin. Also newly pulled: bincode and paste unmaintained notices from the Solana tree; anyhow advisory pre-existing.
- One commit used the logged large-commit bypass for the indivisible 2,136-line Cargo.lock regeneration.

## Follow-ups

- Lift the `time` cap in the ibc-rs fork, then re-pin ibc-solray and drop the accepted advisory.
- Cutting release tags in ibc-solray would make future pin bumps cleaner than rev pins.
- Deploy: set `SOLANA_RPC_URL` on the frontends server and confirm titan RPC reachability from that container before the Solana surfaces activate.
- Review notes, deliberate and revisitable: the currencies-cache readiness check runs after the native-SOL RPC call (one wasted call on a cold cache); the semaphore permit is held through retry backoff as backpressure; the SOLANA protocol match uses a prefix comparison.