### PR TITLE
ci: authenticate cargo fetch of the private ibc-solray dep

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -17,3 +17,5 @@ jobs:
       service: webapp-dev
       health_port: 5050
       base_domain: app-dev.nolus.io
+    secrets:
+      IBC_SOLRAY_DEPLOY_KEY: ${{ secrets.IBC_SOLRAY_DEPLOY_KEY }}

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -17,3 +17,5 @@ jobs:
       service: webapp-prod
       health_port: 5051
       base_domain: app.nolus.io
+    secrets:
+      IBC_SOLRAY_DEPLOY_KEY: ${{ secrets.IBC_SOLRAY_DEPLOY_KEY }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -92,6 +92,10 @@ jobs:
           cd backend
           cargo build --release
 
+      - name: Remove the staged deploy key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/ibc-solray-deploy-key" "$RUNNER_TEMP/ibc-solray-known-hosts"
+
       - name: Prepare deployment bundle
         run: |
           mkdir -p deploy-bundle

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,6 +19,10 @@ on:
         description: Public host the SPA talks to; the three VITE_* URLs derive from it.
         required: true
         type: string
+    secrets:
+      IBC_SOLRAY_DEPLOY_KEY:
+        description: Read-only deploy key for the private ibc-solray cargo git dependency.
+        required: true
 
 jobs:
   build-and-deploy:
@@ -33,6 +37,14 @@ jobs:
       DEPLOY_DIR: ${{ inputs.deploy_dir }}
       SERVICE: ${{ inputs.service }}
       HEALTH_PORT: ${{ inputs.health_port }}
+      # ibc-solray is private; cargo shells out to git (fetch-with-cli) and the
+      # env-scoped rewrite + key keep the persistent runner's global git config
+      # untouched. The rewrite matches only the ibc-solray URL.
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      GIT_SSH_COMMAND: ssh -i ${{ runner.temp }}/ibc-solray-deploy-key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new
+      GIT_CONFIG_COUNT: "1"
+      GIT_CONFIG_KEY_0: url.ssh://git@github.com/nolus-protocol/ibc-solray.insteadOf
+      GIT_CONFIG_VALUE_0: https://github.com/nolus-protocol/ibc-solray
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -60,6 +72,13 @@ jobs:
         run: |
           npm ci
           npm run build
+
+      - name: Stage the ibc-solray deploy key
+        env:
+          IBC_SOLRAY_DEPLOY_KEY: ${{ secrets.IBC_SOLRAY_DEPLOY_KEY }}
+        run: |
+          printf '%s\n' "$IBC_SOLRAY_DEPLOY_KEY" > "$RUNNER_TEMP/ibc-solray-deploy-key"
+          chmod 600 "$RUNNER_TEMP/ibc-solray-deploy-key"
 
       - name: Build Rust backend
         # The [self-hosted, frontend-deploy] runner keeps its workspace and the

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,14 +37,6 @@ jobs:
       DEPLOY_DIR: ${{ inputs.deploy_dir }}
       SERVICE: ${{ inputs.service }}
       HEALTH_PORT: ${{ inputs.health_port }}
-      # ibc-solray is private; cargo shells out to git (fetch-with-cli) and the
-      # env-scoped rewrite + key keep the persistent runner's global git config
-      # untouched. The rewrite prefix-matches the ibc-solray repo URL.
-      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-      GIT_SSH_COMMAND: ssh -i "${{ runner.temp }}/ibc-solray-deploy-key" -o IdentitiesOnly=yes -o BatchMode=yes -o UserKnownHostsFile="${{ runner.temp }}/ibc-solray-known-hosts" -o StrictHostKeyChecking=yes
-      GIT_CONFIG_COUNT: "1"
-      GIT_CONFIG_KEY_0: url.ssh://git@github.com/nolus-protocol/ibc-solray.insteadOf
-      GIT_CONFIG_VALUE_0: https://github.com/nolus-protocol/ibc-solray
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -73,6 +65,10 @@ jobs:
           npm ci
           npm run build
 
+      # ibc-solray is private; cargo shells out to git (fetch-with-cli) and the
+      # key + URL rewrite exported here keep the persistent runner's global git
+      # config untouched. The rewrite prefix-matches the ibc-solray repo URL.
+      # (The runner context is unavailable in job-level env, hence GITHUB_ENV.)
       - name: Stage the ibc-solray deploy key
         env:
           IBC_SOLRAY_DEPLOY_KEY: ${{ secrets.IBC_SOLRAY_DEPLOY_KEY }}
@@ -80,6 +76,13 @@ jobs:
           [ -n "$IBC_SOLRAY_DEPLOY_KEY" ] || { echo "IBC_SOLRAY_DEPLOY_KEY is empty"; exit 1; }
           (umask 077; printf '%s\n' "$IBC_SOLRAY_DEPLOY_KEY" > "$RUNNER_TEMP/ibc-solray-deploy-key")
           echo "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl" > "$RUNNER_TEMP/ibc-solray-known-hosts"
+          {
+            echo "CARGO_NET_GIT_FETCH_WITH_CLI=true"
+            echo "GIT_SSH_COMMAND=ssh -i \"$RUNNER_TEMP/ibc-solray-deploy-key\" -o IdentitiesOnly=yes -o BatchMode=yes -o UserKnownHostsFile=\"$RUNNER_TEMP/ibc-solray-known-hosts\" -o StrictHostKeyChecking=yes"
+            echo "GIT_CONFIG_COUNT=1"
+            echo "GIT_CONFIG_KEY_0=url.ssh://git@github.com/nolus-protocol/ibc-solray.insteadOf"
+            echo "GIT_CONFIG_VALUE_0=https://github.com/nolus-protocol/ibc-solray"
+          } >> "$GITHUB_ENV"
 
       - name: Build Rust backend
         # The [self-hosted, frontend-deploy] runner keeps its workspace and the

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,9 +39,9 @@ jobs:
       HEALTH_PORT: ${{ inputs.health_port }}
       # ibc-solray is private; cargo shells out to git (fetch-with-cli) and the
       # env-scoped rewrite + key keep the persistent runner's global git config
-      # untouched. The rewrite matches only the ibc-solray URL.
+      # untouched. The rewrite prefix-matches the ibc-solray repo URL.
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-      GIT_SSH_COMMAND: ssh -i ${{ runner.temp }}/ibc-solray-deploy-key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new
+      GIT_SSH_COMMAND: ssh -i "${{ runner.temp }}/ibc-solray-deploy-key" -o IdentitiesOnly=yes -o BatchMode=yes -o UserKnownHostsFile="${{ runner.temp }}/ibc-solray-known-hosts" -o StrictHostKeyChecking=yes
       GIT_CONFIG_COUNT: "1"
       GIT_CONFIG_KEY_0: url.ssh://git@github.com/nolus-protocol/ibc-solray.insteadOf
       GIT_CONFIG_VALUE_0: https://github.com/nolus-protocol/ibc-solray
@@ -77,8 +77,9 @@ jobs:
         env:
           IBC_SOLRAY_DEPLOY_KEY: ${{ secrets.IBC_SOLRAY_DEPLOY_KEY }}
         run: |
-          printf '%s\n' "$IBC_SOLRAY_DEPLOY_KEY" > "$RUNNER_TEMP/ibc-solray-deploy-key"
-          chmod 600 "$RUNNER_TEMP/ibc-solray-deploy-key"
+          [ -n "$IBC_SOLRAY_DEPLOY_KEY" ] || { echo "IBC_SOLRAY_DEPLOY_KEY is empty"; exit 1; }
+          (umask 077; printf '%s\n' "$IBC_SOLRAY_DEPLOY_KEY" > "$RUNNER_TEMP/ibc-solray-deploy-key")
+          echo "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl" > "$RUNNER_TEMP/ibc-solray-known-hosts"
 
       - name: Build Rust backend
         # The [self-hosted, frontend-deploy] runner keeps its workspace and the

--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -232,7 +232,7 @@ jobs:
 
       - name: Remove the staged deploy key
         if: always()
-        run: rm -f "$RUNNER_TEMP/ibc-solray-deploy-key"
+        run: rm -f "$RUNNER_TEMP/ibc-solray-deploy-key" "$RUNNER_TEMP/ibc-solray-known-hosts"
 
   e2e-static:
     name: E2E — fixture schemas, gate, coverage matrix

--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -159,20 +159,15 @@ jobs:
       run:
         working-directory: backend
 
-    env:
-      # ibc-solray is private; cargo shells out to git (fetch-with-cli) so the
-      # deploy key + URL rewrite below apply. The rewrite prefix-matches the
-      # ibc-solray repo URL. Fork PRs don't receive the secret — their backend
-      # job fails fast at the key-staging step until ibc-solray goes public.
-      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-      GIT_SSH_COMMAND: ssh -i "${{ runner.temp }}/ibc-solray-deploy-key" -o IdentitiesOnly=yes -o BatchMode=yes -o UserKnownHostsFile="${{ runner.temp }}/ibc-solray-known-hosts" -o StrictHostKeyChecking=yes
-      GIT_CONFIG_COUNT: "1"
-      GIT_CONFIG_KEY_0: url.ssh://git@github.com/nolus-protocol/ibc-solray.insteadOf
-      GIT_CONFIG_VALUE_0: https://github.com/nolus-protocol/ibc-solray
-
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      # ibc-solray is private; cargo shells out to git (fetch-with-cli) so the
+      # deploy key + URL rewrite below apply to every later step. The rewrite
+      # prefix-matches the ibc-solray repo URL. Fork PRs don't receive the
+      # secret — their backend job fails fast here until ibc-solray goes
+      # public. (The runner context is unavailable in job-level env, hence
+      # GITHUB_ENV.)
       - name: Stage the ibc-solray deploy key
         env:
           IBC_SOLRAY_DEPLOY_KEY: ${{ secrets.IBC_SOLRAY_DEPLOY_KEY }}
@@ -180,6 +175,13 @@ jobs:
           [ -n "$IBC_SOLRAY_DEPLOY_KEY" ] || { echo "IBC_SOLRAY_DEPLOY_KEY is empty (fork PRs do not receive secrets)"; exit 1; }
           (umask 077; printf '%s\n' "$IBC_SOLRAY_DEPLOY_KEY" > "$RUNNER_TEMP/ibc-solray-deploy-key")
           echo "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl" > "$RUNNER_TEMP/ibc-solray-known-hosts"
+          {
+            echo "CARGO_NET_GIT_FETCH_WITH_CLI=true"
+            echo "GIT_SSH_COMMAND=ssh -i \"$RUNNER_TEMP/ibc-solray-deploy-key\" -o IdentitiesOnly=yes -o BatchMode=yes -o UserKnownHostsFile=\"$RUNNER_TEMP/ibc-solray-known-hosts\" -o StrictHostKeyChecking=yes"
+            echo "GIT_CONFIG_COUNT=1"
+            echo "GIT_CONFIG_KEY_0=url.ssh://git@github.com/nolus-protocol/ibc-solray.insteadOf"
+            echo "GIT_CONFIG_VALUE_0=https://github.com/nolus-protocol/ibc-solray"
+          } >> "$GITHUB_ENV"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch @ 2026-06-30

--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -161,11 +161,11 @@ jobs:
 
     env:
       # ibc-solray is private; cargo shells out to git (fetch-with-cli) so the
-      # deploy key + URL rewrite below apply. The rewrite matches only the
-      # ibc-solray URL. Fork PRs don't receive the secret — their backend job
-      # cannot build until ibc-solray goes public.
+      # deploy key + URL rewrite below apply. The rewrite prefix-matches the
+      # ibc-solray repo URL. Fork PRs don't receive the secret — their backend
+      # job fails fast at the key-staging step until ibc-solray goes public.
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-      GIT_SSH_COMMAND: ssh -i ${{ runner.temp }}/ibc-solray-deploy-key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new
+      GIT_SSH_COMMAND: ssh -i "${{ runner.temp }}/ibc-solray-deploy-key" -o IdentitiesOnly=yes -o BatchMode=yes -o UserKnownHostsFile="${{ runner.temp }}/ibc-solray-known-hosts" -o StrictHostKeyChecking=yes
       GIT_CONFIG_COUNT: "1"
       GIT_CONFIG_KEY_0: url.ssh://git@github.com/nolus-protocol/ibc-solray.insteadOf
       GIT_CONFIG_VALUE_0: https://github.com/nolus-protocol/ibc-solray
@@ -177,8 +177,9 @@ jobs:
         env:
           IBC_SOLRAY_DEPLOY_KEY: ${{ secrets.IBC_SOLRAY_DEPLOY_KEY }}
         run: |
-          printf '%s\n' "$IBC_SOLRAY_DEPLOY_KEY" > "$RUNNER_TEMP/ibc-solray-deploy-key"
-          chmod 600 "$RUNNER_TEMP/ibc-solray-deploy-key"
+          [ -n "$IBC_SOLRAY_DEPLOY_KEY" ] || { echo "IBC_SOLRAY_DEPLOY_KEY is empty (fork PRs do not receive secrets)"; exit 1; }
+          (umask 077; printf '%s\n' "$IBC_SOLRAY_DEPLOY_KEY" > "$RUNNER_TEMP/ibc-solray-deploy-key")
+          echo "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl" > "$RUNNER_TEMP/ibc-solray-known-hosts"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch @ 2026-06-30
@@ -228,6 +229,10 @@ jobs:
           name: backend-coverage
           path: backend/target/tarpaulin/
           retention-days: 7
+
+      - name: Remove the staged deploy key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/ibc-solray-deploy-key"
 
   e2e-static:
     name: E2E — fixture schemas, gate, coverage matrix

--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -159,8 +159,26 @@ jobs:
       run:
         working-directory: backend
 
+    env:
+      # ibc-solray is private; cargo shells out to git (fetch-with-cli) so the
+      # deploy key + URL rewrite below apply. The rewrite matches only the
+      # ibc-solray URL. Fork PRs don't receive the secret — their backend job
+      # cannot build until ibc-solray goes public.
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      GIT_SSH_COMMAND: ssh -i ${{ runner.temp }}/ibc-solray-deploy-key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new
+      GIT_CONFIG_COUNT: "1"
+      GIT_CONFIG_KEY_0: url.ssh://git@github.com/nolus-protocol/ibc-solray.insteadOf
+      GIT_CONFIG_VALUE_0: https://github.com/nolus-protocol/ibc-solray
+
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Stage the ibc-solray deploy key
+        env:
+          IBC_SOLRAY_DEPLOY_KEY: ${{ secrets.IBC_SOLRAY_DEPLOY_KEY }}
+        run: |
+          printf '%s\n' "$IBC_SOLRAY_DEPLOY_KEY" > "$RUNNER_TEMP/ibc-solray-deploy-key"
+          chmod 600 "$RUNNER_TEMP/ibc-solray-deploy-key"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch @ 2026-06-30


### PR DESCRIPTION
## Summary
Grant CI read access to the private ibc-solray repository so the backend can fetch it as a cargo git dependency (arrives with the chain-client PR #357). A read-only deploy key lives in the new required Actions secret `IBC_SOLRAY_DEPLOY_KEY`; cargo shells out to git and an env-scoped SSH command + URL rewrite apply it, so the persistent self-hosted deploy runner's global git config is never touched.

## Changes
- `pr-validate.yaml` backend job + reusable `deploy.yaml`: stage the key into `RUNNER_TEMP` (umask 077, empty-secret fast-fail), `CARGO_NET_GIT_FETCH_WITH_CLI` + `GIT_SSH_COMMAND` with a pinned github.com host key + `GIT_CONFIG_*` insteadOf rewrite scoped to the ibc-solray URL, and an `if: always()` cleanup of the staged files.
- `deploy.yaml` declares the secret in its `workflow_call` contract; both caller stubs pass it explicitly.

## Verification
- Validated all workflow YAML parses; byte-compared the pinned host key against GitHub's published ed25519 key from the live API.
- Ran three independent review passes (generic 12-item checklist, security, project-rule conformance): all pass, no blocking findings; the two earlier rounds' findings (persistent-runner key cleanup, host-key pinning, umask race, empty-secret guard) are fixed in this diff.
- Confirmed the rewrite leaves crates.io and the webapp checkout untouched; the wiring is inert until the ibc-solray dependency lands.

## Follow-ups
- Fork PRs receive no secrets, so their backend job fails fast at key staging until ibc-solray goes public. Accepted trade-off, documented in the workflow comment.