### PR TITLE
feat(swap): provider seam and swap op-kind in route steps

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -490,6 +490,11 @@ test block — a goto-only test cannot satisfy a cell, and a removed/renamed lab
   cell, not asserted as a client guarantee.
 - **Schemaless endpoints** (all `/api/etl/*`, `/api/governance/*`, `/api/staking/positions`)
   have no Zod schema; their fixtures are shape-mirrored and marked unvalidated in the matrix.
+- **Swap-leg route stepper is funded-gated** — the pending-transfer stepper renders a `swap`
+  op-kind leg (real Skip swap ops carry `chain_id` + `from_chain_id`, no `to_chain_id`) only for a
+  send/receive route that includes a swap hop, which needs a funded wallet producing such a route.
+  Recorded as a funded-gated cell (`/activities` × `route-stepper`); the swap-leg step assembly is
+  unit-covered in the history-store `getRouteSteps` suite.
 
 ### CI (the `e2e-static` job)
 

--- a/e2e/coverage-matrix.json
+++ b/e2e/coverage-matrix.json
@@ -1,6 +1,15 @@
 {
   "routes": ["/", "/assets", "/earn", "/positions", "/stake", "/activities", "/vote", "/stats"],
-  "components": ["shell", "primary-figure", "secondary-figure", "visual", "ws", "cross-field", "wallet-menu"],
+  "components": [
+    "shell",
+    "primary-figure",
+    "secondary-figure",
+    "visual",
+    "ws",
+    "cross-field",
+    "wallet-menu",
+    "route-stepper"
+  ],
   "states": ["loading", "empty", "error", "populated"],
   "cells": [
     {
@@ -721,6 +730,16 @@
         "type": "gap",
         "category": "funded-gated",
         "reason": "the wallet-menu Solana address row renders only for a connected svm (Phantom/Solflare) session, which the walletless fixture suite cannot produce; the row render + copy idiom are unit-covered (WalletInfo.vue suite), so e2e is wallet-gated"
+      }
+    },
+    {
+      "route": "/activities",
+      "component": "route-stepper",
+      "state": "populated",
+      "mapping": {
+        "type": "gap",
+        "category": "funded-gated",
+        "reason": "the pending-transfer route stepper renders a swap leg — a `swap` op (carrying `chain_id` + `from_chain_id` but no `to_chain_id`) alongside `transfer`/`cctp_transfer` — only when a send/receive route includes a swap hop, which needs a connected + funded wallet producing such a route; the swap-leg step assembly is unit-covered (history-store getRouteSteps suite: addPendingTransfer_renders_swap_leg_from_captured_osmosis_payload + the swap-op tests), so e2e is funded-gated"
       }
     }
   ]

--- a/src/common/stores/history/index.test.ts
+++ b/src/common/stores/history/index.test.ts
@@ -386,10 +386,14 @@ describe("HistoryStore", () => {
     }
   });
 
-  it("addPendingTransfer_ignores_non_transfer_operations", () => {
+  it("addPendingTransfer_skips_swap_operation_with_unresolvable_chains", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       const store = useHistoryStore();
+      // A `swap` op is a recognized op kind handled on the same path as
+      // transfer/cctp_transfer. An empty swap body has no resolvable from/to
+      // chains, so the step is skipped with a logged error rather than falling
+      // through silently as an unknown op.
       store.addPendingTransfer(
         { ...baseReceivePayload(), skipRoute: { amount_out: "1000000", operations: [{ swap: {} }] } },
         i18nInstance
@@ -397,7 +401,7 @@ describe("HistoryStore", () => {
       const entry = store.pendingTransfers["1"];
       if (entry === undefined) throw new Error("expected pending transfer 1 to be created");
       expect(entry.historyData.route).toMatchObject({ steps: [] });
-      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalled();
     } finally {
       consoleSpy.mockRestore();
     }
@@ -455,6 +459,135 @@ describe("HistoryStore", () => {
       // The send step (amount_in) is kept; only the malformed receive step is dropped.
       expect(route.steps).toHaveLength(1);
       expect(consoleSpy).toHaveBeenCalled();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Swap op-kind rendering. getRouteSteps recognizes a `swap` op alongside
+  // `transfer` / `cctp_transfer`. Real Skip swap ops carry `chain_id` +
+  // `from_chain_id` but no `to_chain_id` (see the captured osmosis-swap
+  // baseline), so chain resolution falls back to `chain_id` and a single-chain
+  // swap renders as an on-chain step.
+  // ---------------------------------------------------------------------------
+  it("addPendingTransfer_renders_a_step_for_a_swap_operation", () => {
+    seedConfigCurrencies();
+    const store = useHistoryStore();
+    store.addPendingTransfer(
+      {
+        ...baseReceivePayload(),
+        skipRoute: {
+          amount_out: "8156769821",
+          operations: [
+            {
+              amount_in: "10000000",
+              amount_out: "8156769821",
+              swap: { chain_id: "osmosis-1", from_chain_id: "osmosis-1" }
+            }
+          ]
+        },
+        chains: { "osmosis-1": { icon: "osmosis.svg", label: "Osmosis" } }
+      },
+      i18nInstance
+    );
+
+    const entry = store.pendingTransfers["1"];
+    if (entry === undefined) throw new Error("expected pending transfer 1 to be created");
+    const routeDetails = entry.historyData.routeDetails;
+    if (routeDetails === undefined) throw new Error("expected route stepper to be assembled");
+    expect(routeDetails.steps.length).toBeGreaterThan(0);
+  });
+
+  it("addPendingTransfer_swap_leg_adds_a_step_to_a_transfer_swap_transfer_route", () => {
+    seedConfigCurrencies();
+    const store = useHistoryStore();
+
+    const chains = {
+      nolus: { icon: "nolus.svg", label: "Nolus" },
+      solana: { icon: "solana.svg", label: "Solana" }
+    };
+    const transferLeg = (from: string, to: string) => ({
+      amount_in: "100",
+      amount_out: "99",
+      transfer: { from_chain_id: from, to_chain_id: to }
+    });
+    // Real Skip swap-op shape: `chain_id` + `from_chain_id`, no `to_chain_id`.
+    const swapLeg = { amount_in: "99", amount_out: "200", swap: { chain_id: "solana", from_chain_id: "solana" } };
+
+    store.addPendingTransfer(
+      {
+        ...baseReceivePayload(),
+        id: 10,
+        skipRoute: {
+          amount_out: "1000000",
+          operations: [transferLeg("nolus", "solana"), transferLeg("solana", "nolus")]
+        },
+        chains
+      },
+      i18nInstance
+    );
+    store.addPendingTransfer(
+      {
+        ...baseReceivePayload(),
+        id: 11,
+        skipRoute: {
+          amount_out: "1000000",
+          operations: [transferLeg("nolus", "solana"), swapLeg, transferLeg("solana", "nolus")]
+        },
+        chains
+      },
+      i18nInstance
+    );
+
+    const withoutSwap = store.pendingTransfers["10"]?.historyData.routeDetails;
+    const withSwap = store.pendingTransfers["11"]?.historyData.routeDetails;
+    if (withoutSwap === undefined || withSwap === undefined) throw new Error("expected both route steppers");
+    expect(withSwap.steps.length).toBeGreaterThan(withoutSwap.steps.length);
+  });
+
+  it("addPendingTransfer_renders_swap_leg_from_captured_osmosis_payload", () => {
+    seedConfigCurrencies();
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const store = useHistoryStore();
+      // Operations lifted verbatim from the captured production quote
+      // (.claude/baselines/osmosis-swap-baseline): an on-chain swap leg
+      // (`chain_id`+`from_chain_id`, no `to_chain_id`) then an IBC transfer home.
+      store.addPendingTransfer(
+        {
+          ...baseReceivePayload(),
+          skipRoute: {
+            amount_out: "8156769821",
+            operations: [
+              {
+                amount_in: "10000000",
+                amount_out: "8156769821",
+                swap: { chain_id: "osmosis-1", from_chain_id: "osmosis-1" }
+              },
+              {
+                amount_in: "8156769821",
+                amount_out: "8156769821",
+                transfer: { chain_id: "osmosis-1", from_chain_id: "osmosis-1", to_chain_id: "pirin-1" }
+              }
+            ]
+          },
+          chains: {
+            "osmosis-1": { icon: "osmosis.svg", label: "Osmosis" },
+            "pirin-1": { icon: "nolus.svg", label: "Nolus" }
+          }
+        },
+        i18nInstance
+      );
+
+      const entry = store.pendingTransfers["1"];
+      if (entry === undefined) throw new Error("expected pending transfer 1 to be created");
+      const routeDetails = entry.historyData.routeDetails;
+      if (routeDetails === undefined) throw new Error("expected route stepper to be assembled");
+      // Swap leg + transfer leg + receive step = 3; the swap leg is rendered,
+      // not dropped, and nothing is skipped with an error.
+      expect(routeDetails.steps).toHaveLength(3);
+      expect(consoleSpy).not.toHaveBeenCalled();
     } finally {
       consoleSpy.mockRestore();
     }

--- a/src/common/stores/history/index.ts
+++ b/src/common/stores/history/index.ts
@@ -555,12 +555,16 @@ export const useHistoryStore = defineStore("history", () => {
         ? operation.transfer
         : isRecord(operation.cctp_transfer)
           ? operation.cctp_transfer
-          : undefined;
+          : isRecord(operation.swap)
+            ? operation.swap
+            : undefined;
       if (op === undefined) {
         continue;
       }
-      const from = getChainDisplay(chains, op.from_chain_id);
-      const to = getChainDisplay(chains, op.to_chain_id);
+      // Skip swap ops carry `chain_id` (+ `from_chain_id`) but no `to_chain_id`;
+      // fall back to chain_id so a single-chain swap resolves to an on-chain step.
+      const from = getChainDisplay(chains, op.from_chain_id ?? op.chain_id);
+      const to = getChainDisplay(chains, op.to_chain_id ?? op.chain_id);
       if (from === undefined || to === undefined) {
         console.error("[HistoryStore] Skipping route step with unknown chain:", op.from_chain_id, op.to_chain_id);
         continue;

--- a/src/common/utils/swapProvider.test.ts
+++ b/src/common/utils/swapProvider.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import type { AppConfigResponse, NetworkInfo } from "@/common/api/types/config";
+import { useConfigStore } from "@/common/stores/config";
+
+// `getSwapProvider` resolves a protocolFilter (uppercase network key) to its
+// network's chain_type and returns the matching provider: cosmos -> Skip
+// (OSMOSIS, unchanged), svm -> the Solana router. An unknown network must yield
+// a typed error, never a silent Skip fallback.
+import { getSwapProvider, UnknownSwapNetworkError } from "./swapProvider";
+
+// A cosmos network keyed by its uppercase filter, matching the backend shape
+// pinned in src/networks/config.test.ts.
+const OSMOSIS = {
+  key: "OSMOSIS",
+  value: "osmosis",
+  name: "Osmosis",
+  prefix: "osmo",
+  symbol: "OSMO",
+  chain_type: "cosmos",
+  native: false,
+  icon: "/assets/icons/networks/osmosis.svg",
+  gas_price: "0.025uosmo",
+  gas_multiplier: 3.5,
+  explorer: "https://www.mintscan.io/osmosis"
+} as unknown as NetworkInfo;
+
+const SOLANA = {
+  key: "SOLANA",
+  value: "solana",
+  name: "Solana",
+  prefix: "",
+  symbol: "SOL",
+  chain_type: "svm",
+  native: false,
+  icon: "/assets/icons/networks/solana.svg",
+  rpc_url: "",
+  rest_url: "",
+  gas_price: "",
+  gas_multiplier: 1.0,
+  program_id: "NoLuSpRoGrAm1111111111111111111111111111111",
+  transfer_channel_id: "channel-0",
+  explorer_url_pattern: "https://solscan.io/tx/{txHash}"
+} as unknown as NetworkInfo;
+
+function seedNetworks(networks: NetworkInfo[]): void {
+  const configStore = useConfigStore();
+  configStore.config = { networks } as unknown as AppConfigResponse;
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("getSwapProvider", () => {
+  it("returns_the_skip_provider_for_a_cosmos_network", () => {
+    seedNetworks([OSMOSIS]);
+    expect(getSwapProvider("OSMOSIS").id).toBe("skip");
+  });
+
+  it("returns_the_solana_provider_for_an_svm_network", () => {
+    seedNetworks([SOLANA]);
+    expect(getSwapProvider("SOLANA").id).toBe("solana");
+  });
+
+  it("throws_a_typed_error_for_an_unknown_network", () => {
+    seedNetworks([OSMOSIS, SOLANA]);
+    expect(() => getSwapProvider("MARS")).toThrow(UnknownSwapNetworkError);
+  });
+
+  it("throws_for_the_empty_protocol_filter_rather_than_defaulting_to_skip", () => {
+    seedNetworks([OSMOSIS, SOLANA]);
+    expect(() => getSwapProvider("")).toThrow(UnknownSwapNetworkError);
+  });
+});

--- a/src/common/utils/swapProvider.ts
+++ b/src/common/utils/swapProvider.ts
@@ -1,0 +1,46 @@
+import { useConfigStore } from "@/common/stores/config";
+import { ChainType } from "@/common/types/Network";
+
+/**
+ * Which router services a network's swaps.
+ * `skip` = Cosmos networks via the Skip API (OSMOSIS, unchanged);
+ * `solana` = the Solana router.
+ */
+export type SwapProviderId = "skip" | "solana";
+
+/**
+ * Seam over the swap pipeline. Call sites dispatch on `id` to select the
+ * concrete router for the session's active network.
+ */
+export interface SwapProvider {
+  readonly id: SwapProviderId;
+}
+
+/** Raised when a network's `chain_type` maps to no swap provider. */
+export class UnknownSwapNetworkError extends Error {
+  constructor(protocolFilter: string) {
+    super(`No swap provider is registered for network "${protocolFilter}"`);
+    this.name = "UnknownSwapNetworkError";
+  }
+}
+
+const SKIP_PROVIDER: SwapProvider = { id: "skip" };
+const SOLANA_PROVIDER: SwapProvider = { id: "solana" };
+
+/**
+ * Resolve the swap provider for a `protocolFilter` (an uppercase network key)
+ * by the network's `chain_type`: cosmos -> Skip, svm -> Solana. An unknown or
+ * unconfigured network throws {@link UnknownSwapNetworkError} — never a silent
+ * Skip fallback.
+ */
+export function getSwapProvider(protocolFilter: string): SwapProvider {
+  const chainType = useConfigStore().getNetwork(protocolFilter)?.chain_type;
+  switch (chainType) {
+    case ChainType.cosmos:
+      return SKIP_PROVIDER;
+    case ChainType.svm:
+      return SOLANA_PROVIDER;
+    default:
+      throw new UnknownSwapNetworkError(protocolFilter);
+  }
+}


### PR DESCRIPTION
Introduces the swap provider seam ahead of the swap pipeline (epic #287, WS4). Closes #297.

## What
- `src/common/utils/swapProvider.ts` — `getSwapProvider(protocolFilter)` resolves the network's `chain_type` via the config store and returns a discriminated provider (`cosmos` -> `skip`, `svm` -> `solana`). Unknown or unconfigured networks throw a typed `UnknownSwapNetworkError` — never a silent default to Skip.
- `getRouteSteps` now renders `swap` operations as a route step. Chain resolution matches the real Skip payload shape (`swap.chain_id` + `from_chain_id`, no `to_chain_id` — verified against a captured live Osmosis quote at main's SHA); previously a swap leg was silently dropped from the stepper.
- Call sites are intentionally NOT rerouted yet (follow-up: WS4.2). Osmosis/Skip behavior is untouched.

## QA suite impact
suite impact: no new live assertion — the swap-leg route stepper is funded-gated (recorded as /activities x route-stepper in coverage-matrix.json); swap-leg step assembly is covered by the history-store getRouteSteps unit suite.

## Evidence
- Tests: 53/53 in touched files (incl. a proof test feeding the captured Osmosis 2-op route: 3 steps rendered, zero console errors); full app suite 1129/1129; e2e static suite 418/418; `check:matrix` OK (funded-gated 7->8).
- Gates: vue-tsc, eslint + style, prettier, vitest, vite build — all green in both workspaces.
- Review: generic 12-item checklist PASS (report below), security review CLEAR (report below), project-rule conformance walk PASS (verdict only; rule-by-rule walk kept locally).

<details><summary>Generic review report</summary>

# Diff Review Report

Branch: feat/swap-provider-seam
Diff range: c6f19a56..HEAD (HEAD = ec1a597f, round 2)
Files changed: 6 (e2e/README.md, e2e/coverage-matrix.json, src/common/stores/history/index.test.ts, src/common/stores/history/index.ts, src/common/utils/swapProvider.test.ts [new], src/common/utils/swapProvider.ts [new])

## Acceptance criteria check
- AC1 (getSwapProvider dispatch cosmos->skip, svm->solana, unknown/empty -> typed UnknownSwapNetworkError, never silent-default): MET — `src/common/utils/swapProvider.ts:38-46` switches on `chain_type`, `default` throws `UnknownSwapNetworkError`. Verified against `ChainType` enum and `getNetwork` (keyed by uppercase `n.key`). 4 tests pass including empty-filter -> throw.
- AC2 (getRouteSteps swap arm with captured Skip shape: from_chain_id ?? chain_id, to_chain_id ?? chain_id): MET — `src/common/stores/history/index.ts:558-570`. Proof test `addPendingTransfer_renders_swap_leg_from_captured_osmosis_payload` feeds the captured Osmosis 2-op route, asserts exactly 3 steps and zero console.error. Passes.
- AC3 (P6 remedy: matrix/README gain route-stepper + funded-gated /activities cell, check:matrix passes, funded-gated 7->8): MET — ran `npm run check:matrix` in e2e: "coverage matrix OK — 40 mapped cell(s); gaps: funded-gated=8". README documents the gap.
- AC4 (round-1 task-reference comments removed; comment discipline): MET — grep for `#297`/`round-1`/`task ` in added lines returns nothing; remaining comments explain non-obvious WHY (Skip payload shape).
- AC5 (seam exposes only readonly id discriminant; call sites intentionally NOT rerouted): MET — `SwapProvider` interface has only `readonly id`; grep confirms no non-test call site imports `getSwapProvider`.
- Full run: 53/53 tests pass across both affected files; eslint clean on all 4 changed src files.

## Checklist

1. **No debug prints, logging leftovers, or commented-out code** — PASS
   `console.error` calls are pre-existing structured error-logging in getRouteSteps (documented "skip, don't throw" design), not debug leftovers. No console.log/debugger. No commented-out code.

2. **No off-by-one errors in loops, slices, or ranges** — PASS
   Diff adds only the `swap` narrowing arm and `?? chain_id` fallbacks; surrounding index math (`index === 0 ? amount_in : amount_out`, `index === operations.length - 1` receive step) is unchanged and correct. Captured-payload test confirms exactly 3 steps for the 2-op route.

3. **All match/enum arms handled** — PASS
   `getSwapProvider` switch handles `cosmos` and `svm` explicitly; `evm` and unknown fall to `default` which throws a typed error (never a silent default). See LOW finding on evm messaging.

4. **Error paths return meaningful errors — no silent swallows** — PASS
   `getSwapProvider` throws `UnknownSwapNetworkError` with the offending filter name. getRouteSteps unresolvable-chain path logs a specific error and skips (documented resilience design); empty-swap case now asserted to log (test flipped to `toHaveBeenCalled`).

5. **Boundary conditions: empty collections, zero/negative values, max values** — PASS
   Empty swap `{}` -> unresolved chains -> skipped with error (tested). Empty operations -> `[]` steps. Empty protocolFilter `""` -> throws (tested). Unknown network `"MARS"` -> throws (tested).

6. **Async: no held locks across await, no missing await** — PASS
   No async code introduced; `getSwapProvider` is synchronous, getRouteSteps arm is synchronous.

7. **No resource leaks: unclosed files, connections, transactions** — PASS
   Test console spies restored in `finally` blocks; `afterEach` runs `vi.restoreAllMocks()`. No files/connections opened.

8. **SQL: parameterized queries only — no string interpolation** — PASS (N/A)
   No SQL in diff.

9. **New public functions/endpoints have test coverage** — PASS
   `getSwapProvider` / `UnknownSwapNetworkError`: 4-test spec. New swap-op arm of getRouteSteps: 3 new tests + updated existing test, all passing.

10. **No logic inversions (`!=` vs `==`, `&&` vs `||`)** — PASS
    `op.from_chain_id ?? op.chain_id` and `op.to_chain_id ?? op.chain_id` are correct nullish fallbacks. Test assertion correctly flipped from `not.toHaveBeenCalled` to `toHaveBeenCalled` to match the new behavior (empty swap now logs).

11. **Types: no unnecessary clones/copies** — PASS
    `SKIP_PROVIDER` / `SOLANA_PROVIDER` are module-level singletons returned by reference — no per-call allocation. No `any` (verified via eslint clean). Test fixtures use `as unknown as NetworkInfo` casts, acceptable in test scope.

12. **Concurrency: shared state properly guarded, no TOCTOU races** — PASS (N/A)
    Single-threaded frontend; no shared mutable concurrency introduced.

## Additional findings beyond the 12-item checklist
None blocking.

## Verdict
PASS — all 12 items pass, all acceptance criteria met. Tests 53/53, eslint clean, check:matrix OK (funded-gated=8). One LOW cosmetic note below; non-blocking.
</details>

<details><summary>Security review report</summary>

# Security Review Report

Branch: feat/swap-provider-seam
Diff range: c6f19a56..HEAD (round 2, commit ec1a597f)

## Diff classification
- Files in diff: 6 (2 source, 2 test, 2 e2e/docs)
- Categories detected:
  - **Untrusted input parsing** — `getRouteSteps` deserializes route-operation payloads (Skip API / on-chain history data); the new `swap` op arm and the `chain_id` fallback extend that parser.
  - **Config read** (secondary, non-sensitive) — `getSwapProvider` reads `chain_type` from the config store to dispatch a provider. No secrets, no auth boundary.
- Categories NOT present: crypto/key handling, secrets/credentials, auth/access control, SQL/DB, smart contracts, dependency manifests, network egress, concurrency/shared state.
- Re-classified from scratch; agrees with the caller's spawn-gate classification (untrusted input) — no disagreement to report.

## Skills dispatched
- `differential-review` (always) — run diff-scoped.
- Semgrep (table-mapped for untrusted-input parsing) intentionally **not** run: the caller forbade repo-wide scanners. The two changed source files were instead reviewed line-by-line and adversarially, so the parsing category is covered manually + via differential-review.

## Findings

### CRITICAL (must fix before merge)
None.

### HIGH (should fix before merge)
None.

### MEDIUM (track as TODO)
None.

### LOW / INFORMATIONAL
- `src/common/stores/history/index.ts:571` — the unresolved-chain skip branch logs `op.from_chain_id, op.to_chain_id` but not the `chain_id` value it actually fell back to. Purely a diagnostic-quality nit; no security impact.
- `src/common/stores/history/index.test.ts` (`addPendingTransfer_skips_swap_operation_with_unresolvable_chains`) — an empty `swap: {}` body now emits a `console.error` where it was previously skipped silently as an unknown op. Benign: real Skip swap ops always carry `chain_id` + `from_chain_id` per the captured baseline, so an empty body is genuinely malformed and logging + skip is the correct behavior.

## Verification of the round-2 focus items
- **New `swap` discriminant** — `isRecord(operation.swap)`-guarded identically to `transfer`/`cctp_transfer`; no unguarded field access introduced.
- **`chain_id` fallback** — `op.from_chain_id ?? op.chain_id` (and `to_chain_id ?? chain_id`) flows into `getChainDisplay`, which type-checks `chainId` (string|number), `isRecord`-guards the chains entry, and type-checks `icon`/`label` as strings. Output rendered through Vue `h()` (auto-escaped). No new injection/XSS sink; the icon/label extraction and rendering predate this diff.
- **`getSwapProvider` dispatch** — fail-closed: `cosmos→skip`, `svm→solana`; every other input (valid-but-unhandled `evm`, unknown network, empty string) throws the typed `UnknownSwapNetworkError`. No silent Skip default. `getNetwork("")` returns undefined → throws. Directly test-covered (4 specs incl. empty-string and unknown-network cases).
- **P6 compliance remedy** — proof test `addPendingTransfer_renders_swap_leg_from_captured_osmosis_payload` feeds the captured 2-op Osmosis route (on-chain swap leg + IBC transfer home) and asserts exactly 3 assembled steps with zero `console.error`. `e2e/coverage-matrix.json` adds the `route-stepper` component and a funded-gated `/activities × route-stepper` cell whose reason string accurately describes the real payload shape (`chain_id` + `from_chain_id`, no `to_chain_id`). `e2e/README.md` documents the gap. Remedy is complete and accurate.
- **Regression check** — git blame confirms no security code was removed (prior touch was an unrelated snake_case amount fix, #342). No `any` in source; `as unknown as` casts appear only in test fixtures.

## Coverage gaps
- Categories present with no matching diff-scoped skill: none.
- Semgrep (untrusted-input mapping) was scoped out per the no-repo-wide-scanner constraint; parsing paths were covered by manual + differential-review analysis instead, so no manual follow-up is outstanding.
- Manual review recommended for: none beyond what was performed.

## Verdict
CLEAR — no findings above MEDIUM. The change is defensively coded, fail-closed on unknown networks and unresolvable chains, and fully unit-covered including a captured-payload proof test. The P6 QA-matrix/tier-evidence remedy is verified.
</details>
