### PR TITLE
feat(backend): Nolus-Solana transfer tracker and status API

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,6 +36,11 @@ SOLANA_RPC_URL=
 # independently.
 # SOLANA_MAX_CONCURRENT_QUERIES=256
 
+# Deployed Solray IBC program id, used for packet-PDA owner checks and PDA
+# derivation. Differs per cluster; default is the mainnet id. Set this when
+# pointing SOLANA_RPC_URL at devnet/testnet.
+# SOLANA_SOLRAY_PROGRAM_ID=JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFF
+
 # Path to the durable transfer tracking-set image (default: ./data/transfers.json).
 # Backs GET /api/transfer/status/{id} across restarts; the parent directory is
 # created on startup and a corrupt image fails loud rather than starting empty.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,6 +36,11 @@ SOLANA_RPC_URL=
 # independently.
 # SOLANA_MAX_CONCURRENT_QUERIES=256
 
+# Path to the durable transfer tracking-set image (default: ./data/transfers.json).
+# Backs GET /api/transfer/status/{id} across restarts; the parent directory is
+# created on startup and a corrupt image fails loud rather than starting empty.
+# TRANSFER_STORE_PATH=./data/transfers.json
+
 # =============================================================================
 # External API URLs (Required)
 # =============================================================================

--- a/backend/openapi.snapshot.json
+++ b/backend/openapi.snapshot.json
@@ -3701,6 +3701,119 @@
         }
       }
     },
+    "/api/transfer/status/{id}": {
+      "get": {
+        "tags": [
+          "transfer"
+        ],
+        "summary": "Return the current status of a tracked route.",
+        "operationId": "get_transfer_status",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Tracked route id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current route status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransferStatusResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown route id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/transfer/track": {
+      "post": {
+        "tags": [
+          "transfer"
+        ],
+        "summary": "Register an in-flight route for tracking.",
+        "operationId": "track_transfer",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferTrackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Route registered for tracking",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackAccepted"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Untrackable request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Active tracking set full",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Solana RPC error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Solana RPC unconfigured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/zero-interest/config": {
       "get": {
         "tags": [
@@ -4178,6 +4291,22 @@
           }
         }
       },
+      "AssetRelease": {
+        "type": "object",
+        "description": "Where the asset currently rests, mirroring Skip's `transfer_asset_release`.",
+        "required": [
+          "chain",
+          "released"
+        ],
+        "properties": {
+          "chain": {
+            "type": "string"
+          },
+          "released": {
+            "type": "boolean"
+          }
+        }
+      },
       "AssetResponse": {
         "type": "object",
         "description": "Single asset with display info and price",
@@ -4434,6 +4563,14 @@
             "type": "string"
           }
         }
+      },
+      "Chain": {
+        "type": "string",
+        "description": "The two chains a transfer leg can touch.",
+        "enum": [
+          "nolus",
+          "solana"
+        ]
       },
       "ClaimRewardsRequest": {
         "type": "object",
@@ -4789,6 +4926,14 @@
           }
         }
       },
+      "Direction": {
+        "type": "string",
+        "description": "Direction of the overall route, fixing which chain holds the commitment\ntruth and which supplies terminal events.",
+        "enum": [
+          "nolus_to_solana",
+          "solana_to_nolus"
+        ]
+      },
       "DownpaymentRange": {
         "type": "object",
         "description": "Downpayment range for an asset",
@@ -5133,6 +5278,26 @@
             "items": {
               "type": "string"
             }
+          }
+        }
+      },
+      "IbcHeight": {
+        "type": "object",
+        "description": "An IBC height is a `(revision_number, revision_height)` tuple. Timeout\neligibility compares the whole tuple, never the slot alone.",
+        "required": [
+          "revision_number",
+          "revision_height"
+        ],
+        "properties": {
+          "revision_number": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "revision_height": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
           }
         }
       },
@@ -8049,6 +8214,38 @@
           }
         }
       },
+      "TrackAccepted": {
+        "type": "object",
+        "description": "`POST /api/transfer/track` success body.",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        }
+      },
+      "TrackLegSpec": {
+        "type": "object",
+        "description": "One requested leg of a route to track.",
+        "required": [
+          "from_chain",
+          "to_chain",
+          "timeout_height"
+        ],
+        "properties": {
+          "from_chain": {
+            "$ref": "#/components/schemas/Chain"
+          },
+          "to_chain": {
+            "$ref": "#/components/schemas/Chain"
+          },
+          "timeout_height": {
+            "$ref": "#/components/schemas/IbcHeight"
+          }
+        }
+      },
       "TrackRequest": {
         "type": "object",
         "description": "Request to track a swap transaction on Skip.",
@@ -8102,6 +8299,111 @@
           },
           "native": {
             "type": "boolean"
+          }
+        }
+      },
+      "TransferError": {
+        "type": "object",
+        "description": "Typed per-route error, mirroring Skip's error envelope.",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "TransferLeg": {
+        "type": "object",
+        "description": "One entry of the modern `transfers[]` shape: a per-leg state plus the\nchains it bridges.",
+        "required": [
+          "state",
+          "from_chain",
+          "to_chain"
+        ],
+        "properties": {
+          "state": {
+            "type": "string"
+          },
+          "from_chain": {
+            "type": "string"
+          },
+          "to_chain": {
+            "type": "string"
+          }
+        }
+      },
+      "TransferStatusResponse": {
+        "type": "object",
+        "description": "The status response served by `GET /api/transfer/status/{id}`. This is the\ntracker's own type, NOT a re-use of `SkipStatusResponse`.",
+        "required": [
+          "state",
+          "transfers"
+        ],
+        "properties": {
+          "state": {
+            "type": "string"
+          },
+          "transfers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferLeg"
+            }
+          },
+          "next_blocking_transfer": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "transfer_asset_release": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AssetRelease"
+              }
+            ]
+          },
+          "error": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TransferError"
+              }
+            ]
+          }
+        }
+      },
+      "TransferTrackRequest": {
+        "type": "object",
+        "description": "`POST /api/transfer/track` request body.",
+        "required": [
+          "direction",
+          "channel",
+          "legs"
+        ],
+        "properties": {
+          "direction": {
+            "$ref": "#/components/schemas/Direction"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "legs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TrackLegSpec"
+            }
           }
         }
       },
@@ -8598,6 +8900,10 @@
     {
       "name": "swap",
       "description": "Cross-chain swap (Skip passthrough, opaque bodies)"
+    },
+    {
+      "name": "transfer",
+      "description": "Nolus<->Solana transfer tracking and status"
     },
     {
       "name": "etl",

--- a/backend/src/external/solana.rs
+++ b/backend/src/external/solana.rs
@@ -9,6 +9,7 @@
 //! semaphore/env var rather than sharing the chain client's. No raw RPC proxy
 //! is exposed to the frontend.
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -487,6 +488,44 @@ impl SolanaClient {
     }
 }
 
+/// The deployed Solray program id. Every packet PDA fetched from Solana must be
+/// owned by this program before its bytes are decoded — the decoders operate on
+/// raw bytes and cannot tell a packet PDA from any other account whose data
+/// happens to decode as the same B-tree.
+pub const SOLRAY_PROGRAM_ID: &str = "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFF";
+
+/// A decoded packet PDA, indexed by sequence. An `Absent` account (the
+/// `getAccountInfo` value was null) is distinct from a `Present` but empty PDA:
+/// the first means the channel has no such PDA, the second means the PDA exists
+/// and currently holds no entries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PacketPdaSnapshot {
+    Absent,
+    Present(BTreeSet<u64>),
+}
+
+/// Decode a fetched packet-commitment PDA into the set of sequences that still
+/// hold an outstanding commitment. Owner-checked against [`SOLRAY_PROGRAM_ID`];
+/// `None` maps to [`PacketPdaSnapshot::Absent`]. Pure over the fetched
+/// `account` — no RPC — so a poll cycle decodes once and indexes by sequence.
+pub fn decode_commitment_pda(
+    account: Option<&SolanaAccount>,
+) -> Result<PacketPdaSnapshot, AppError> {
+    let _ = account;
+    todo!("Absent for None; else owner-check then ibc_solray::api::query::decode_packet_commitments")
+}
+
+/// Decode a fetched packet-acknowledgement PDA into the set of acknowledged
+/// sequences. Presence proves an ack exists; the success-vs-error polarity is
+/// NOT decodable here (the PDA stores only a commitment hash). Owner-checked;
+/// `None` maps to [`PacketPdaSnapshot::Absent`].
+pub fn decode_acknowledgement_pda(
+    account: Option<&SolanaAccount>,
+) -> Result<PacketPdaSnapshot, AppError> {
+    let _ = account;
+    todo!("Absent for None; else owner-check then decode+index the ack PDA")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -930,5 +969,80 @@ mod sdk_pin_tests {
         let derived = id.derive_address();
         assert_eq!(derived.to_string(), EXPECTED_VAULT_AUTHORITY);
         assert!(id.point_to(&derived));
+    }
+}
+
+/// Wrapper behavior for the packet-PDA decoders: owner verification, the
+/// absent-vs-empty distinction, and malformed-bytes error surfacing. The
+/// happy-path B-tree decode itself is covered by ibc-solray's own crate tests;
+/// these pin the webapp-side wrapper contract, which needs no live RPC.
+#[cfg(test)]
+mod packet_pda_tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    const OTHER_OWNER: &str = "11111111111111111111111111111111";
+    /// base64 of a 3-byte buffer — too short to be a valid B-tree header.
+    const TRUNCATED_BASE64: &str = "AAAA";
+
+    fn account(owner: &str, data_base64: &str) -> SolanaAccount {
+        SolanaAccount {
+            lamports: 10,
+            owner: owner.to_string(),
+            executable: false,
+            data: vec![data_base64.to_string(), "base64".to_string()],
+        }
+    }
+
+    #[test]
+    fn absent_commitment_account_is_absent_not_empty() {
+        assert_eq!(
+            decode_commitment_pda(None).expect("absent decodes"),
+            PacketPdaSnapshot::Absent
+        );
+    }
+
+    #[test]
+    fn present_empty_commitment_pda_is_present_with_no_sequences() {
+        let empty = account(SOLRAY_PROGRAM_ID, "");
+        assert_eq!(
+            decode_commitment_pda(Some(&empty)).expect("empty PDA decodes"),
+            PacketPdaSnapshot::Present(BTreeSet::new())
+        );
+    }
+
+    #[test]
+    fn wrong_owner_commitment_account_is_rejected_before_decode() {
+        let foreign = account(OTHER_OWNER, "");
+        assert!(
+            decode_commitment_pda(Some(&foreign)).is_err(),
+            "an account not owned by the solray program must be rejected"
+        );
+    }
+
+    #[test]
+    fn truncated_commitment_bytes_surface_as_error() {
+        let malformed = account(SOLRAY_PROGRAM_ID, TRUNCATED_BASE64);
+        assert!(
+            decode_commitment_pda(Some(&malformed)).is_err(),
+            "a sub-header byte buffer must surface a decode error"
+        );
+    }
+
+    #[test]
+    fn absent_acknowledgement_account_is_absent_not_empty() {
+        assert_eq!(
+            decode_acknowledgement_pda(None).expect("absent decodes"),
+            PacketPdaSnapshot::Absent
+        );
+    }
+
+    #[test]
+    fn wrong_owner_acknowledgement_account_is_rejected_before_decode() {
+        let foreign = account(OTHER_OWNER, "");
+        assert!(
+            decode_acknowledgement_pda(Some(&foreign)).is_err(),
+            "an account not owned by the solray program must be rejected"
+        );
     }
 }

--- a/backend/src/external/solana.rs
+++ b/backend/src/external/solana.rs
@@ -10,7 +10,7 @@
 //! is exposed to the frontend.
 
 use std::collections::BTreeSet;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use reqwest::Client;
@@ -199,10 +199,11 @@ impl SolanaClient {
 
     /// Execute a JSON-RPC call and return the raw `result`.
     ///
-    /// Acquires a semaphore permit held across the full retry chain; retries
-    /// 429/503 with exponential backoff + jitter (honoring `Retry-After`); maps
-    /// transport failures, non-2xx responses, and JSON-RPC `error` objects to
-    /// typed [`AppError::ChainRpc`].
+    /// Acquires a fresh semaphore permit for each attempt, held across that
+    /// attempt's request but released before the backoff sleep; retries 429/503
+    /// with exponential backoff + jitter (honoring `Retry-After`); maps transport
+    /// failures, non-2xx responses, and JSON-RPC `error` objects to typed
+    /// [`AppError::ChainRpc`].
     async fn request<R: DeserializeOwned>(
         &self,
         method: &str,
@@ -494,11 +495,28 @@ impl SolanaClient {
     }
 }
 
-/// The deployed Solray program id. Every packet PDA fetched from Solana must be
-/// owned by this program before its bytes are decoded — the decoders operate on
-/// raw bytes and cannot tell a packet PDA from any other account whose data
-/// happens to decode as the same B-tree.
+/// The deployed Solray program id on Solana mainnet — the default when
+/// `SOLANA_SOLRAY_PROGRAM_ID` is unset. Every packet PDA fetched from Solana
+/// must be owned by the configured program before its bytes are decoded, since
+/// the decoders operate on raw bytes and cannot tell a packet PDA from any
+/// other account whose data happens to decode as the same B-tree.
 pub const SOLRAY_PROGRAM_ID: &str = "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFF";
+
+/// The solray program id in effect for owner checks and PDA derivation. The
+/// program id differs per cluster (devnet/testnet/mainnet), so it is overridable
+/// via `SOLANA_SOLRAY_PROGRAM_ID`; unset (or empty) falls back to the mainnet
+/// [`SOLRAY_PROGRAM_ID`]. Read once at first use.
+static CONFIGURED_SOLRAY_PROGRAM_ID: LazyLock<String> = LazyLock::new(|| {
+    std::env::var("SOLANA_SOLRAY_PROGRAM_ID")
+        .ok()
+        .filter(|id| !id.is_empty())
+        .unwrap_or_else(|| SOLRAY_PROGRAM_ID.to_string())
+});
+
+/// The configured solray program id (see [`CONFIGURED_SOLRAY_PROGRAM_ID`]).
+pub fn solray_program_id() -> &'static str {
+    CONFIGURED_SOLRAY_PROGRAM_ID.as_str()
+}
 
 /// A decoded packet PDA, indexed by sequence. An `Absent` account (the
 /// `getAccountInfo` value was null) is distinct from a `Present` but empty PDA:
@@ -518,7 +536,7 @@ fn checked_pda_bytes(account: Option<&SolanaAccount>) -> Result<Option<Vec<u8>>,
     let Some(account) = account else {
         return Ok(None);
     };
-    if account.owner != SOLRAY_PROGRAM_ID {
+    if account.owner.as_str() != solray_program_id() {
         return Err(AppError::ChainRpc {
             chain: CHAIN.to_string(),
             message: format!(

--- a/backend/src/external/solana.rs
+++ b/backend/src/external/solana.rs
@@ -504,6 +504,32 @@ pub enum PacketPdaSnapshot {
     Present(BTreeSet<u64>),
 }
 
+/// Owner-check a fetched packet PDA and return its raw account bytes. `None`
+/// account -> `Ok(None)` (the PDA is absent). A non-solray owner is rejected
+/// *before* any decode, since the decoders operate on raw bytes and cannot tell
+/// a packet PDA from a foreign account whose data happens to decode.
+fn checked_pda_bytes(account: Option<&SolanaAccount>) -> Result<Option<Vec<u8>>, AppError> {
+    let Some(account) = account else {
+        return Ok(None);
+    };
+    if account.owner != SOLRAY_PROGRAM_ID {
+        return Err(AppError::ChainRpc {
+            chain: CHAIN.to_string(),
+            message: format!(
+                "packet PDA owned by {}, not the solray program",
+                account.owner
+            ),
+        });
+    }
+    let encoded = account.data.first().map_or("", String::as_str);
+    let bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, encoded)
+        .map_err(|e| AppError::ChainRpc {
+            chain: CHAIN.to_string(),
+            message: format!("decoding packet PDA account data: {e}"),
+        })?;
+    Ok(Some(bytes))
+}
+
 /// Decode a fetched packet-commitment PDA into the set of sequences that still
 /// hold an outstanding commitment. Owner-checked against [`SOLRAY_PROGRAM_ID`];
 /// `None` maps to [`PacketPdaSnapshot::Absent`]. Pure over the fetched
@@ -511,8 +537,24 @@ pub enum PacketPdaSnapshot {
 pub fn decode_commitment_pda(
     account: Option<&SolanaAccount>,
 ) -> Result<PacketPdaSnapshot, AppError> {
-    let _ = account;
-    todo!("Absent for None; else owner-check then ibc_solray::api::query::decode_packet_commitments")
+    let Some(bytes) = checked_pda_bytes(account)? else {
+        return Ok(PacketPdaSnapshot::Absent);
+    };
+    let entries = ibc_solray::api::query::decode_packet_commitments(&bytes).map_err(|e| {
+        AppError::ChainRpc {
+            chain: CHAIN.to_string(),
+            message: format!("decoding packet commitment PDA: {e}"),
+        }
+    })?;
+    let mut sequences = BTreeSet::new();
+    for entry in entries {
+        let (sequence, _commitment) = entry.map_err(|e| AppError::ChainRpc {
+            chain: CHAIN.to_string(),
+            message: format!("decoding packet commitment entry: {e}"),
+        })?;
+        sequences.insert(u64::from(sequence));
+    }
+    Ok(PacketPdaSnapshot::Present(sequences))
 }
 
 /// Decode a fetched packet-acknowledgement PDA into the set of acknowledged
@@ -522,8 +564,24 @@ pub fn decode_commitment_pda(
 pub fn decode_acknowledgement_pda(
     account: Option<&SolanaAccount>,
 ) -> Result<PacketPdaSnapshot, AppError> {
-    let _ = account;
-    todo!("Absent for None; else owner-check then decode+index the ack PDA")
+    let Some(bytes) = checked_pda_bytes(account)? else {
+        return Ok(PacketPdaSnapshot::Absent);
+    };
+    let entries = ibc_solray::api::query::decode_packet_acknowledgements(&bytes).map_err(|e| {
+        AppError::ChainRpc {
+            chain: CHAIN.to_string(),
+            message: format!("decoding packet acknowledgement PDA: {e}"),
+        }
+    })?;
+    let mut sequences = BTreeSet::new();
+    for entry in entries {
+        let (sequence, _stored_ack) = entry.map_err(|e| AppError::ChainRpc {
+            chain: CHAIN.to_string(),
+            message: format!("decoding packet acknowledgement entry: {e}"),
+        })?;
+        sequences.insert(u64::from(sequence));
+    }
+    Ok(PacketPdaSnapshot::Present(sequences))
 }
 
 #[cfg(test)]

--- a/backend/src/external/solana.rs
+++ b/backend/src/external/solana.rs
@@ -215,12 +215,6 @@ impl SolanaClient {
                 message: "Solana RPC not configured (set SOLANA_RPC_URL)".to_string(),
             })?;
 
-        let _permit = self
-            .query_semaphore
-            .acquire()
-            .await
-            .map_err(|e| AppError::Internal(format!("Semaphore closed: {e}")))?;
-
         let body = json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -231,6 +225,15 @@ impl SolanaClient {
         let mut backoff_ms = INITIAL_BACKOFF_MS;
 
         for attempt in 0..=MAX_RETRIES {
+            // Acquire the concurrency permit per attempt and hold it only across
+            // the request itself, never across the backoff sleep below, so a
+            // backing-off request does not occupy a slot other callers need.
+            let permit = self
+                .query_semaphore
+                .acquire()
+                .await
+                .map_err(|e| AppError::Internal(format!("Semaphore closed: {e}")))?;
+
             let response = self
                 .client
                 .post(url)
@@ -278,6 +281,9 @@ impl SolanaClient {
                 actual_wait
             );
 
+            // Release the concurrency slot before backing off so waiting does
+            // not starve other callers.
+            drop(permit);
             tokio::time::sleep(Duration::from_millis(actual_wait)).await;
             backoff_ms *= 2;
         }

--- a/backend/src/handlers/etl_proxy.rs
+++ b/backend/src/handlers/etl_proxy.rs
@@ -498,6 +498,7 @@ mod tests {
             config_store,
             translation_storage,
             llm_client,
+            transfer_store: crate::transfer_tracker::TransferStore::ephemeral(),
             startup_time: std::time::Instant::now(),
         })
     }

--- a/backend/src/handlers/governance.rs
+++ b/backend/src/handlers/governance.rs
@@ -699,6 +699,7 @@ mod tests {
             config_store,
             translation_storage,
             llm_client,
+            transfer_store: crate::transfer_tracker::TransferStore::ephemeral(),
             startup_time: Instant::now(),
         })
     }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -20,6 +20,7 @@ pub mod spa;
 pub mod staking;
 pub mod swap;
 pub mod transactions;
+pub mod transfer;
 pub mod translations;
 pub mod websocket;
 pub mod zero_interest;

--- a/backend/src/handlers/openapi.rs
+++ b/backend/src/handlers/openapi.rs
@@ -20,8 +20,9 @@ use crate::external;
 use crate::handlers::{
     admin, common_types, config, currencies, earn, etl_proxy, fees, gated_assets, gated_networks,
     gated_protocols, governance, leases, locales, protocols, referral, solana, staking, swap,
-    transactions, zero_interest,
+    transactions, transfer, zero_interest,
 };
+use crate::transfer_tracker;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -133,6 +134,9 @@ use crate::handlers::{
         swap::track_transaction,
         swap::get_route,
         swap::get_messages,
+        // Transfer tracker (Nolus<->Solana route status)
+        transfer::track_transfer,
+        transfer::get_transfer_status,
         // ETL proxy (opaque passthrough)
         etl_proxy::proxy_subscribe,
         etl_proxy::batch_stats_overview,
@@ -290,6 +294,17 @@ use crate::handlers::{
         swap::SwapConfigResponse,
         swap::NetworkTransfers,
         swap::TransferCurrency,
+        // Transfer tracker typed bodies
+        transfer::TrackRequest,
+        transfer::TrackLegSpec,
+        transfer::TrackAccepted,
+        transfer_tracker::TransferStatusResponse,
+        transfer_tracker::TransferLeg,
+        transfer_tracker::AssetRelease,
+        transfer_tracker::TransferError,
+        transfer_tracker::Chain,
+        transfer_tracker::Direction,
+        transfer_tracker::IbcHeight,
         // Skip ingress responses validated at the boundary
         external::skip::SkipRouteResponse,
         external::skip::SkipMessagesResponse,
@@ -336,6 +351,7 @@ use crate::handlers::{
         (name = "assets", description = "Gated assets catalog (deduplicated view)"),
         (name = "networks", description = "Gated networks catalog"),
         (name = "swap", description = "Cross-chain swap (Skip passthrough, opaque bodies)"),
+        (name = "transfer", description = "Nolus<->Solana transfer tracking and status"),
         (name = "etl", description = "ETL proxy endpoints (opaque passthrough)"),
         (name = "transactions", description = "Enriched transactions (opaque passthrough)"),
         (name = "intercom", description = "Intercom user-hash issuance"),

--- a/backend/src/handlers/transfer.rs
+++ b/backend/src/handlers/transfer.rs
@@ -1,0 +1,173 @@
+//! HTTP surface for the transfer tracker.
+//!
+//! `POST /api/transfer/track` (strict-class) registers an in-flight route for
+//! tracking; `GET /api/transfer/status/{id}` (read-class) returns its status.
+//! Registration is refused for untrackable work: an unknown channel, too many
+//! legs, no on-chain commitment evidence, a full active set, or an
+//! unconfigured Solana client.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::error::AppError;
+use crate::transfer_tracker::{Chain, Direction, IbcHeight, TransferStatusResponse};
+use crate::AppState;
+
+/// One requested leg of a route to track.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrackLegSpec {
+    pub from_chain: Chain,
+    pub to_chain: Chain,
+    pub timeout_height: IbcHeight,
+}
+
+/// `POST /api/transfer/track` request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrackRequest {
+    pub direction: Direction,
+    pub channel: String,
+    pub legs: Vec<TrackLegSpec>,
+}
+
+/// `POST /api/transfer/track` success body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrackAccepted {
+    pub id: String,
+}
+
+/// Runtime facts the registration check needs, gathered before validation.
+pub struct TrackPreconditions {
+    pub channel_known: bool,
+    pub solana_configured: bool,
+    pub commitment_evidence: bool,
+    pub active_count: usize,
+    pub capacity: usize,
+}
+
+/// Reject untrackable registration requests with the mapped typed error:
+/// unconfigured Solana client -> 503, unknown channel / over-leg-cap / no
+/// commitment evidence -> 400, full active set -> 429.
+pub fn validate_track(request: &TrackRequest, pre: &TrackPreconditions) -> Result<(), AppError> {
+    let _ = (request, pre);
+    todo!("map each precondition failure to its typed AppError")
+}
+
+/// Register an in-flight route for tracking.
+pub async fn track_transfer(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<TrackRequest>,
+) -> Result<Json<TrackAccepted>, AppError> {
+    let _ = (state, request);
+    todo!("gather preconditions, validate_track, insert into the store")
+}
+
+/// Return the current status of a tracked route.
+pub async fn get_transfer_status(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<TransferStatusResponse>, AppError> {
+    let _ = (state, id);
+    todo!("look up the route, build its status response, 404 when absent")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn leg() -> TrackLegSpec {
+        TrackLegSpec {
+            from_chain: Chain::Solana,
+            to_chain: Chain::Nolus,
+            timeout_height: IbcHeight {
+                revision_number: 5,
+                revision_height: 100,
+            },
+        }
+    }
+
+    fn request_with_legs(count: usize) -> TrackRequest {
+        TrackRequest {
+            direction: Direction::SolanaToNolus,
+            channel: "channel-0".to_string(),
+            legs: std::iter::repeat_with(leg).take(count).collect(),
+        }
+    }
+
+    /// Preconditions where every gate passes; each test flips exactly one.
+    fn all_good() -> TrackPreconditions {
+        TrackPreconditions {
+            channel_known: true,
+            solana_configured: true,
+            commitment_evidence: true,
+            active_count: 0,
+            capacity: 512,
+        }
+    }
+
+    #[test]
+    fn accepts_a_valid_registration() {
+        let result = validate_track(&request_with_legs(1), &all_good());
+        assert!(result.is_ok(), "a fully-valid request must be accepted");
+    }
+
+    #[test]
+    fn rejects_unknown_channel_as_validation_error() {
+        let pre = TrackPreconditions {
+            channel_known: false,
+            ..all_good()
+        };
+        assert!(matches!(
+            validate_track(&request_with_legs(1), &pre),
+            Err(AppError::Validation { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_leg_count_over_cap_as_validation_error() {
+        let pre = all_good();
+        assert!(matches!(
+            validate_track(&request_with_legs(crate::transfer_tracker::MAX_TRACKED_LEGS + 1), &pre),
+            Err(AppError::Validation { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_registration_without_commitment_evidence() {
+        let pre = TrackPreconditions {
+            commitment_evidence: false,
+            ..all_good()
+        };
+        assert!(matches!(
+            validate_track(&request_with_legs(1), &pre),
+            Err(AppError::Validation { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_registration_at_active_set_capacity() {
+        let pre = TrackPreconditions {
+            active_count: 512,
+            capacity: 512,
+            ..all_good()
+        };
+        assert!(matches!(
+            validate_track(&request_with_legs(1), &pre),
+            Err(AppError::RateLimited { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_registration_when_solana_client_unconfigured() {
+        let pre = TrackPreconditions {
+            solana_configured: false,
+            ..all_good()
+        };
+        assert!(matches!(
+            validate_track(&request_with_legs(1), &pre),
+            Err(AppError::ServiceUnavailable { .. })
+        ));
+    }
+}

--- a/backend/src/handlers/transfer.rs
+++ b/backend/src/handlers/transfer.rs
@@ -17,6 +17,7 @@ use ibc_solray::api::{
 };
 use serde::{Deserialize, Serialize};
 use solana_pubkey::Pubkey;
+use tracing::warn;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -26,9 +27,9 @@ use crate::external::solana::{
     SOLRAY_PROGRAM_ID,
 };
 use crate::transfer_tracker::{
-    apply_poll, commitment_pda_chain, phase_from_ack_pda, status_response, AckPdaSnapshot, Chain,
-    CommitmentObservation, Direction, IbcHeight, LegPhase, PollObservation, TrackedLeg,
-    TrackedTransfer, TransferStatusResponse, MAX_TRACKED_LEGS,
+    apply_poll, commitment_pda_chain, phase_from_ack_pda, status_response, top_level_state,
+    AckPdaSnapshot, Chain, CommitmentObservation, Direction, IbcHeight, LegPhase, PollObservation,
+    TrackedLeg, TrackedTransfer, TransferStatusResponse, MAX_TRACKED_LEGS, STATE_PENDING,
 };
 use crate::AppState;
 
@@ -131,36 +132,37 @@ pub async fn track_transfer(
     let solana_configured = state.solana_client.is_configured();
     let channel_known = channel_id_from_name(&request.channel).is_ok();
 
-    // Only reach out to chain once the cheap gates can pass; validate_track
-    // still makes the final decision and maps each failure to its typed error.
-    let poll = if solana_configured && channel_known {
-        Some(poll_route(&state.solana_client, request.direction, &request.channel).await?)
-    } else {
-        None
-    };
-    let commitment_evidence = poll.as_ref().is_some_and(|poll| {
-        matches!(poll.commitment, CommitmentObservation::Present) || poll.ack_snapshot.is_some()
-    });
-
-    let pre = TrackPreconditions {
+    // Cheap gates first — reject a saturated set, an unconfigured client, an
+    // unknown channel, or a malformed leg list BEFORE spending any RPC. The
+    // endpoint is unauthenticated, so an early reject also denies RPC
+    // amplification. Commitment evidence is assumed here and verified against
+    // chain immediately after, once the cheap gates pass.
+    let base = TrackPreconditions {
         channel_known,
         solana_configured,
-        commitment_evidence,
+        commitment_evidence: true,
         active_count: state.transfer_store.active_count(),
         capacity: state.transfer_store.capacity(),
     };
-    validate_track(&request, &pre)?;
+    validate_track(&request, &base)?;
 
-    let poll = poll.ok_or_else(|| {
-        AppError::Internal("registration poll missing after passing validation".to_string())
-    })?;
+    // Cheap gates passed: one RPC verifies the route has a live on-chain
+    // commitment before it is admitted to the tracking set.
+    let observation = poll_route(&state.solana_client, request.direction, &request.channel).await?;
+    let verified = TrackPreconditions {
+        commitment_evidence: matches!(observation.commitment, CommitmentObservation::Present),
+        ..base
+    };
+    validate_track(&request, &verified)?;
 
     let id = Uuid::new_v4().to_string();
+    // Legs start at `Committed`; each GET /status re-polls and folds fresh
+    // observations forward (REST poll v1), so registration does not seed phases.
     let legs = request
         .legs
         .iter()
         .map(|spec| TrackedLeg {
-            phase: initial_leg_phase(request.direction, spec, &poll),
+            phase: LegPhase::Committed,
             from_chain: spec.from_chain,
             to_chain: spec.to_chain,
             timeout_height: spec.timeout_height,
@@ -195,21 +197,40 @@ pub async fn get_transfer_status(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<TransferStatusResponse>, AppError> {
-    let record = state
+    let mut record = state
         .transfer_store
         .get(&id)
         .ok_or_else(|| AppError::NotFound {
             resource: format!("transfer {id}"),
         })?;
+
+    // REST poll v1 (matches the swap UI's polling model): fold a fresh on-chain
+    // observation into per-leg state on every read, persisting when it advances.
+    if refresh_record(&state.solana_client, &mut record).await {
+        if let Err(e) = state.transfer_store.update(record.clone()).await {
+            // The fresh status is already computed; a persist failure only means
+            // the next GET re-derives it. Surface, do not fail the read.
+            warn!("failed to persist transfer {id} status update: {e}");
+        }
+    }
     Ok(Json(status_response(&record)))
 }
 
-/// A one-shot read of a route's Solana packet PDAs plus the current Solana
-/// height, used to seed a freshly registered route's per-leg phases.
-struct RoutePoll {
+/// A single fresh read of a route's Solana packet PDAs plus the current Solana
+/// height. Only the packet-commitment PDA drives phase transitions.
+///
+/// The acknowledgement PDA is per *channel* — a BTree of every acknowledged
+/// sequence on the channel — and the tracked record carries no packet sequence
+/// to pick out THIS transfer's ack. Ack-PDA presence is therefore *uncorrelated*
+/// evidence: it may only ever keep a leg in an in-flight phase (`Acked` at
+/// most), never advance it to `Delivered` or a terminal, so a still-in-flight
+/// transfer on a channel that has ever carried an acked packet is never falsely
+/// reported as completed. Receive events and success/error polarity are
+/// event-sourced (Nolus CometBFT) and land in a later PR.
+struct RouteObservation {
     current_height: IbcHeight,
     commitment: CommitmentObservation,
-    ack_snapshot: Option<AckPdaSnapshot>,
+    ack_present: bool,
 }
 
 /// Which per-channel packet PDA to address.
@@ -218,13 +239,70 @@ enum PacketPdaKind {
     Acknowledgement,
 }
 
-/// Poll a route's Solana packet PDAs once, deriving the current commitment
-/// observation and (presence-only) acknowledgement snapshot.
+/// Fold one fresh on-chain observation into a record's per-leg phases, stamping
+/// `terminal_at` when the route first reaches a terminal top-level state.
+/// Returns whether anything changed. A poll failure leaves every leg untouched
+/// (see [`apply_poll`]).
+async fn refresh_record(client: &SolanaClient, record: &mut TrackedTransfer) -> bool {
+    let observation = poll_route(client, record.direction, &record.channel).await;
+    let mut changed = false;
+    for leg in &mut record.legs {
+        let next = match &observation {
+            Ok(obs) => fold_leg(leg.phase, record.direction, leg.timeout_height, obs),
+            Err(_) => leg.phase,
+        };
+        if next != leg.phase {
+            leg.phase = next;
+            changed = true;
+        }
+    }
+    if changed && record.terminal_at.is_none() {
+        let phases: Vec<LegPhase> = record.legs.iter().map(|leg| leg.phase).collect();
+        if top_level_state(&phases) != STATE_PENDING {
+            record.terminal_at = Some(Utc::now());
+        }
+    }
+    changed
+}
+
+/// Fold a fresh observation into a leg's next phase. Commitment-PDA evidence
+/// drives the sanctioned transitions through [`reconcile`]; uncorrelated ack-PDA
+/// presence may only lift a still-pre-ack leg to the in-flight `Acked` phase,
+/// never to `Delivered` or a terminal (see [`RouteObservation`]).
+fn fold_leg(
+    prior: LegPhase,
+    direction: Direction,
+    timeout_height: IbcHeight,
+    obs: &RouteObservation,
+) -> LegPhase {
+    let observation = PollObservation {
+        commitment: obs.commitment,
+        ack_event: None, // success/error polarity is event-sourced, never PDA-sourced
+        timeout_event: false, // timeout events are event-sourced, not observable from PDAs
+        recv_observed: false, // never inferred from the uncorrelated ack PDA
+        event_gap: false,
+        current_height: obs.current_height,
+        timeout_height,
+    };
+    let reconciled = apply_poll(prior, direction, Ok(observation));
+    if obs.ack_present && matches!(reconciled, LegPhase::Committed | LegPhase::Relayed) {
+        // Uncorrelated ack presence caps at the in-flight `Acked` phase; the
+        // snapshot hash is ignored by `phase_from_ack_pda` (polarity unknowable).
+        phase_from_ack_pda(&AckPdaSnapshot {
+            commitment_hash: [0u8; 32],
+        })
+    } else {
+        reconciled
+    }
+}
+
+/// Poll a route's Solana packet PDAs once. See [`RouteObservation`] for why the
+/// acknowledgement observation is presence-only and never terminal.
 async fn poll_route(
     client: &SolanaClient,
     direction: Direction,
     channel: &str,
-) -> Result<RoutePoll, AppError> {
+) -> Result<RouteObservation, AppError> {
     let epoch = client.get_epoch_info().await?;
     let current_height = IbcHeight {
         revision_number: epoch.epoch,
@@ -253,39 +331,12 @@ async fn poll_route(
         decode_acknowledgement_pda(ack_account.as_ref())?,
         PacketPdaSnapshot::Present(sequences) if !sequences.is_empty()
     );
-    // The ack PDA proves an acknowledgement exists; its success-vs-error
-    // polarity is unknowable off-chain, so the (ignored) hash is a presence
-    // marker only. Event-sourced polarity arrives via the CometBFT path.
-    let ack_snapshot = ack_present.then_some(AckPdaSnapshot {
-        commitment_hash: [0u8; 32],
-    });
 
-    Ok(RoutePoll {
+    Ok(RouteObservation {
         current_height,
         commitment,
-        ack_snapshot,
+        ack_present,
     })
-}
-
-/// Seed a leg's initial phase from a registration-time poll. A poll error keeps
-/// the leg at `Committed` (unknown, not terminal) via [`apply_poll`].
-fn initial_leg_phase(direction: Direction, spec: &TrackLegSpec, poll: &RoutePoll) -> LegPhase {
-    let observation = PollObservation {
-        commitment: poll.commitment,
-        ack_event: None, // polarity is event-sourced, never PDA-sourced
-        timeout_event: false,
-        recv_observed: poll.ack_snapshot.is_some(),
-        event_gap: false,
-        current_height: poll.current_height,
-        timeout_height: spec.timeout_height,
-    };
-    let reconciled = apply_poll(LegPhase::Committed, direction, Ok(observation));
-    match (&poll.ack_snapshot, reconciled) {
-        // An observed ack PDA proves the leg is at least acknowledged; do not
-        // report it as still committed/relayed while that evidence stands.
-        (Some(snapshot), LegPhase::Committed | LegPhase::Relayed) => phase_from_ack_pda(snapshot),
-        _ => reconciled,
-    }
 }
 
 /// Derive the base58 address of a per-channel packet PDA on Solana via the
@@ -406,5 +457,233 @@ mod tests {
             validate_track(&request_with_legs(1), &pre),
             Err(AppError::ServiceUnavailable { .. })
         ));
+    }
+}
+
+#[cfg(test)]
+mod handler_tests {
+    use super::*;
+    use crate::transfer_tracker::{TransferStore, STATE_PENDING};
+    use axum::extract::{Path, State};
+    use axum::Json;
+    use serde_json::json;
+    use std::sync::Arc;
+    use wiremock::matchers::{body_partial_json, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn height(rev: u64, h: u64) -> IbcHeight {
+        IbcHeight {
+            revision_number: rev,
+            revision_height: h,
+        }
+    }
+
+    /// A one-leg Nolus->Solana request. This direction has no queryable Solana
+    /// commitment PDA, so a poll only needs `getEpochInfo` + a null ack account.
+    fn nolus_to_solana(timeout: IbcHeight) -> TrackRequest {
+        TrackRequest {
+            direction: Direction::NolusToSolana,
+            channel: "channel-0".to_string(),
+            legs: vec![TrackLegSpec {
+                from_chain: Chain::Nolus,
+                to_chain: Chain::Solana,
+                timeout_height: timeout,
+            }],
+        }
+    }
+
+    async fn mount_epoch(server: &MockServer, slot: u64, epoch: u64) {
+        Mock::given(method("POST"))
+            .and(body_partial_json(json!({ "method": "getEpochInfo" })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0", "id": 1,
+                "result": { "absoluteSlot": slot, "epoch": epoch },
+            })))
+            .mount(server)
+            .await;
+    }
+
+    async fn mount_account_null(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(body_partial_json(json!({ "method": "getAccountInfo" })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0", "id": 1,
+                "result": { "context": { "slot": 1 }, "value": null },
+            })))
+            .mount(server)
+            .await;
+    }
+
+    async fn state_with_solana(url: &str) -> Arc<crate::AppState> {
+        let mut config = crate::test_utils::test_config();
+        config.external.solana_rpc_url = Some(url.to_string());
+        crate::test_utils::test_app_state_with_config_and_client(config, reqwest::Client::new())
+            .await
+    }
+
+    #[tokio::test]
+    async fn track_transfer_registers_a_route_and_persists_it() {
+        let server = MockServer::start().await;
+        mount_epoch(&server, 100, 5).await;
+        mount_account_null(&server).await;
+        let state = state_with_solana(&server.uri()).await;
+
+        let accepted = track_transfer(State(state.clone()), Json(nolus_to_solana(height(5, 1000))))
+            .await
+            .expect("registration succeeds")
+            .0;
+
+        assert_eq!(state.transfer_store.active_count(), 1);
+        let record = state
+            .transfer_store
+            .get(&accepted.id)
+            .expect("record persisted");
+        assert_eq!(record.legs[0].phase, LegPhase::Committed);
+    }
+
+    #[tokio::test]
+    async fn get_transfer_status_repolls_advances_and_persists() {
+        // Current height (6, 2000) is already past the leg's timeout (5, 100): a
+        // status GET must fold Committed -> AwaitingTimeout and persist it.
+        let server = MockServer::start().await;
+        mount_epoch(&server, 2000, 6).await;
+        mount_account_null(&server).await;
+        let state = state_with_solana(&server.uri()).await;
+
+        let accepted = track_transfer(State(state.clone()), Json(nolus_to_solana(height(5, 100))))
+            .await
+            .expect("registration")
+            .0;
+        assert_eq!(
+            state.transfer_store.get(&accepted.id).unwrap().legs[0].phase,
+            LegPhase::Committed
+        );
+
+        let response = get_transfer_status(State(state.clone()), Path(accepted.id.clone()))
+            .await
+            .expect("status")
+            .0;
+        assert_eq!(response.state, STATE_PENDING);
+        assert_eq!(
+            state.transfer_store.get(&accepted.id).unwrap().legs[0].phase,
+            LegPhase::AwaitingTimeout,
+            "the re-poll must advance and persist the leg phase"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_transfer_status_unknown_id_is_404() {
+        let state = state_with_solana("http://127.0.0.1:1/").await;
+        let err = get_transfer_status(State(state), Path("missing".to_string()))
+            .await
+            .expect_err("unknown id must 404 before any poll");
+        assert!(matches!(err, AppError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn track_transfer_rejects_at_capacity_before_any_rpc() {
+        // A saturated set must reject BEFORE poll_route: the Solana client points
+        // at an unroutable stub, so a RateLimited (rather than a ChainRpc/timeout)
+        // proves the capacity check runs before any RPC is spent.
+        let mut config = crate::test_utils::test_config();
+        config.external.solana_rpc_url = Some("http://127.0.0.1:1/".to_string());
+        let store = TransferStore::ephemeral_with_capacity(1);
+        store
+            .insert(TrackedTransfer {
+                id: "existing".to_string(),
+                direction: Direction::NolusToSolana,
+                channel: "channel-0".to_string(),
+                legs: Vec::new(),
+                created_at: Utc::now(),
+                terminal_at: None,
+            })
+            .await
+            .expect("seed insert fills the single slot");
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(1))
+            .build()
+            .expect("client builds");
+        let state =
+            crate::test_utils::test_app_state_with_config_client_and_store(config, http, store)
+                .await;
+
+        let err = track_transfer(State(state), Json(nolus_to_solana(height(5, 100))))
+            .await
+            .expect_err("a full set must reject");
+        assert!(
+            matches!(err, AppError::RateLimited { .. }),
+            "capacity must reject before spending an RPC, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_record_keeps_prior_phase_on_poll_error() {
+        let client = SolanaClient::new(
+            Some("http://127.0.0.1:1/".to_string()),
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_millis(1))
+                .build()
+                .expect("client builds"),
+        );
+        let mut record = TrackedTransfer {
+            id: "t".to_string(),
+            direction: Direction::NolusToSolana,
+            channel: "channel-0".to_string(),
+            legs: vec![TrackedLeg {
+                phase: LegPhase::Relayed,
+                from_chain: Chain::Nolus,
+                to_chain: Chain::Solana,
+                timeout_height: height(5, 100),
+            }],
+            created_at: Utc::now(),
+            terminal_at: None,
+        };
+        let changed = refresh_record(&client, &mut record).await;
+        assert!(!changed, "a failed poll must change nothing");
+        assert_eq!(record.legs[0].phase, LegPhase::Relayed);
+    }
+
+    #[test]
+    fn fold_leg_uncorrelated_ack_never_reaches_terminal_or_delivered() {
+        let obs = RouteObservation {
+            current_height: height(5, 10),
+            commitment: CommitmentObservation::Present,
+            ack_present: true,
+        };
+        let phase = fold_leg(
+            LegPhase::Relayed,
+            Direction::SolanaToNolus,
+            height(5, 1000),
+            &obs,
+        );
+        assert_eq!(
+            phase,
+            LegPhase::Acked,
+            "uncorrelated ack presence caps at the in-flight Acked phase"
+        );
+        assert_eq!(top_level_state(&[phase]), STATE_PENDING);
+        assert!(!matches!(
+            phase,
+            LegPhase::Delivered | LegPhase::CompletedSuccess | LegPhase::CompletedError
+        ));
+    }
+
+    #[test]
+    fn fold_leg_refund_comes_from_commitment_not_uncorrelated_ack() {
+        // Commitment gone on Solana->Nolus with an ack present on the channel: the
+        // sanctioned commitment inference still refunds; ack presence must never
+        // upgrade it to a success.
+        let obs = RouteObservation {
+            current_height: height(5, 10),
+            commitment: CommitmentObservation::Gone,
+            ack_present: true,
+        };
+        let phase = fold_leg(
+            LegPhase::Relayed,
+            Direction::SolanaToNolus,
+            height(5, 1000),
+            &obs,
+        );
+        assert_eq!(phase, LegPhase::TimedOutRefunded);
     }
 }

--- a/backend/src/handlers/transfer.rs
+++ b/backend/src/handlers/transfer.rs
@@ -23,8 +23,8 @@ use uuid::Uuid;
 
 use crate::error::AppError;
 use crate::external::solana::{
-    decode_acknowledgement_pda, decode_commitment_pda, PacketPdaSnapshot, SolanaClient,
-    SOLRAY_PROGRAM_ID,
+    decode_acknowledgement_pda, decode_commitment_pda, solray_program_id, PacketPdaSnapshot,
+    SolanaClient,
 };
 use crate::transfer_tracker::{
     apply_poll, commitment_pda_chain, phase_from_ack_pda, status_response, top_level_state,
@@ -206,7 +206,10 @@ pub async fn get_transfer_status(
 
     // REST poll v1 (matches the swap UI's polling model): fold a fresh on-chain
     // observation into per-leg state on every read, persisting when it advances.
-    if refresh_record(&state.solana_client, &mut record).await {
+    // A terminal route is immutable, so it is served straight from the store
+    // with zero RPC — this unauthenticated endpoint cannot be used to amplify
+    // Solana reads by polling already-settled transfers.
+    if record.terminal_at.is_none() && refresh_record(&state.solana_client, &mut record).await {
         if let Err(e) = state.transfer_store.update(record.clone()).await {
             // The fresh status is already computed; a persist failure only means
             // the next GET re-derives it. Surface, do not fail the read.
@@ -347,7 +350,7 @@ fn packet_pda_address(channel: &str, kind: &PacketPdaKind) -> Result<String, App
         field: Some("channel".to_string()),
         details: None,
     })?;
-    let program = Pubkey::from_str(SOLRAY_PROGRAM_ID)
+    let program = Pubkey::from_str(solray_program_id())
         .map_err(|e| AppError::Internal(format!("invalid solray program id: {e}")))?;
     let address = match kind {
         PacketPdaKind::Commitment => PacketCommitmentsReference::find(program, channel_id).addr(),
@@ -463,7 +466,7 @@ mod tests {
 #[cfg(test)]
 mod handler_tests {
     use super::*;
-    use crate::transfer_tracker::{TransferStore, STATE_PENDING};
+    use crate::transfer_tracker::{TransferStore, STATE_COMPLETED_SUCCESS, STATE_PENDING};
     use axum::extract::{Path, State};
     use axum::Json;
     use serde_json::json;
@@ -578,6 +581,47 @@ mod handler_tests {
             .await
             .expect_err("unknown id must 404 before any poll");
         assert!(matches!(err, AppError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn get_transfer_status_terminal_record_performs_no_poll() {
+        let server = MockServer::start().await;
+        mount_epoch(&server, 1, 1).await;
+        mount_account_null(&server).await;
+        let state = state_with_solana(&server.uri()).await;
+
+        // A settled (terminal) route: terminal_at set, leg completed.
+        state
+            .transfer_store
+            .insert(TrackedTransfer {
+                id: "done".to_string(),
+                direction: Direction::SolanaToNolus,
+                channel: "channel-0".to_string(),
+                legs: vec![TrackedLeg {
+                    phase: LegPhase::CompletedSuccess,
+                    from_chain: Chain::Solana,
+                    to_chain: Chain::Nolus,
+                    timeout_height: height(5, 100),
+                }],
+                created_at: Utc::now(),
+                terminal_at: Some(Utc::now()),
+            })
+            .await
+            .expect("seed terminal record");
+
+        let response = get_transfer_status(State(state), Path("done".to_string()))
+            .await
+            .expect("status")
+            .0;
+        assert_eq!(response.state, STATE_COMPLETED_SUCCESS);
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .is_empty(),
+            "a terminal route must be served with zero RPC"
+        );
     }
 
     #[tokio::test]

--- a/backend/src/handlers/transfer.rs
+++ b/backend/src/handlers/transfer.rs
@@ -6,18 +6,34 @@
 //! legs, no on-chain commitment evidence, a full active set, or an
 //! unconfigured Solana client.
 
+use std::str::FromStr as _;
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
 use axum::Json;
+use chrono::Utc;
+use ibc_solray::api::{
+    channel_id_from_name, PacketAcknowledgementReference, PacketCommitmentsReference,
+};
 use serde::{Deserialize, Serialize};
+use solana_pubkey::Pubkey;
+use utoipa::ToSchema;
+use uuid::Uuid;
 
 use crate::error::AppError;
-use crate::transfer_tracker::{Chain, Direction, IbcHeight, TransferStatusResponse};
+use crate::external::solana::{
+    decode_acknowledgement_pda, decode_commitment_pda, PacketPdaSnapshot, SolanaClient,
+    SOLRAY_PROGRAM_ID,
+};
+use crate::transfer_tracker::{
+    apply_poll, commitment_pda_chain, phase_from_ack_pda, status_response, AckPdaSnapshot, Chain,
+    CommitmentObservation, Direction, IbcHeight, LegPhase, PollObservation, TrackedLeg,
+    TrackedTransfer, TransferStatusResponse, MAX_TRACKED_LEGS,
+};
 use crate::AppState;
 
 /// One requested leg of a route to track.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TrackLegSpec {
     pub from_chain: Chain,
     pub to_chain: Chain,
@@ -25,7 +41,8 @@ pub struct TrackLegSpec {
 }
 
 /// `POST /api/transfer/track` request body.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[schema(as = TransferTrackRequest)]
 pub struct TrackRequest {
     pub direction: Direction,
     pub channel: String,
@@ -33,7 +50,7 @@ pub struct TrackRequest {
 }
 
 /// `POST /api/transfer/track` success body.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TrackAccepted {
     pub id: String,
 }
@@ -51,26 +68,243 @@ pub struct TrackPreconditions {
 /// unconfigured Solana client -> 503, unknown channel / over-leg-cap / no
 /// commitment evidence -> 400, full active set -> 429.
 pub fn validate_track(request: &TrackRequest, pre: &TrackPreconditions) -> Result<(), AppError> {
-    let _ = (request, pre);
-    todo!("map each precondition failure to its typed AppError")
+    if !pre.solana_configured {
+        return Err(AppError::ServiceUnavailable {
+            message: "Solana RPC not configured (set SOLANA_RPC_URL)".to_string(),
+        });
+    }
+    if !pre.channel_known {
+        return Err(AppError::Validation {
+            message: format!("unknown IBC channel: {}", request.channel),
+            field: Some("channel".to_string()),
+            details: None,
+        });
+    }
+    if request.legs.is_empty() {
+        return Err(AppError::Validation {
+            message: "a tracked route must declare at least one leg".to_string(),
+            field: Some("legs".to_string()),
+            details: None,
+        });
+    }
+    if request.legs.len() > MAX_TRACKED_LEGS {
+        return Err(AppError::Validation {
+            message: format!(
+                "route declares {} legs; the maximum is {MAX_TRACKED_LEGS}",
+                request.legs.len()
+            ),
+            field: Some("legs".to_string()),
+            details: None,
+        });
+    }
+    if !pre.commitment_evidence {
+        return Err(AppError::Validation {
+            message: "no on-chain commitment evidence for the route".to_string(),
+            field: Some("channel".to_string()),
+            details: None,
+        });
+    }
+    if pre.active_count >= pre.capacity {
+        return Err(AppError::RateLimited { retry_after: None });
+    }
+    Ok(())
 }
 
 /// Register an in-flight route for tracking.
+#[utoipa::path(
+    post,
+    path = "/api/transfer/track",
+    tag = "transfer",
+    request_body = TrackRequest,
+    responses(
+        (status = 200, description = "Route registered for tracking", body = TrackAccepted),
+        (status = 400, description = "Untrackable request", body = crate::error::ErrorResponse),
+        (status = 429, description = "Active tracking set full", body = crate::error::ErrorResponse),
+        (status = 502, description = "Solana RPC error", body = crate::error::ErrorResponse),
+        (status = 503, description = "Solana RPC unconfigured", body = crate::error::ErrorResponse),
+    ),
+)]
 pub async fn track_transfer(
     State(state): State<Arc<AppState>>,
     Json(request): Json<TrackRequest>,
 ) -> Result<Json<TrackAccepted>, AppError> {
-    let _ = (state, request);
-    todo!("gather preconditions, validate_track, insert into the store")
+    let solana_configured = state.solana_client.is_configured();
+    let channel_known = channel_id_from_name(&request.channel).is_ok();
+
+    // Only reach out to chain once the cheap gates can pass; validate_track
+    // still makes the final decision and maps each failure to its typed error.
+    let poll = if solana_configured && channel_known {
+        Some(poll_route(&state.solana_client, request.direction, &request.channel).await?)
+    } else {
+        None
+    };
+    let commitment_evidence = poll.as_ref().is_some_and(|poll| {
+        matches!(poll.commitment, CommitmentObservation::Present) || poll.ack_snapshot.is_some()
+    });
+
+    let pre = TrackPreconditions {
+        channel_known,
+        solana_configured,
+        commitment_evidence,
+        active_count: state.transfer_store.active_count(),
+        capacity: state.transfer_store.capacity(),
+    };
+    validate_track(&request, &pre)?;
+
+    let poll = poll.ok_or_else(|| {
+        AppError::Internal("registration poll missing after passing validation".to_string())
+    })?;
+
+    let id = Uuid::new_v4().to_string();
+    let legs = request
+        .legs
+        .iter()
+        .map(|spec| TrackedLeg {
+            phase: initial_leg_phase(request.direction, spec, &poll),
+            from_chain: spec.from_chain,
+            to_chain: spec.to_chain,
+            timeout_height: spec.timeout_height,
+        })
+        .collect();
+    let record = TrackedTransfer {
+        id: id.clone(),
+        direction: request.direction,
+        channel: request.channel.clone(),
+        legs,
+        created_at: Utc::now(),
+        terminal_at: None,
+    };
+    state.transfer_store.insert(record).await?;
+    Ok(Json(TrackAccepted { id }))
 }
 
 /// Return the current status of a tracked route.
+#[utoipa::path(
+    get,
+    path = "/api/transfer/status/{id}",
+    tag = "transfer",
+    params(
+        ("id" = String, Path, description = "Tracked route id"),
+    ),
+    responses(
+        (status = 200, description = "Current route status", body = TransferStatusResponse),
+        (status = 404, description = "Unknown route id", body = crate::error::ErrorResponse),
+    ),
+)]
 pub async fn get_transfer_status(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<TransferStatusResponse>, AppError> {
-    let _ = (state, id);
-    todo!("look up the route, build its status response, 404 when absent")
+    let record = state
+        .transfer_store
+        .get(&id)
+        .ok_or_else(|| AppError::NotFound {
+            resource: format!("transfer {id}"),
+        })?;
+    Ok(Json(status_response(&record)))
+}
+
+/// A one-shot read of a route's Solana packet PDAs plus the current Solana
+/// height, used to seed a freshly registered route's per-leg phases.
+struct RoutePoll {
+    current_height: IbcHeight,
+    commitment: CommitmentObservation,
+    ack_snapshot: Option<AckPdaSnapshot>,
+}
+
+/// Which per-channel packet PDA to address.
+enum PacketPdaKind {
+    Commitment,
+    Acknowledgement,
+}
+
+/// Poll a route's Solana packet PDAs once, deriving the current commitment
+/// observation and (presence-only) acknowledgement snapshot.
+async fn poll_route(
+    client: &SolanaClient,
+    direction: Direction,
+    channel: &str,
+) -> Result<RoutePoll, AppError> {
+    let epoch = client.get_epoch_info().await?;
+    let current_height = IbcHeight {
+        revision_number: epoch.epoch,
+        revision_height: epoch.absolute_slot,
+    };
+
+    let commitment = match commitment_pda_chain(direction) {
+        Some(Chain::Solana) => {
+            let address = packet_pda_address(channel, &PacketPdaKind::Commitment)?;
+            let account = client.get_account_info(&address).await?;
+            match decode_commitment_pda(account.as_ref())? {
+                PacketPdaSnapshot::Present(sequences) if !sequences.is_empty() => {
+                    CommitmentObservation::Present
+                }
+                _ => CommitmentObservation::Gone,
+            }
+        }
+        // Nolus->Solana holds the source commitment on Nolus (observed via
+        // CometBFT events, not a Solana PDA), so the poll cannot prove it gone.
+        _ => CommitmentObservation::Present,
+    };
+
+    let ack_address = packet_pda_address(channel, &PacketPdaKind::Acknowledgement)?;
+    let ack_account = client.get_account_info(&ack_address).await?;
+    let ack_present = matches!(
+        decode_acknowledgement_pda(ack_account.as_ref())?,
+        PacketPdaSnapshot::Present(sequences) if !sequences.is_empty()
+    );
+    // The ack PDA proves an acknowledgement exists; its success-vs-error
+    // polarity is unknowable off-chain, so the (ignored) hash is a presence
+    // marker only. Event-sourced polarity arrives via the CometBFT path.
+    let ack_snapshot = ack_present.then_some(AckPdaSnapshot {
+        commitment_hash: [0u8; 32],
+    });
+
+    Ok(RoutePoll {
+        current_height,
+        commitment,
+        ack_snapshot,
+    })
+}
+
+/// Seed a leg's initial phase from a registration-time poll. A poll error keeps
+/// the leg at `Committed` (unknown, not terminal) via [`apply_poll`].
+fn initial_leg_phase(direction: Direction, spec: &TrackLegSpec, poll: &RoutePoll) -> LegPhase {
+    let observation = PollObservation {
+        commitment: poll.commitment,
+        ack_event: None, // polarity is event-sourced, never PDA-sourced
+        timeout_event: false,
+        recv_observed: poll.ack_snapshot.is_some(),
+        event_gap: false,
+        current_height: poll.current_height,
+        timeout_height: spec.timeout_height,
+    };
+    let reconciled = apply_poll(LegPhase::Committed, direction, Ok(observation));
+    match (&poll.ack_snapshot, reconciled) {
+        // An observed ack PDA proves the leg is at least acknowledged; do not
+        // report it as still committed/relayed while that evidence stands.
+        (Some(snapshot), LegPhase::Committed | LegPhase::Relayed) => phase_from_ack_pda(snapshot),
+        _ => reconciled,
+    }
+}
+
+/// Derive the base58 address of a per-channel packet PDA on Solana via the
+/// pinned solray SDK's PDA derivation.
+fn packet_pda_address(channel: &str, kind: &PacketPdaKind) -> Result<String, AppError> {
+    let channel_id = channel_id_from_name(channel).map_err(|e| AppError::Validation {
+        message: format!("unparseable IBC channel id {channel}: {e}"),
+        field: Some("channel".to_string()),
+        details: None,
+    })?;
+    let program = Pubkey::from_str(SOLRAY_PROGRAM_ID)
+        .map_err(|e| AppError::Internal(format!("invalid solray program id: {e}")))?;
+    let address = match kind {
+        PacketPdaKind::Commitment => PacketCommitmentsReference::find(program, channel_id).addr(),
+        PacketPdaKind::Acknowledgement => {
+            PacketAcknowledgementReference::find(program, channel_id).addr()
+        }
+    };
+    Ok(address.to_string())
 }
 
 #[cfg(test)]
@@ -129,7 +363,10 @@ mod tests {
     fn rejects_leg_count_over_cap_as_validation_error() {
         let pre = all_good();
         assert!(matches!(
-            validate_track(&request_with_legs(crate::transfer_tracker::MAX_TRACKED_LEGS + 1), &pre),
+            validate_track(
+                &request_with_legs(crate::transfer_tracker::MAX_TRACKED_LEGS + 1),
+                &pre
+            ),
             Err(AppError::Validation { .. })
         ));
     }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -34,6 +34,7 @@ mod num_utils;
 mod propagation;
 mod query_types;
 pub mod refresh;
+mod transfer_tracker;
 mod translations;
 mod validation;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -49,6 +49,13 @@ use crate::translations::{
     TranslationStorage,
 };
 
+/// Default filesystem path for the durable transfer tracking-set image.
+/// Override with the `TRANSFER_STORE_PATH` environment variable.
+const DEFAULT_TRANSFER_STORE_PATH: &str = "./data/transfers.json";
+
+/// Retention window (hours) a terminal transfer record is kept before pruning.
+const TRANSFER_RETENTION_HOURS: i64 = 24;
+
 /// Application state shared across all handlers
 pub struct AppState {
     pub config: AppConfig,
@@ -185,14 +192,14 @@ async fn main() -> anyhow::Result<()> {
     // deployment starts an empty set.
     let transfer_store_path = std::path::PathBuf::from(
         std::env::var("TRANSFER_STORE_PATH")
-            .unwrap_or_else(|_err| "./data/transfers.json".to_string()),
+            .unwrap_or_else(|_err| DEFAULT_TRANSFER_STORE_PATH.to_string()),
     );
     if let Some(parent) = transfer_store_path.parent() {
         if !parent.as_os_str().is_empty() {
             tokio::fs::create_dir_all(parent).await?;
         }
     }
-    let transfer_retention = chrono::Duration::hours(24);
+    let transfer_retention = chrono::Duration::hours(TRANSFER_RETENTION_HOURS);
     let transfer_store = if transfer_store_path.exists() {
         transfer_tracker::TransferStore::load(
             transfer_store_path,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -65,6 +65,8 @@ pub struct AppState {
     pub translation_storage: TranslationStorage,
     /// LLM client for AI-powered translations (via OpenRouter)
     pub llm_client: LlmClient,
+    /// Durable tracking set for in-flight Nolus<->Solana transfers.
+    pub transfer_store: transfer_tracker::TransferStore,
     /// Server startup time for uptime tracking
     pub startup_time: Instant,
 }
@@ -178,6 +180,34 @@ async fn main() -> anyhow::Result<()> {
         base_url: None,
     });
 
+    // Initialize the durable transfer tracking set. An existing image is loaded
+    // (a corrupt image fails loud rather than silently starting empty); a fresh
+    // deployment starts an empty set.
+    let transfer_store_path = std::path::PathBuf::from(
+        std::env::var("TRANSFER_STORE_PATH")
+            .unwrap_or_else(|_err| "./data/transfers.json".to_string()),
+    );
+    if let Some(parent) = transfer_store_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+    }
+    let transfer_retention = chrono::Duration::hours(24);
+    let transfer_store = if transfer_store_path.exists() {
+        transfer_tracker::TransferStore::load(
+            transfer_store_path,
+            transfer_tracker::DEFAULT_ACTIVE_SET_CAP,
+            transfer_retention,
+        )
+        .await?
+    } else {
+        transfer_tracker::TransferStore::create(
+            transfer_store_path,
+            transfer_tracker::DEFAULT_ACTIVE_SET_CAP,
+            transfer_retention,
+        )
+    };
+
     // Create shared application state
     let state = Arc::new(AppState {
         config,
@@ -192,6 +222,7 @@ async fn main() -> anyhow::Result<()> {
         config_store,
         translation_storage,
         llm_client,
+        transfer_store,
         startup_time: Instant::now(),
     });
 
@@ -432,6 +463,11 @@ fn create_router(state: Arc<AppState>) -> Router {
         .route("/swap/config", get(handlers::swap::get_swap_config))
         .route("/swap/status/{tx_hash}", get(handlers::swap::get_status))
         .route("/swap/chains", get(handlers::swap::get_chains))
+        // Transfer tracker (read) — status of a tracked Nolus<->Solana route
+        .route(
+            "/transfer/status/{id}",
+            get(handlers::transfer::get_transfer_status),
+        )
         // Referral (read)
         .route(
             "/referral/validate/{code}",
@@ -585,6 +621,8 @@ fn create_router(state: Arc<AppState>) -> Router {
         .route("/swap/track", post(handlers::swap::track_transaction))
         .route("/swap/route", post(handlers::swap::get_route))
         .route("/swap/messages", post(handlers::swap::get_messages))
+        // Transfer tracker (write) — register an in-flight route for tracking
+        .route("/transfer/track", post(handlers::transfer::track_transfer))
         // Referral (write)
         .route("/referral/register", post(handlers::referral::register))
         .route("/referral/assign", post(handlers::referral::assign))

--- a/backend/src/middleware/cache_control.rs
+++ b/backend/src/middleware/cache_control.rs
@@ -73,6 +73,7 @@ fn determine_cache_duration(path: &str) -> u32 {
         || path.contains("/referral/")
         || path.contains("/swap/status")
         || path.contains("/swap/history")
+        || path.contains("/transfer/status")
         || path.contains("/zero-interest/eligibility")
         || path.contains("/zero-interest/payments")
         || path.contains("/campaigns/eligibility")

--- a/backend/src/middleware/cache_control.rs
+++ b/backend/src/middleware/cache_control.rs
@@ -194,6 +194,11 @@ mod tests {
     }
 
     #[test]
+    fn test_cache_duration_no_cache_transfer_status() {
+        assert_eq!(determine_cache_duration("/api/transfer/status/abc123"), 0);
+    }
+
+    #[test]
     fn test_cache_duration_no_cache_zero_interest_user_data() {
         assert_eq!(
             determine_cache_duration("/api/zero-interest/eligibility"),

--- a/backend/src/refresh.rs
+++ b/backend/src/refresh.rs
@@ -1534,6 +1534,7 @@ mod tests {
             config_store,
             translation_storage,
             llm_client,
+            transfer_store: crate::transfer_tracker::TransferStore::ephemeral(),
             startup_time: Instant::now(),
         })
     }

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -90,6 +90,21 @@ pub async fn test_app_state_with_config_and_client(
     config: AppConfig,
     http_client: reqwest::Client,
 ) -> Arc<AppState> {
+    test_app_state_with_config_client_and_store(
+        config,
+        http_client,
+        crate::transfer_tracker::TransferStore::ephemeral(),
+    )
+    .await
+}
+
+/// Like [`test_app_state_with_config_and_client`] but with a caller-supplied
+/// transfer store (e.g. a small-capacity store for the registration cap path).
+pub async fn test_app_state_with_config_client_and_store(
+    config: AppConfig,
+    http_client: reqwest::Client,
+    transfer_store: crate::transfer_tracker::TransferStore,
+) -> Arc<AppState> {
     let etl_client =
         external::etl::EtlClient::new(config.external.etl_api_url.clone(), http_client.clone());
     let skip_client = external::skip::SkipClient::new(
@@ -147,7 +162,7 @@ pub async fn test_app_state_with_config_and_client(
         config_store,
         translation_storage,
         llm_client,
-        transfer_store: crate::transfer_tracker::TransferStore::ephemeral(),
+        transfer_store,
         startup_time: Instant::now(),
     })
 }

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -147,6 +147,7 @@ pub async fn test_app_state_with_config_and_client(
         config_store,
         translation_storage,
         llm_client,
+        transfer_store: crate::transfer_tracker::TransferStore::ephemeral(),
         startup_time: Instant::now(),
     })
 }

--- a/backend/src/transfer_tracker/mod.rs
+++ b/backend/src/transfer_tracker/mod.rs
@@ -8,6 +8,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 mod store;
 
@@ -29,16 +30,27 @@ pub const STATE_COMPLETED_ERROR: &str = "STATE_COMPLETED_ERROR";
 pub const STATE_ABANDONED: &str = "STATE_ABANDONED";
 
 /// The two chains a transfer leg can touch.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Chain {
     Nolus,
     Solana,
 }
 
+impl Chain {
+    /// Lowercase wire label, matching this enum's `serde` representation. Used
+    /// where the response carries the chain as a plain `String`.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Nolus => "nolus",
+            Self::Solana => "solana",
+        }
+    }
+}
+
 /// Direction of the overall route, fixing which chain holds the commitment
 /// truth and which supplies terminal events.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Direction {
     NolusToSolana,
@@ -81,7 +93,7 @@ pub enum LegPhase {
 
 /// An IBC height is a `(revision_number, revision_height)` tuple. Timeout
 /// eligibility compares the whole tuple, never the slot alone.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct IbcHeight {
     pub revision_number: u64,
     pub revision_height: u64,
@@ -128,14 +140,14 @@ pub struct TrackedTransfer {
 }
 
 /// Where the asset currently rests, mirroring Skip's `transfer_asset_release`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct AssetRelease {
     pub chain: String,
     pub released: bool,
 }
 
 /// Typed per-route error, mirroring Skip's error envelope.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct TransferError {
     pub code: String,
     pub message: String,
@@ -143,7 +155,7 @@ pub struct TransferError {
 
 /// One entry of the modern `transfers[]` shape: a per-leg state plus the
 /// chains it bridges.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct TransferLeg {
     pub state: String,
     pub from_chain: String,
@@ -152,7 +164,7 @@ pub struct TransferLeg {
 
 /// The status response served by `GET /api/transfer/status/{id}`. This is the
 /// tracker's own type, NOT a re-use of `SkipStatusResponse`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct TransferStatusResponse {
     pub state: String,
     pub transfers: Vec<TransferLeg>,
@@ -164,39 +176,82 @@ pub struct TransferStatusResponse {
 /// True when `current` is at or past `timeout`, comparing the full IBC height
 /// tuple (revision number first, then revision height).
 pub fn timeout_reached(current: IbcHeight, timeout: IbcHeight) -> bool {
-    let _ = (current, timeout);
-    todo!("compare (revision_number, revision_height) tuple, never slot alone")
+    (current.revision_number, current.revision_height)
+        >= (timeout.revision_number, timeout.revision_height)
 }
 
 /// Terminal phase derived from a Nolus `acknowledge_packet` event's ack
 /// payload polarity — the only source of success-vs-error truth.
-pub fn phase_from_ack_event(outcome: AckOutcome) -> LegPhase {
-    let _ = outcome;
-    todo!("Success -> CompletedSuccess, Error -> CompletedError")
+pub const fn phase_from_ack_event(outcome: AckOutcome) -> LegPhase {
+    match outcome {
+        AckOutcome::Success => LegPhase::CompletedSuccess,
+        AckOutcome::Error => LegPhase::CompletedError,
+    }
 }
 
 /// Phase implied by an acknowledgement PDA snapshot alone. The 32-byte hash
 /// carries no polarity, so this never yields a success/error terminal.
-pub fn phase_from_ack_pda(snapshot: &AckPdaSnapshot) -> LegPhase {
+pub const fn phase_from_ack_pda(snapshot: &AckPdaSnapshot) -> LegPhase {
     let _ = snapshot;
-    todo!("ack PDA proves acknowledgement exists; polarity unknown -> Acked")
+    LegPhase::Acked
 }
 
 /// The chain whose commitment PDA the tracker may query for this direction.
 /// Nolus->Solana observes the commitment through Nolus CometBFT events, so it
 /// has no commitment PDA to query (`None`); Solana->Nolus reads the commitment
 /// PDA on Solana. Never Nolus — Nolus is Cosmos and holds no packet PDAs.
-pub fn commitment_pda_chain(direction: Direction) -> Option<Chain> {
-    let _ = direction;
-    todo!("SolanaToNolus -> Some(Solana); NolusToSolana -> None; never Nolus")
+pub const fn commitment_pda_chain(direction: Direction) -> Option<Chain> {
+    match direction {
+        Direction::SolanaToNolus => Some(Chain::Solana),
+        Direction::NolusToSolana => None,
+    }
 }
 
 /// Fold one poll observation into the next leg phase. Applies the timeout
 /// tuple rule, the Solana->Nolus timeout-refund inference, and the
 /// commitment-gone-across-a-gap -> `Indeterminate` rule.
 pub fn reconcile(prior: LegPhase, direction: Direction, obs: &PollObservation) -> LegPhase {
-    let _ = (prior, direction, obs);
-    todo!("event-sourced terminals first; gap => Indeterminate; present+past-timeout => AwaitingTimeout")
+    // 1. A captured acknowledgement event is authoritative: it is the only
+    //    source of success-vs-error polarity and wins over any inference.
+    if let Some(outcome) = obs.ack_event {
+        return phase_from_ack_event(outcome);
+    }
+
+    // 2. A captured timeout event refunds the leg, in either direction.
+    if obs.timeout_event {
+        return LegPhase::TimedOutRefunded;
+    }
+
+    // 3. The commitment vanished from the source channel.
+    if matches!(obs.commitment, CommitmentObservation::Gone) {
+        // A gap in observation with no captured terminal cannot be told apart
+        // from a missed ack/timeout: the outcome is genuinely unknown.
+        if obs.event_gap {
+            return LegPhase::Indeterminate;
+        }
+        // Under continuous observation, only Solana->Nolus can infer a
+        // timeout-refund from a vanished commitment with no receive; Nolus->Solana
+        // has no queryable commitment and must wait for an event.
+        if direction == Direction::SolanaToNolus && !obs.recv_observed {
+            return LegPhase::TimedOutRefunded;
+        }
+    }
+
+    // 4. Delivered to the destination, ack not yet returned.
+    if obs.recv_observed {
+        return LegPhase::Delivered;
+    }
+
+    // 5. Commitment still present past its timeout height: eligible for a
+    //    timeout the relayer has not yet driven, not itself a refund.
+    if matches!(obs.commitment, CommitmentObservation::Present)
+        && timeout_reached(obs.current_height, obs.timeout_height)
+    {
+        return LegPhase::AwaitingTimeout;
+    }
+
+    // 6. Nothing new observed: hold the prior phase.
+    prior
 }
 
 /// Apply a poll result. A failed poll (RPC / decode error) is unknown, not
@@ -206,20 +261,120 @@ pub fn apply_poll(
     direction: Direction,
     poll: Result<PollObservation, crate::error::AppError>,
 ) -> LegPhase {
-    let _ = (prior, direction, poll);
-    todo!("Err(_) => prior unchanged; Ok(obs) => reconcile(prior, direction, &obs)")
+    match poll {
+        Ok(obs) => reconcile(prior, direction, &obs),
+        Err(_) => prior,
+    }
+}
+
+/// Whether a per-leg phase is still in flight (blocking the route from
+/// resolving). Terminal phases — the two successes, the two failures, and the
+/// indeterminate terminal — are not blocking.
+const fn is_in_flight(phase: LegPhase) -> bool {
+    matches!(
+        phase,
+        LegPhase::Committed | LegPhase::Relayed | LegPhase::Acked | LegPhase::AwaitingTimeout
+    )
 }
 
 /// Top-level route state from the per-leg phases, mirroring the Skip enum.
 pub fn top_level_state(legs: &[LegPhase]) -> &'static str {
-    let _ = legs;
-    todo!("all-success => COMPLETED_SUCCESS; any error/refund => COMPLETED_ERROR; any indeterminate => ABANDONED; else PENDING")
+    let mut any_error = false;
+    let mut any_indeterminate = false;
+    let mut any_in_flight = false;
+    for &phase in legs {
+        match phase {
+            LegPhase::CompletedError | LegPhase::TimedOutRefunded => any_error = true,
+            LegPhase::Indeterminate => any_indeterminate = true,
+            LegPhase::Committed
+            | LegPhase::Relayed
+            | LegPhase::Acked
+            | LegPhase::AwaitingTimeout => any_in_flight = true,
+            LegPhase::CompletedSuccess | LegPhase::Delivered => {}
+        }
+    }
+    if any_error {
+        STATE_COMPLETED_ERROR
+    } else if any_indeterminate {
+        STATE_ABANDONED
+    } else if any_in_flight {
+        STATE_PENDING
+    } else {
+        STATE_COMPLETED_SUCCESS
+    }
 }
 
 /// Build the status response for a tracked route.
 pub fn status_response(record: &TrackedTransfer) -> TransferStatusResponse {
-    let _ = record;
-    todo!("derive top-level state + per-leg transfers[] + asset release")
+    let phases: Vec<LegPhase> = record.legs.iter().map(|leg| leg.phase).collect();
+    let state = top_level_state(&phases);
+
+    let transfers = record
+        .legs
+        .iter()
+        .map(|leg| TransferLeg {
+            state: top_level_state(&[leg.phase]).to_string(),
+            from_chain: leg.from_chain.label().to_string(),
+            to_chain: leg.to_chain.label().to_string(),
+        })
+        .collect();
+
+    let next_blocking_transfer = record.legs.iter().position(|leg| is_in_flight(leg.phase));
+
+    let transfer_asset_release = asset_release(record, state);
+    let error = route_error(&record.legs, state);
+
+    TransferStatusResponse {
+        state: state.to_string(),
+        transfers,
+        next_blocking_transfer,
+        transfer_asset_release,
+        error,
+    }
+}
+
+/// Where the asset rests once the route reaches a terminal: released at the
+/// final destination on success, refunded to the source on failure, and
+/// unknown (in transit) while the route is still pending or abandoned.
+fn asset_release(record: &TrackedTransfer, state: &str) -> Option<AssetRelease> {
+    match state {
+        STATE_COMPLETED_SUCCESS => record.legs.last().map(|leg| AssetRelease {
+            chain: leg.to_chain.label().to_string(),
+            released: true,
+        }),
+        STATE_COMPLETED_ERROR => record.legs.first().map(|leg| AssetRelease {
+            chain: leg.from_chain.label().to_string(),
+            released: true,
+        }),
+        _ => None,
+    }
+}
+
+/// Operational error envelope for a failed route. Worded as an operational
+/// outcome (the relayer is a permissioned single operator), never as a
+/// cryptographic guarantee.
+fn route_error(legs: &[TrackedLeg], state: &str) -> Option<TransferError> {
+    if state != STATE_COMPLETED_ERROR {
+        return None;
+    }
+    let failing = legs.iter().find_map(|leg| match leg.phase {
+        LegPhase::CompletedError => Some(TransferError {
+            code: "ERROR_ACKNOWLEDGED".to_string(),
+            message:
+                "The transfer was rejected on the destination chain and refunded to the source."
+                    .to_string(),
+        }),
+        LegPhase::TimedOutRefunded => Some(TransferError {
+            code: "TIMED_OUT_REFUNDED".to_string(),
+            message: "The transfer timed out before delivery and was refunded to the source."
+                .to_string(),
+        }),
+        _ => None,
+    });
+    failing.or(Some(TransferError {
+        code: "TRANSFER_FAILED".to_string(),
+        message: "The transfer did not complete and was refunded to the source.".to_string(),
+    }))
 }
 
 #[cfg(test)]
@@ -269,12 +424,18 @@ mod tests {
 
     #[test]
     fn ack_event_success_payload_yields_success_terminal() {
-        assert_eq!(phase_from_ack_event(AckOutcome::Success), LegPhase::CompletedSuccess);
+        assert_eq!(
+            phase_from_ack_event(AckOutcome::Success),
+            LegPhase::CompletedSuccess
+        );
     }
 
     #[test]
     fn ack_event_error_payload_yields_error_terminal() {
-        assert_eq!(phase_from_ack_event(AckOutcome::Error), LegPhase::CompletedError);
+        assert_eq!(
+            phase_from_ack_event(AckOutcome::Error),
+            LegPhase::CompletedError
+        );
     }
 
     // Rule 2 — never query a commitment PDA on the wrong side for a direction.
@@ -511,10 +672,7 @@ mod tests {
 
     #[test]
     fn in_flight_leg_maps_to_pending() {
-        assert_eq!(
-            top_level_state(&[LegPhase::Relayed]),
-            STATE_PENDING
-        );
+        assert_eq!(top_level_state(&[LegPhase::Relayed]), STATE_PENDING);
     }
 
     #[test]

--- a/backend/src/transfer_tracker/mod.rs
+++ b/backend/src/transfer_tracker/mod.rs
@@ -1,0 +1,551 @@
+//! Nolus <-> Solana transfer tracker: state model, per-leg reconciliation, and
+//! the status response shape served by `GET /api/transfer/status/{id}`.
+//!
+//! Terminal outcomes derive from observed chain events, never from a packet
+//! PDA snapshot: an acknowledgement PDA holds only a 32-byte commitment hash
+//! whose success-vs-error polarity is unknowable off-chain. The durable
+//! tracking set lives in [`store`].
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+mod store;
+
+pub use store::TransferStore;
+
+/// Maximum number of legs a single tracked route may declare. A transfer ->
+/// swap -> transfer route is three legs; the cap bounds pathological requests.
+pub const MAX_TRACKED_LEGS: usize = 8;
+
+/// Default cap on the durable active-tracking set. The tracker refuses new
+/// registrations once this many in-flight routes are held.
+pub const DEFAULT_ACTIVE_SET_CAP: usize = 512;
+
+/// Top-level status string mirroring the Skip enum the frontend already
+/// consumes. Kept as `&str` constants so the response contract is named once.
+pub const STATE_PENDING: &str = "STATE_PENDING";
+pub const STATE_COMPLETED_SUCCESS: &str = "STATE_COMPLETED_SUCCESS";
+pub const STATE_COMPLETED_ERROR: &str = "STATE_COMPLETED_ERROR";
+pub const STATE_ABANDONED: &str = "STATE_ABANDONED";
+
+/// The two chains a transfer leg can touch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Chain {
+    Nolus,
+    Solana,
+}
+
+/// Direction of the overall route, fixing which chain holds the commitment
+/// truth and which supplies terminal events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Direction {
+    NolusToSolana,
+    SolanaToNolus,
+}
+
+/// Polarity of a Nolus `acknowledge_packet` event's ack payload. This is the
+/// only source of success-vs-error truth for an acked leg.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AckOutcome {
+    Success,
+    Error,
+}
+
+/// Whether a channel's commitment for this packet is still present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommitmentObservation {
+    Present,
+    Gone,
+}
+
+/// Per-leg lifecycle phase. `Acked` records that an acknowledgement exists
+/// without asserting its polarity; the success/error terminals are reachable
+/// only from an ack *event*, and `TimedOutRefunded` only from an observed
+/// timeout event (or the Solana->Nolus commitment-gone-without-recv
+/// inference). `Indeterminate` is a real terminal: the commitment vanished
+/// across an observation gap and no terminal was captured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LegPhase {
+    Committed,
+    Relayed,
+    Acked,
+    Delivered,
+    AwaitingTimeout,
+    CompletedSuccess,
+    CompletedError,
+    TimedOutRefunded,
+    Indeterminate,
+}
+
+/// An IBC height is a `(revision_number, revision_height)` tuple. Timeout
+/// eligibility compares the whole tuple, never the slot alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IbcHeight {
+    pub revision_number: u64,
+    pub revision_height: u64,
+}
+
+/// The raw acknowledgement PDA image: a single 32-byte commitment hash. It
+/// carries no success-vs-error signal by construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AckPdaSnapshot {
+    pub commitment_hash: [u8; 32],
+}
+
+/// One poll cycle's observation for a single leg. Feeds [`reconcile`].
+#[derive(Debug, Clone)]
+pub struct PollObservation {
+    pub commitment: CommitmentObservation,
+    pub ack_event: Option<AckOutcome>,
+    pub timeout_event: bool,
+    pub recv_observed: bool,
+    pub event_gap: bool,
+    pub current_height: IbcHeight,
+    pub timeout_height: IbcHeight,
+}
+
+/// A single tracked leg's persisted record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrackedLeg {
+    pub phase: LegPhase,
+    pub from_chain: Chain,
+    pub to_chain: Chain,
+    pub timeout_height: IbcHeight,
+}
+
+/// A tracked route: the durable unit the store persists and the status
+/// endpoint reads.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrackedTransfer {
+    pub id: String,
+    pub direction: Direction,
+    pub channel: String,
+    pub legs: Vec<TrackedLeg>,
+    pub created_at: DateTime<Utc>,
+    pub terminal_at: Option<DateTime<Utc>>,
+}
+
+/// Where the asset currently rests, mirroring Skip's `transfer_asset_release`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssetRelease {
+    pub chain: String,
+    pub released: bool,
+}
+
+/// Typed per-route error, mirroring Skip's error envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferError {
+    pub code: String,
+    pub message: String,
+}
+
+/// One entry of the modern `transfers[]` shape: a per-leg state plus the
+/// chains it bridges.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferLeg {
+    pub state: String,
+    pub from_chain: String,
+    pub to_chain: String,
+}
+
+/// The status response served by `GET /api/transfer/status/{id}`. This is the
+/// tracker's own type, NOT a re-use of `SkipStatusResponse`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferStatusResponse {
+    pub state: String,
+    pub transfers: Vec<TransferLeg>,
+    pub next_blocking_transfer: Option<usize>,
+    pub transfer_asset_release: Option<AssetRelease>,
+    pub error: Option<TransferError>,
+}
+
+/// True when `current` is at or past `timeout`, comparing the full IBC height
+/// tuple (revision number first, then revision height).
+pub fn timeout_reached(current: IbcHeight, timeout: IbcHeight) -> bool {
+    let _ = (current, timeout);
+    todo!("compare (revision_number, revision_height) tuple, never slot alone")
+}
+
+/// Terminal phase derived from a Nolus `acknowledge_packet` event's ack
+/// payload polarity — the only source of success-vs-error truth.
+pub fn phase_from_ack_event(outcome: AckOutcome) -> LegPhase {
+    let _ = outcome;
+    todo!("Success -> CompletedSuccess, Error -> CompletedError")
+}
+
+/// Phase implied by an acknowledgement PDA snapshot alone. The 32-byte hash
+/// carries no polarity, so this never yields a success/error terminal.
+pub fn phase_from_ack_pda(snapshot: &AckPdaSnapshot) -> LegPhase {
+    let _ = snapshot;
+    todo!("ack PDA proves acknowledgement exists; polarity unknown -> Acked")
+}
+
+/// The chain whose commitment PDA the tracker may query for this direction.
+/// Nolus->Solana observes the commitment through Nolus CometBFT events, so it
+/// has no commitment PDA to query (`None`); Solana->Nolus reads the commitment
+/// PDA on Solana. Never Nolus — Nolus is Cosmos and holds no packet PDAs.
+pub fn commitment_pda_chain(direction: Direction) -> Option<Chain> {
+    let _ = direction;
+    todo!("SolanaToNolus -> Some(Solana); NolusToSolana -> None; never Nolus")
+}
+
+/// Fold one poll observation into the next leg phase. Applies the timeout
+/// tuple rule, the Solana->Nolus timeout-refund inference, and the
+/// commitment-gone-across-a-gap -> `Indeterminate` rule.
+pub fn reconcile(prior: LegPhase, direction: Direction, obs: &PollObservation) -> LegPhase {
+    let _ = (prior, direction, obs);
+    todo!("event-sourced terminals first; gap => Indeterminate; present+past-timeout => AwaitingTimeout")
+}
+
+/// Apply a poll result. A failed poll (RPC / decode error) is unknown, not
+/// terminal: the prior phase is returned untouched.
+pub fn apply_poll(
+    prior: LegPhase,
+    direction: Direction,
+    poll: Result<PollObservation, crate::error::AppError>,
+) -> LegPhase {
+    let _ = (prior, direction, poll);
+    todo!("Err(_) => prior unchanged; Ok(obs) => reconcile(prior, direction, &obs)")
+}
+
+/// Top-level route state from the per-leg phases, mirroring the Skip enum.
+pub fn top_level_state(legs: &[LegPhase]) -> &'static str {
+    let _ = legs;
+    todo!("all-success => COMPLETED_SUCCESS; any error/refund => COMPLETED_ERROR; any indeterminate => ABANDONED; else PENDING")
+}
+
+/// Build the status response for a tracked route.
+pub fn status_response(record: &TrackedTransfer) -> TransferStatusResponse {
+    let _ = record;
+    todo!("derive top-level state + per-leg transfers[] + asset release")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HASH: [u8; 32] = [0xAB; 32];
+
+    fn height(rev: u64, h: u64) -> IbcHeight {
+        IbcHeight {
+            revision_number: rev,
+            revision_height: h,
+        }
+    }
+
+    // Rule 1 — terminal polarity comes from ack events, never PDAs.
+
+    #[test]
+    fn ack_pda_snapshot_never_yields_a_success_terminal() {
+        let phase = phase_from_ack_pda(&AckPdaSnapshot {
+            commitment_hash: HASH,
+        });
+        assert!(
+            !matches!(phase, LegPhase::CompletedSuccess),
+            "ack PDA hash has no polarity; must not imply CompletedSuccess"
+        );
+    }
+
+    #[test]
+    fn ack_pda_snapshot_never_yields_an_error_terminal() {
+        let phase = phase_from_ack_pda(&AckPdaSnapshot {
+            commitment_hash: HASH,
+        });
+        assert!(
+            !matches!(phase, LegPhase::CompletedError),
+            "ack PDA hash has no polarity; must not imply CompletedError"
+        );
+    }
+
+    #[test]
+    fn ack_pda_snapshot_resolves_to_acked_polarity_unknown() {
+        let phase = phase_from_ack_pda(&AckPdaSnapshot {
+            commitment_hash: HASH,
+        });
+        assert_eq!(phase, LegPhase::Acked);
+    }
+
+    #[test]
+    fn ack_event_success_payload_yields_success_terminal() {
+        assert_eq!(phase_from_ack_event(AckOutcome::Success), LegPhase::CompletedSuccess);
+    }
+
+    #[test]
+    fn ack_event_error_payload_yields_error_terminal() {
+        assert_eq!(phase_from_ack_event(AckOutcome::Error), LegPhase::CompletedError);
+    }
+
+    // Rule 2 — never query a commitment PDA on the wrong side for a direction.
+
+    #[test]
+    fn nolus_to_solana_has_no_commitment_pda_to_query() {
+        assert_eq!(commitment_pda_chain(Direction::NolusToSolana), None);
+    }
+
+    #[test]
+    fn solana_to_nolus_queries_the_solana_commitment_pda() {
+        assert_eq!(
+            commitment_pda_chain(Direction::SolanaToNolus),
+            Some(Chain::Solana)
+        );
+    }
+
+    #[test]
+    fn commitment_pda_chain_is_never_nolus() {
+        for direction in [Direction::NolusToSolana, Direction::SolanaToNolus] {
+            assert_ne!(
+                commitment_pda_chain(direction),
+                Some(Chain::Nolus),
+                "Nolus is Cosmos and holds no packet PDAs"
+            );
+        }
+    }
+
+    // Rule 3 — a gap without a captured terminal is INDETERMINATE.
+
+    #[test]
+    fn commitment_gone_across_observation_gap_is_indeterminate() {
+        let obs = PollObservation {
+            commitment: CommitmentObservation::Gone,
+            ack_event: None,
+            timeout_event: false,
+            recv_observed: false,
+            event_gap: true,
+            current_height: height(5, 10),
+            timeout_height: height(5, 1000),
+        };
+        assert_eq!(
+            reconcile(LegPhase::Relayed, Direction::SolanaToNolus, &obs),
+            LegPhase::Indeterminate
+        );
+    }
+
+    #[test]
+    fn indeterminate_is_never_a_fabricated_timeout() {
+        let obs = PollObservation {
+            commitment: CommitmentObservation::Gone,
+            ack_event: None,
+            timeout_event: false,
+            recv_observed: false,
+            event_gap: true,
+            current_height: height(5, 10),
+            timeout_height: height(5, 1000),
+        };
+        assert_ne!(
+            reconcile(LegPhase::Relayed, Direction::NolusToSolana, &obs),
+            LegPhase::TimedOutRefunded
+        );
+    }
+
+    // Rule 2 — Solana->Nolus timeout-refund inference (continuous observation).
+
+    #[test]
+    fn solana_to_nolus_commitment_gone_no_recv_no_gap_is_timeout_refunded() {
+        let obs = PollObservation {
+            commitment: CommitmentObservation::Gone,
+            ack_event: None,
+            timeout_event: false,
+            recv_observed: false,
+            event_gap: false,
+            current_height: height(5, 10),
+            timeout_height: height(5, 5),
+        };
+        assert_eq!(
+            reconcile(LegPhase::Relayed, Direction::SolanaToNolus, &obs),
+            LegPhase::TimedOutRefunded
+        );
+    }
+
+    // Rule 4 — past the timeout height with the commitment still present is
+    // awaiting-timeout, not refunded. Straddles an epoch boundary.
+
+    #[test]
+    fn present_commitment_past_timeout_height_is_awaiting_not_refunded() {
+        let obs = PollObservation {
+            commitment: CommitmentObservation::Present,
+            ack_event: None,
+            timeout_event: false,
+            recv_observed: false,
+            event_gap: false,
+            current_height: height(6, 1),
+            timeout_height: height(5, 1000),
+        };
+        assert_eq!(
+            reconcile(LegPhase::Relayed, Direction::NolusToSolana, &obs),
+            LegPhase::AwaitingTimeout
+        );
+    }
+
+    #[test]
+    fn timeout_reached_uses_epoch_before_slot() {
+        // Higher epoch, lower slot: reached despite the slot being smaller.
+        assert!(timeout_reached(height(6, 1), height(5, 1000)));
+    }
+
+    #[test]
+    fn timeout_not_reached_when_epoch_is_behind_despite_larger_slot() {
+        // Lower epoch, larger slot: NOT reached. A slot-only comparison fails.
+        assert!(!timeout_reached(height(5, 5000), height(6, 1)));
+    }
+
+    // Rule 5 — event-sourced terminals drive the leg terminal through
+    // `reconcile` itself (not only the `phase_from_ack_event` helper), and take
+    // precedence over the commitment inference. AC1: each terminal — delivered,
+    // error-acked, timeout-refunded — is reached with the correct per-leg state.
+
+    #[test]
+    fn reconcile_ack_success_event_wins_over_commitment_gone_inference() {
+        // Commitment gone with no recv on Solana->Nolus would otherwise infer a
+        // timeout-refund; a success ack event must win and deliver the leg.
+        let obs = PollObservation {
+            commitment: CommitmentObservation::Gone,
+            ack_event: Some(AckOutcome::Success),
+            timeout_event: false,
+            recv_observed: false,
+            event_gap: false,
+            current_height: height(5, 10),
+            timeout_height: height(5, 1000),
+        };
+        assert_eq!(
+            reconcile(LegPhase::Relayed, Direction::SolanaToNolus, &obs),
+            LegPhase::CompletedSuccess
+        );
+    }
+
+    #[test]
+    fn reconcile_ack_error_event_yields_error_terminal_over_commitment_gone() {
+        let obs = PollObservation {
+            commitment: CommitmentObservation::Gone,
+            ack_event: Some(AckOutcome::Error),
+            timeout_event: false,
+            recv_observed: false,
+            event_gap: false,
+            current_height: height(5, 10),
+            timeout_height: height(5, 1000),
+        };
+        assert_eq!(
+            reconcile(LegPhase::Relayed, Direction::SolanaToNolus, &obs),
+            LegPhase::CompletedError
+        );
+    }
+
+    #[test]
+    fn reconcile_recv_without_ack_is_delivered_not_terminal() {
+        // Packet arrived on the destination; the source ack has not returned, so
+        // the leg is delivered-but-not-yet-terminal.
+        let obs = PollObservation {
+            commitment: CommitmentObservation::Present,
+            ack_event: None,
+            timeout_event: false,
+            recv_observed: true,
+            event_gap: false,
+            current_height: height(5, 10),
+            timeout_height: height(5, 1000),
+        };
+        assert_eq!(
+            reconcile(LegPhase::Relayed, Direction::NolusToSolana, &obs),
+            LegPhase::Delivered
+        );
+    }
+
+    #[test]
+    fn reconcile_explicit_timeout_event_refunds_nolus_to_solana_leg() {
+        // Nolus->Solana cannot infer a timeout from a vanished commitment; only
+        // an observed timeout event reaches the refund terminal for that leg.
+        let obs = PollObservation {
+            commitment: CommitmentObservation::Gone,
+            ack_event: None,
+            timeout_event: true,
+            recv_observed: false,
+            event_gap: false,
+            current_height: height(6, 1),
+            timeout_height: height(5, 1000),
+        };
+        assert_eq!(
+            reconcile(LegPhase::Relayed, Direction::NolusToSolana, &obs),
+            LegPhase::TimedOutRefunded
+        );
+    }
+
+    // Rule 9 — a poll error is unknown, not terminal.
+
+    #[test]
+    fn poll_error_leaves_prior_phase_untouched() {
+        let poll = Err(crate::error::AppError::ChainRpc {
+            chain: "solana".to_string(),
+            message: "rpc down".to_string(),
+        });
+        assert_eq!(
+            apply_poll(LegPhase::Relayed, Direction::SolanaToNolus, poll),
+            LegPhase::Relayed
+        );
+    }
+
+    // Rule 7 (body) — top-level state mapping and whole-value response shape.
+
+    #[test]
+    fn all_legs_delivered_maps_to_completed_success() {
+        assert_eq!(
+            top_level_state(&[LegPhase::CompletedSuccess, LegPhase::Delivered]),
+            STATE_COMPLETED_SUCCESS
+        );
+    }
+
+    #[test]
+    fn any_error_leg_maps_to_completed_error() {
+        assert_eq!(
+            top_level_state(&[LegPhase::CompletedSuccess, LegPhase::CompletedError]),
+            STATE_COMPLETED_ERROR
+        );
+    }
+
+    #[test]
+    fn any_indeterminate_leg_maps_to_abandoned() {
+        assert_eq!(
+            top_level_state(&[LegPhase::Delivered, LegPhase::Indeterminate]),
+            STATE_ABANDONED
+        );
+    }
+
+    #[test]
+    fn in_flight_leg_maps_to_pending() {
+        assert_eq!(
+            top_level_state(&[LegPhase::Relayed]),
+            STATE_PENDING
+        );
+    }
+
+    #[test]
+    fn status_response_matches_modern_transfers_shape() {
+        let record = TrackedTransfer {
+            id: "t1".to_string(),
+            direction: Direction::SolanaToNolus,
+            channel: "channel-0".to_string(),
+            legs: vec![TrackedLeg {
+                phase: LegPhase::CompletedSuccess,
+                from_chain: Chain::Solana,
+                to_chain: Chain::Nolus,
+                timeout_height: height(5, 100),
+            }],
+            created_at: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
+            terminal_at: Some(DateTime::<Utc>::from_timestamp(1_700_000_100, 0).unwrap()),
+        };
+        let expected = serde_json::json!({
+            "state": "STATE_COMPLETED_SUCCESS",
+            "transfers": [
+                {
+                    "state": "STATE_COMPLETED_SUCCESS",
+                    "from_chain": "solana",
+                    "to_chain": "nolus"
+                }
+            ],
+            "next_blocking_transfer": null,
+            "transfer_asset_release": { "chain": "nolus", "released": true },
+            "error": null
+        });
+        let actual = serde_json::to_value(status_response(&record)).expect("response serializes");
+        assert_eq!(actual, expected);
+    }
+}

--- a/backend/src/transfer_tracker/store.rs
+++ b/backend/src/transfer_tracker/store.rs
@@ -1,0 +1,170 @@
+//! Durable tracking set for in-flight transfers.
+//!
+//! A single locked canonical map of route id -> [`TrackedTransfer`], persisted
+//! as a whole-map JSON image. Each write goes to a unique temp file, is
+//! `sync_all`'d, renamed into place, and the parent directory is fsync'd. A
+//! corrupt image on load is a loud failure with a `.bak` fallback — never a
+//! silent empty start. Terminal routes are retained for a window, then pruned.
+
+use std::path::PathBuf;
+
+use chrono::{DateTime, Duration, Utc};
+
+use crate::error::AppError;
+
+use super::TrackedTransfer;
+
+/// The durable, capped, self-pruning tracking set.
+pub struct TransferStore {
+    path: PathBuf,
+    capacity: usize,
+    retention: Duration,
+}
+
+impl TransferStore {
+    /// Bind a store to `path` with an empty in-memory set — the create path
+    /// when no prior image exists.
+    pub fn create(path: PathBuf, capacity: usize, retention: Duration) -> Self {
+        let _ = (path, capacity, retention);
+        todo!("initialise an empty locked map bound to `path`")
+    }
+
+    /// Load an existing image from `path`. A corrupt primary image falls back
+    /// to `<path>.bak`; if neither loads, this returns `Err` — it must never
+    /// silently yield an empty set.
+    pub async fn load(path: PathBuf, capacity: usize, retention: Duration) -> Result<Self, AppError> {
+        let _ = (path, capacity, retention);
+        todo!("load primary; on corruption try .bak; else Err (never empty-start)")
+    }
+
+    /// Persist the whole map: unique temp file -> `sync_all` -> atomic rename
+    /// -> parent-dir fsync.
+    pub async fn persist(&self) -> Result<(), AppError> {
+        todo!("whole-map write via unique temp + sync_all + parent fsync")
+    }
+
+    /// Insert a new tracked route. Rejects with `Err` once the active set is at
+    /// capacity.
+    pub async fn insert(&self, record: TrackedTransfer) -> Result<(), AppError> {
+        let _ = record;
+        todo!("reject at capacity; otherwise insert and persist")
+    }
+
+    /// Fetch a tracked route by id.
+    pub fn get(&self, id: &str) -> Option<TrackedTransfer> {
+        let _ = id;
+        todo!("clone the record out of the locked map")
+    }
+
+    /// Number of routes currently held.
+    pub fn active_count(&self) -> usize {
+        todo!("map length under the lock")
+    }
+
+    /// Drop terminal routes whose `terminal_at` is older than the retention
+    /// window relative to `now`.
+    pub fn prune(&self, now: DateTime<Utc>) {
+        let _ = now;
+        todo!("evict terminal routes past the retention window")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transfer_tracker::{Chain, Direction, IbcHeight, LegPhase, TrackedLeg};
+    use tempfile::TempDir;
+
+    fn retention() -> Duration {
+        Duration::seconds(3600)
+    }
+
+    fn at(secs: i64) -> DateTime<Utc> {
+        DateTime::<Utc>::from_timestamp(secs, 0).expect("valid timestamp")
+    }
+
+    fn record(id: &str, terminal_at: Option<DateTime<Utc>>) -> TrackedTransfer {
+        TrackedTransfer {
+            id: id.to_string(),
+            direction: Direction::SolanaToNolus,
+            channel: "channel-0".to_string(),
+            legs: vec![TrackedLeg {
+                phase: LegPhase::CompletedSuccess,
+                from_chain: Chain::Solana,
+                to_chain: Chain::Nolus,
+                timeout_height: IbcHeight {
+                    revision_number: 5,
+                    revision_height: 100,
+                },
+            }],
+            created_at: at(1_700_000_000),
+            terminal_at,
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_persist_then_reload_recovers_the_record() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("transfers.json");
+        let original = record("t1", None);
+
+        let store = TransferStore::create(path.clone(), 512, retention());
+        store.insert(original.clone()).await.expect("insert");
+        store.persist().await.expect("persist");
+
+        let reloaded = TransferStore::load(path, 512, retention())
+            .await
+            .expect("reload from persisted image");
+        assert_eq!(reloaded.get("t1"), Some(original));
+    }
+
+    #[tokio::test]
+    async fn corrupt_image_load_errors_rather_than_starting_empty() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("transfers.json");
+        std::fs::write(&path, b"{ this is not valid json").expect("seed corrupt file");
+
+        let result = TransferStore::load(path, 512, retention()).await;
+        assert!(
+            result.is_err(),
+            "a corrupt image must be a loud failure, never a silent empty set"
+        );
+    }
+
+    #[tokio::test]
+    async fn insert_is_rejected_at_capacity() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("transfers.json");
+        let store = TransferStore::create(path, 1, retention());
+
+        store.insert(record("t1", None)).await.expect("first insert fits");
+        assert!(
+            store.insert(record("t2", None)).await.is_err(),
+            "insert past the active-set cap must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_record_survives_within_retention_then_prunes() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("transfers.json");
+        let terminal = at(1_700_000_000);
+        let store = TransferStore::create(path, 512, retention());
+        store
+            .insert(record("t1", Some(terminal)))
+            .await
+            .expect("insert terminal record");
+
+        store.prune(terminal + Duration::seconds(60));
+        assert!(
+            store.get("t1").is_some(),
+            "terminal record must remain within the retention window"
+        );
+
+        store.prune(terminal + retention() + Duration::seconds(1));
+        assert!(
+            store.get("t1").is_none(),
+            "terminal record must be pruned past the retention window"
+        );
+    }
+}

--- a/backend/src/transfer_tracker/store.rs
+++ b/backend/src/transfer_tracker/store.rs
@@ -24,14 +24,16 @@ static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// The durable, capped, self-pruning tracking set.
 ///
-/// The canonical map is guarded by a single [`Mutex`]. The guard is never held
-/// across an `.await`: async methods snapshot or mutate under the lock, drop
-/// it, then do file I/O.
+/// The canonical map is guarded by a single std [`Mutex`], never held across an
+/// `.await`: async methods snapshot or mutate under it, drop it, then do file
+/// I/O. A separate async `write_gate` serializes persist calls so that the
+/// image written to disk is always the newest snapshot (see [`persist`]).
 pub struct TransferStore {
     path: PathBuf,
     capacity: usize,
     retention: Duration,
     entries: Mutex<HashMap<String, TrackedTransfer>>,
+    write_gate: tokio::sync::Mutex<()>,
 }
 
 impl TransferStore {
@@ -43,6 +45,7 @@ impl TransferStore {
             capacity,
             retention,
             entries: Mutex::new(HashMap::new()),
+            write_gate: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -67,17 +70,27 @@ impl TransferStore {
                 })?
             }
         };
-        Ok(Self {
+        let store = Self {
             path,
             capacity,
             retention,
             entries: Mutex::new(entries),
-        })
+            write_gate: tokio::sync::Mutex::new(()),
+        };
+        // Drop terminals whose retention window elapsed while the process was
+        // down, so they neither reload nor count toward the cap.
+        store.prune(Utc::now());
+        Ok(store)
     }
 
-    /// Persist the whole map: unique temp file -> `sync_all` -> atomic rename
-    /// -> parent-dir fsync.
+    /// Durably write the current tracking set to the store's path. Concurrent
+    /// callers are safe: the newest state always lands last, and a crash never
+    /// leaves a partial image behind.
     pub async fn persist(&self) -> Result<(), AppError> {
+        // Snapshot INSIDE the write gate so snapshot order equals rename
+        // order — a slower writer must never rename a staler image over a
+        // newer one (silent record loss across a restart).
+        let _write = self.write_gate.lock().await;
         let snapshot = self.snapshot();
         let bytes = serde_json::to_vec_pretty(&snapshot)
             .map_err(|e| AppError::Internal(format!("serialising transfer store: {e}")))?;
@@ -129,6 +142,9 @@ impl TransferStore {
     /// capacity. A persist failure rolls the in-memory insert back.
     pub async fn insert(&self, record: TrackedTransfer) -> Result<(), AppError> {
         let id = record.id.clone();
+        // Prune expired terminals first so they stop counting toward the cap:
+        // the capacity gate must reflect live, still-in-flight routes only.
+        self.prune(Utc::now());
         {
             let mut entries = self.lock();
             if entries.len() >= self.capacity {
@@ -149,6 +165,10 @@ impl TransferStore {
     /// (the id is already counted); a route absent from the set (pruned or
     /// removed) is a no-op, so a status re-poll never resurrects it.
     pub async fn update(&self, record: TrackedTransfer) -> Result<(), AppError> {
+        // Opportunistically evict expired terminals on the write path (cheap for
+        // a <=cap map); the just-updated record carries a fresh terminal_at when
+        // it goes terminal, so it is never within the pruned set itself.
+        self.prune(Utc::now());
         {
             let mut entries = self.lock();
             if !entries.contains_key(&record.id) {
@@ -176,7 +196,7 @@ impl TransferStore {
 
     /// Drop terminal routes whose `terminal_at` is older than the retention
     /// window relative to `now`.
-    pub fn prune(&self, now: DateTime<Utc>) {
+    fn prune(&self, now: DateTime<Utc>) {
         let mut entries = self.lock();
         entries.retain(|_id, record| match record.terminal_at {
             Some(terminal_at) => terminal_at + self.retention >= now,
@@ -369,5 +389,69 @@ mod tests {
             .await
             .expect("insert succeeds once the directory exists");
         assert_eq!(store.active_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn expired_terminals_free_capacity_for_new_inserts() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("transfers.json");
+        let store = TransferStore::create(path, 512, retention());
+
+        // Fill the set to capacity with terminal records long past retention.
+        let expired = at(1_700_000_000);
+        {
+            let mut entries = store.entries.lock().expect("lock");
+            for i in 0..512 {
+                let id = format!("old-{i}");
+                entries.insert(id.clone(), record(&id, Some(expired)));
+            }
+        }
+        assert_eq!(store.active_count(), 512);
+
+        // A fresh registration: insert prunes the expired terminals first, so the
+        // cap no longer 429s forever after 512 lifetime transfers.
+        store
+            .insert(record("new", None))
+            .await
+            .expect("insert must succeed once expired terminals are pruned");
+        assert!(store.get("new").is_some());
+        assert!(
+            store.get("old-0").is_none(),
+            "expired terminals were pruned"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_drops_expired_terminal_records() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("transfers.json");
+
+        // Persist a set holding one within-retention terminal and one expired.
+        let fresh = TransferStore::create(path.clone(), 512, retention());
+        fresh
+            .insert(record("fresh", Some(Utc::now())))
+            .await
+            .expect("insert fresh terminal");
+        {
+            let mut entries = fresh.entries.lock().expect("lock");
+            entries.insert(
+                "expired".to_string(),
+                record("expired", Some(at(1_700_000_000))),
+            );
+        }
+        fresh.persist().await.expect("persist");
+
+        // Reload: the expired terminal is dropped, the fresh one survives.
+        let reloaded = TransferStore::load(path, 512, retention())
+            .await
+            .expect("reload");
+        assert!(
+            reloaded.get("fresh").is_some(),
+            "a within-retention terminal survives reload"
+        );
+        assert!(
+            reloaded.get("expired").is_none(),
+            "an expired terminal is dropped on load"
+        );
     }
 }

--- a/backend/src/transfer_tracker/store.rs
+++ b/backend/src/transfer_tracker/store.rs
@@ -6,66 +6,191 @@
 //! corrupt image on load is a loud failure with a `.bak` fallback — never a
 //! silent empty start. Terminal routes are retained for a window, then pruned.
 
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, PoisonError};
 
 use chrono::{DateTime, Duration, Utc};
+use tokio::io::AsyncWriteExt as _;
 
 use crate::error::AppError;
 
 use super::TrackedTransfer;
 
+/// Monotonic suffix source for temp-file uniqueness within a persist directory.
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
 /// The durable, capped, self-pruning tracking set.
+///
+/// The canonical map is guarded by a single [`Mutex`]. The guard is never held
+/// across an `.await`: async methods snapshot or mutate under the lock, drop
+/// it, then do file I/O.
 pub struct TransferStore {
     path: PathBuf,
     capacity: usize,
     retention: Duration,
+    entries: Mutex<HashMap<String, TrackedTransfer>>,
 }
 
 impl TransferStore {
     /// Bind a store to `path` with an empty in-memory set — the create path
     /// when no prior image exists.
     pub fn create(path: PathBuf, capacity: usize, retention: Duration) -> Self {
-        let _ = (path, capacity, retention);
-        todo!("initialise an empty locked map bound to `path`")
+        Self {
+            path,
+            capacity,
+            retention,
+            entries: Mutex::new(HashMap::new()),
+        }
     }
 
     /// Load an existing image from `path`. A corrupt primary image falls back
     /// to `<path>.bak`; if neither loads, this returns `Err` — it must never
     /// silently yield an empty set.
-    pub async fn load(path: PathBuf, capacity: usize, retention: Duration) -> Result<Self, AppError> {
-        let _ = (path, capacity, retention);
-        todo!("load primary; on corruption try .bak; else Err (never empty-start)")
+    pub async fn load(
+        path: PathBuf,
+        capacity: usize,
+        retention: Duration,
+    ) -> Result<Self, AppError> {
+        let primary = Self::read_image(&path).await;
+        let entries = match primary {
+            Ok(map) => map,
+            Err(primary_err) => {
+                let backup = Self::backup_path(&path);
+                Self::read_image(&backup).await.map_err(|_backup_err| {
+                    AppError::Internal(format!(
+                        "transfer store image at {} is unreadable and no valid backup exists: {primary_err}",
+                        path.display()
+                    ))
+                })?
+            }
+        };
+        Ok(Self {
+            path,
+            capacity,
+            retention,
+            entries: Mutex::new(entries),
+        })
     }
 
     /// Persist the whole map: unique temp file -> `sync_all` -> atomic rename
     /// -> parent-dir fsync.
     pub async fn persist(&self) -> Result<(), AppError> {
-        todo!("whole-map write via unique temp + sync_all + parent fsync")
+        let snapshot = self.snapshot();
+        let bytes = serde_json::to_vec_pretty(&snapshot)
+            .map_err(|e| AppError::Internal(format!("serialising transfer store: {e}")))?;
+
+        let dir = self.path.parent().filter(|p| !p.as_os_str().is_empty());
+        let temp = self.temp_path();
+
+        {
+            let mut file = tokio::fs::File::create(&temp).await.map_err(|e| {
+                AppError::Internal(format!("creating transfer store temp file: {e}"))
+            })?;
+            file.write_all(&bytes).await.map_err(|e| {
+                AppError::Internal(format!("writing transfer store temp file: {e}"))
+            })?;
+            file.sync_all().await.map_err(|e| {
+                AppError::Internal(format!("syncing transfer store temp file: {e}"))
+            })?;
+        }
+
+        tokio::fs::rename(&temp, &self.path)
+            .await
+            .map_err(|e| AppError::Internal(format!("committing transfer store image: {e}")))?;
+
+        if let Some(dir) = dir {
+            if let Ok(handle) = tokio::fs::File::open(dir).await {
+                let _ = handle.sync_all().await;
+            }
+        }
+        Ok(())
     }
 
     /// Insert a new tracked route. Rejects with `Err` once the active set is at
     /// capacity.
     pub async fn insert(&self, record: TrackedTransfer) -> Result<(), AppError> {
-        let _ = record;
-        todo!("reject at capacity; otherwise insert and persist")
+        {
+            let mut entries = self.lock();
+            if entries.len() >= self.capacity {
+                return Err(AppError::RateLimited { retry_after: None });
+            }
+            entries.insert(record.id.clone(), record);
+        }
+        self.persist().await
     }
 
     /// Fetch a tracked route by id.
     pub fn get(&self, id: &str) -> Option<TrackedTransfer> {
-        let _ = id;
-        todo!("clone the record out of the locked map")
+        self.lock().get(id).cloned()
     }
 
     /// Number of routes currently held.
     pub fn active_count(&self) -> usize {
-        todo!("map length under the lock")
+        self.lock().len()
+    }
+
+    /// The active-set cap this store enforces on new insertions.
+    pub const fn capacity(&self) -> usize {
+        self.capacity
     }
 
     /// Drop terminal routes whose `terminal_at` is older than the retention
     /// window relative to `now`.
     pub fn prune(&self, now: DateTime<Utc>) {
-        let _ = now;
-        todo!("evict terminal routes past the retention window")
+        let mut entries = self.lock();
+        entries.retain(|_id, record| match record.terminal_at {
+            Some(terminal_at) => terminal_at + self.retention >= now,
+            None => true,
+        });
+    }
+
+    /// Lock the canonical map, recovering the inner guard on poisoning rather
+    /// than panicking (a poisoned lock still holds a usable map).
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, TrackedTransfer>> {
+        self.entries.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Snapshot the canonical map for a whole-image write.
+    fn snapshot(&self) -> HashMap<String, TrackedTransfer> {
+        self.lock().clone()
+    }
+
+    /// The `<path>.bak` fallback image path.
+    fn backup_path(path: &Path) -> PathBuf {
+        let mut name = path.file_name().unwrap_or_default().to_os_string();
+        name.push(".bak");
+        path.with_file_name(name)
+    }
+
+    /// A unique temp path in the image's directory for an atomic write.
+    fn temp_path(&self) -> PathBuf {
+        let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut name = self.path.file_name().unwrap_or_default().to_os_string();
+        name.push(format!(".tmp-{}-{counter}", std::process::id()));
+        self.path.with_file_name(name)
+    }
+
+    /// Read and deserialise a whole-map image. Any I/O or parse failure is an
+    /// `Err` — a missing or corrupt image never yields an empty map here.
+    async fn read_image(path: &Path) -> Result<HashMap<String, TrackedTransfer>, AppError> {
+        let bytes = tokio::fs::read(path)
+            .await
+            .map_err(|e| AppError::Internal(format!("reading transfer store image: {e}")))?;
+        serde_json::from_slice(&bytes)
+            .map_err(|e| AppError::Internal(format!("parsing transfer store image: {e}")))
+    }
+
+    /// Ephemeral store bound to a unique temp file, for tests only.
+    #[cfg(test)]
+    pub fn ephemeral() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "transfers-test-{}-{}.json",
+            std::process::id(),
+            TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        Self::create(path, super::DEFAULT_ACTIVE_SET_CAP, Duration::hours(1))
     }
 }
 
@@ -137,7 +262,10 @@ mod tests {
         let path = dir.path().join("transfers.json");
         let store = TransferStore::create(path, 1, retention());
 
-        store.insert(record("t1", None)).await.expect("first insert fits");
+        store
+            .insert(record("t1", None))
+            .await
+            .expect("first insert fits");
         assert!(
             store.insert(record("t2", None)).await.is_err(),
             "insert past the active-set cap must be rejected"

--- a/backend/src/transfer_tracker/store.rs
+++ b/backend/src/transfer_tracker/store.rs
@@ -13,6 +13,7 @@ use std::sync::{Mutex, PoisonError};
 
 use chrono::{DateTime, Duration, Utc};
 use tokio::io::AsyncWriteExt as _;
+use tracing::warn;
 
 use crate::error::AppError;
 
@@ -100,21 +101,58 @@ impl TransferStore {
             .await
             .map_err(|e| AppError::Internal(format!("committing transfer store image: {e}")))?;
 
+        // The parent-dir fsync durably records the rename; a failure here does
+        // not lose the written image (already fsync'd), so it is non-fatal, but
+        // it must be surfaced rather than swallowed.
         if let Some(dir) = dir {
-            if let Ok(handle) = tokio::fs::File::open(dir).await {
-                let _ = handle.sync_all().await;
+            match tokio::fs::File::open(dir).await {
+                Ok(handle) => {
+                    if let Err(e) = handle.sync_all().await {
+                        warn!(
+                            "transfer store parent-dir fsync failed ({}): {e}",
+                            dir.display()
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "transfer store parent-dir open failed ({}): {e}",
+                        dir.display()
+                    );
+                }
             }
         }
         Ok(())
     }
 
     /// Insert a new tracked route. Rejects with `Err` once the active set is at
-    /// capacity.
+    /// capacity. A persist failure rolls the in-memory insert back.
     pub async fn insert(&self, record: TrackedTransfer) -> Result<(), AppError> {
+        let id = record.id.clone();
         {
             let mut entries = self.lock();
             if entries.len() >= self.capacity {
                 return Err(AppError::RateLimited { retry_after: None });
+            }
+            entries.insert(id.clone(), record);
+        }
+        if let Err(e) = self.persist().await {
+            // Roll back so a persist failure never leaves an orphan record that
+            // permanently consumes a capacity slot until restart.
+            self.lock().remove(&id);
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// Replace an already-tracked route's state and persist. Not capacity-gated
+    /// (the id is already counted); a route absent from the set (pruned or
+    /// removed) is a no-op, so a status re-poll never resurrects it.
+    pub async fn update(&self, record: TrackedTransfer) -> Result<(), AppError> {
+        {
+            let mut entries = self.lock();
+            if !entries.contains_key(&record.id) {
+                return Ok(());
             }
             entries.insert(record.id.clone(), record);
         }
@@ -185,12 +223,19 @@ impl TransferStore {
     /// Ephemeral store bound to a unique temp file, for tests only.
     #[cfg(test)]
     pub fn ephemeral() -> Self {
+        Self::ephemeral_with_capacity(super::DEFAULT_ACTIVE_SET_CAP)
+    }
+
+    /// Ephemeral store with an explicit capacity, bound to a unique temp file,
+    /// for tests only.
+    #[cfg(test)]
+    pub fn ephemeral_with_capacity(capacity: usize) -> Self {
         let path = std::env::temp_dir().join(format!(
             "transfers-test-{}-{}.json",
             std::process::id(),
             TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
         ));
-        Self::create(path, super::DEFAULT_ACTIVE_SET_CAP, Duration::hours(1))
+        Self::create(path, capacity, Duration::hours(1))
     }
 }
 
@@ -294,5 +339,35 @@ mod tests {
             store.get("t1").is_none(),
             "terminal record must be pruned past the retention window"
         );
+    }
+
+    #[tokio::test]
+    async fn failed_persist_rolls_back_the_insert() {
+        // Bind the store under a directory that does not exist yet: the atomic
+        // temp write fails, so persist() (and thus insert) must fail — and the
+        // in-memory insert must roll back so the capacity slot is not leaked.
+        let dir = TempDir::new().expect("tempdir");
+        let missing = dir.path().join("not-created-yet");
+        let path = missing.join("transfers.json");
+        let store = TransferStore::create(path, 512, retention());
+
+        assert!(
+            store.insert(record("t1", None)).await.is_err(),
+            "insert into a non-existent directory must fail to persist"
+        );
+        assert_eq!(
+            store.active_count(),
+            0,
+            "a failed persist must not leak an orphan in-memory record"
+        );
+
+        // Create the directory so persist can now succeed: the previously
+        // rolled-back slot is available and a fresh insert lands.
+        std::fs::create_dir_all(&missing).expect("create parent dir");
+        store
+            .insert(record("t2", None))
+            .await
+            .expect("insert succeeds once the directory exists");
+        assert_eq!(store.active_count(), 1);
     }
 }


### PR DESCRIPTION
Nolus<->Solana transfer tracker and status API (epic #287, WS1.6). Closes #294.

## What
- `transfer_tracker/` — pure state-machine core: per-leg phases (`committed -> relayed -> acked | timed-out/refunded | error-acked/refunded`), reconciliation fold, IBC-height timeout evaluation, top-level status mapping. Terminal outcomes are strictly event-sourced; uncorrelated on-chain evidence can only keep a leg in-flight, and evidence lost across an observation gap yields `STATE_ABANDONED` (indeterminate) rather than a fabricated timeout.
- Durable tracking set: JSON image with atomic persist (temp file -> fsync -> rename -> parent fsync), serialized writers, loud errors on a corrupt image, rollback on failed persist, self-pruning of expired terminal records (on load / insert / update). `TRANSFER_STORE_PATH` env var (documented in `.env.example`).
- `POST /api/transfer/track` + `GET /api/transfer/status/{id}` (Skip modern `transfers[]` response shape). REST-poll v1 per the plan: each status GET re-polls the chain and advances the state machine; terminal records serve with zero RPC. Status path is no-cache; registrations are capped by an active-set limit (429 past it), validated before any RPC spend.
- PDA decoding via the ibc-solray SDK with an owner check before decode; solray program id configurable per cluster via `SOLANA_SOLRAY_PROGRAM_ID` (mainnet default).
- OpenAPI: transfer paths/schemas registered, snapshot regenerated (`TransferTrackRequest` schema name avoids collision with swap's `TrackRequest`).

## Approach
TDD: the first commit is a red 41-test checkpoint pinning the state-machine contract; implementation follows; two review-driven fix commits (REST-poll rework; production pruning + write serialization + terminal fast-path + program-id config). Note: the checkpoint commit intentionally does not build in isolation (`todo!()` stubs) — bisect with `git bisect skip` on it.

## QA suite impact
suite impact: none live — backend-only endpoints; e2e coverage matrix unchanged (backend API routes are not modeled there; the transfer surface enters the matrix when its frontend flow lands in a later PR). Backend unit suite 590 -> 631.

## Evidence
- Tests: 631 passed / 0 failed (41-test TDD checkpoint intact + 14 review-driven additions). Gate: build, fmt, clippy `-D warnings`, tests — all green.
- Review: generic 12-item checklist PASS (report below), security review CLEAR (report below), project-rule conformance walk — remaining style notes fixed or explicitly adjudicated (visibility tightened, doc contract rewritten; canonical program-id constant and house import style kept).

<details><summary>Generic review report</summary>

# Diff Review Report

Branch: feat/solana-transfer-tracker
Diff range: 45fb024b..HEAD (verification focus: delta commit 3269d14a)
Files changed: 14 (delta: 4 — .env.example, external/solana.rs, handlers/transfer.rs, transfer_tracker/store.rs)

## Acceptance criteria check (Round-2 fix verification)
- AC1 — prune() wired in production: MET. `store.rs:82` (load), `store.rs:149` (top of insert, before capacity gate), `store.rs:173` (update). Tests `expired_terminals_free_capacity_for_new_inserts` (store.rs:396) and `load_drops_expired_terminal_records` (store.rs:426) present and assert the freed-capacity + drop-on-load behavior.
- AC2 — persist writers serialized, snapshot inside gate: MET. `write_gate: tokio::sync::Mutex<()>` (store.rs:36); `persist()` takes `_write` gate then `snapshot()` (store.rs:95-96). Snapshot and rename both occur under the gate → snapshot order == rename order. Ordering justified in the persist doc (store.rs:88-93); no deterministic race test — accepted per task.
- AC3 — terminal fast-path zero-RPC: MET. `transfer.rs:212` guards refresh with `record.terminal_at.is_none() &&`. Test `get_transfer_status_terminal_record_performs_no_poll` (transfer.rs:586) asserts `server.received_requests()` is empty.
- AC4 — SOLANA_SOLRAY_PROGRAM_ID override: MET. `CONFIGURED_SOLRAY_PROGRAM_ID` LazyLock + `solray_program_id()` (solana.rs:504-521); used by owner check (solana.rs:539) and `packet_pda_address` (transfer.rs:353); documented in .env.example. Empty-string falls back to mainnet default.
- AC5 — request() per-attempt-permit doc: MET. solana.rs:200-206 doc matches the loop body (permit acquired per attempt, dropped before backoff sleep, solana.rs:232-288).
- AC6 — commit subjects ≤70: MET (git log inspected; all 5 subjects within limit).

## Checklist

1. **No debug prints, logging leftovers, or commented-out code** — PASS
   No println!/dbg!/eprintln! in non-test code. `warn!` calls (store.rs:126, transfer.rs:216, solana.rs:276) are intentional operational logging. No commented-out code.

2. **No off-by-one errors in loops, slices, or ranges** — PASS
   Capacity gate `entries.len() >= self.capacity` (store.rs:152) correct. Prune retain predicate `terminal_at + retention >= now` (store.rs:204) keeps records exactly at the boundary — matches accepted `>=` adjudication. Retry loop `0..=MAX_RETRIES` with `attempt == MAX_RETRIES` terminal branch (solana.rs:228,255) correct.

3. **All match/enum arms handled** — PASS
   `top_level_state` (mod.rs:285-294) exhaustively matches all LegPhase arms. `asset_release` match on state string has explicit `_ => None` (mod.rs:349). Prune `match record.terminal_at { Some/None }` complete (store.rs:203-206).

4. **Error paths return meaningful errors — no silent swallows** — PASS
   Load corrupt image returns typed Internal error naming the path (store.rs:66-69). Persist failure in insert rolls back then returns the error (store.rs:157-162). Persist failure on the status-update path is surfaced via warn! and deliberately non-fatal (transfer.rs:213-217) — documented rationale, the read still serves a correct freshly-computed status. Parent-dir fsync failure warns rather than fails (store.rs:125-137) — image already fsync'd, documented.

5. **Boundary conditions: empty collections, zero/negative values, max values** — PASS
   Empty map prunes/snapshots cleanly. At-capacity (512) with all-expired terminals is exercised by `expired_terminals_free_capacity_for_new_inserts`. Empty `SOLANA_SOLRAY_PROGRAM_ID` filtered to mainnet default (solana.rs:517). Empty parent dir path guarded (`filter(|p| !p.as_os_str().is_empty())`, store.rs:100; main.rs:192).

6. **Async: no held locks across await, no missing await** — PASS
   std `Mutex` is only held for snapshot-clone/mutate, never across `.await` (snapshot at store.rs:216-218 clones then drops). `write_gate` (tokio Mutex) is held across the persist I/O awaits by design (serialization), and never nested inside the std lock — no lock-ordering inversion, no deadlock. RPC permit is dropped before the backoff sleep (solana.rs:287-288). All `.persist()/.update()/.insert()` calls are awaited.

7. **No resource leaks: unclosed files, connections, transactions** — PASS
   Persist temp file is scoped in a block, sync_all'd, then renamed (store.rs:103-117); dir handle scoped and sync_all'd (store.rs:123-131). Failed persist rolls back the in-memory slot so capacity is not leaked (store.rs:157-162, test `failed_persist_rolls_back_the_insert`). Unique temp-file naming avoids cross-writer collision (store.rs:228-233).

8. **SQL: parameterized queries only** — PASS (N/A) — no SQL in the diff; store is a JSON-image file.

9. **New public functions/endpoints have test coverage** — PASS
   `solray_program_id()` exercised via owner-check tests. Terminal fast-path, capacity-prune, load-drop, no-cache header (cache_control.rs:197), persist/reload all covered. Suite reported 631 passing, gate green.

10. **No logic inversions (`!=` vs `==`, `&&` vs `||`)** — PASS
    Fast-path guard `terminal_at.is_none() && refresh(...)` polls only non-terminal routes — correct direction. Owner check `owner.as_str() != solray_program_id()` rejects mismatched owner — correct. Prune `Some => within-window keeps, None => keep` correct.

11. **Types: no unnecessary clones/copies** — PASS
    `record.clone()` at transfer.rs:213 is required (update consumes the value; `status_response(&record)` uses it after). `snapshot()` clone (store.rs:217) is the intended whole-image copy for serialization. `solray_program_id()` returns `&'static str`, no per-call allocation.

12. **Concurrency: shared state properly guarded, no TOCTOU races** — PASS
    Capacity check+insert is atomic under a single std-lock hold (store.rs:150-156) — concurrent inserts cannot exceed the cap. Persist snapshot/rename serialized by write_gate eliminates the stale-image-over-newer race the round-2 fix targeted. Poisoned std lock recovered via `into_inner` (store.rs:212, accepted). Startup `exists()`→load/create is single-threaded, no race.

## Additional findings beyond the 12-item checklist
- LOW (design, within accepted contract): the terminal fast-path freezes ALL non-PENDING top-level states, including `STATE_ABANDONED` (from `LegPhase::Indeterminate`). Once stamped, such a route is never re-polled. This is consistent with the code's own contract — Indeterminate is documented as "a real terminal" (mod.rs:79-91) — and with the operator-accepted "Indeterminate-on-gap" / "event-sourced terminals land later" adjudications. Noted for the record, not a blocker.
- Observation (not a defect): prune runs only on load/insert/update, so a store at capacity that then goes idle retains expired terminals in memory until the next insert. Benign — capacity is only enforced at insert time, which prunes first. No scheduled sweeper needed for correctness.

## Verdict
PASS — all 12 items pass, all Round-2 fix acceptance criteria verified in 3269d14a, no regression introduced by the delta.
</details>

<details><summary>Security review report</summary>

# Security Review Report

Branch: feat/solana-transfer-tracker
Diff range: 45fb024b..HEAD (verification round focused on the 3269d14a delta)

## Diff classification
- Files in full range: 14 (delta 3269d14a: 4 files)
- Categories detected:
  - **HTTP / API** — `handlers/transfer.rs` (status GET, track POST), route wiring in `main.rs`, openapi spec, `middleware/cache_control.rs`
  - **Secrets / config** — `.env.example` (`SOLANA_SOLRAY_PROGRAM_ID`, `TRANSFER_STORE_PATH`), env-var reads in `solana.rs`/`main.rs`
  - **Untrusted input parsing** — JSON `TrackRequest`, `{id}`/`{channel}` path params, deserialization of Solana RPC responses
  - **Network egress** — Solana JSON-RPC client (`reqwest`) in `external/solana.rs`
  - **Concurrency / state** — `TransferStore` std `Mutex<HashMap>` + new `tokio::sync::Mutex` `write_gate` in `store.rs`
  - **Crypto / key handling** — borderline, NOT triggered: PDA derivation uses public program-id / channel-id addresses; owner check is plain string equality over public account data; no key material, signing, secret comparison, or secret-dependent branch. `constant-time-analysis` / `zeroize-audit` are N/A.
  - **Dependencies** — none (no `Cargo.toml`/`Cargo.lock`/`package.json` change); `LazyLock` is std, `tokio::sync::Mutex` already a dependency. Supply-chain audit N/A.
  - **SQL / DB / Smart contracts** — none (this is an off-chain read-only tracker; no SQL, no contract code changed).

## Skills dispatched
Applied as diff-scoped analysis per the caller's "no repo-wide scanners" constraint:
- `differential-review` (always) — delta security regression analysis
- `sharp-edges` — env-override API ergonomics + URL/PDA building footguns
- `insecure-defaults` — program-id default, cache-control default, config parsing
- Intentionally NOT run: `static-analysis:semgrep` / `codeql` (repo-wide scanners, excluded by caller); `supply-chain-risk-auditor` (no manifest change); `constant-time-analysis`/`zeroize-audit` (no secret-handling crypto).

## Verification of the five 3269d14a round-2 fixes

1. **Prune wired in prod (was HIGH: prune-never-called).** Confirmed at three sites: `load` (store.rs:82, drops terminals expired while process was down), top of `insert` before the capacity gate (store.rs:149, expired terminals free a slot instead of a permanent 429), and `update` (store.rs:173). Tests `expired_terminals_free_capacity_for_new_inserts` and `load_drops_expired_terminal_records` present and assert the behavior. The prior HIGH is resolved; the delta strictly improves the capacity-exhaustion posture.

2. **Persist serialization / stale-snapshot (was MEDIUM).** `write_gate: tokio::sync::Mutex<()>` acquired at persist.rs entry (store.rs:95) with the snapshot taken INSIDE the gate (store.rs:96). Ordering argument is sound: because the clone happens under the gate, the last writer to `rename` is also the last to snapshot, so a slow writer cannot rename a staler image over a newer one. Map mutations still happen under the std lock and are each followed by their own persist, so no update is lost. No lock is held across an `.await`; no std/tokio lock-ordering inversion.

3. **Terminal fast-path / RPC amplification (was MEDIUM).** `get_transfer_status` guards refresh with `record.terminal_at.is_none() && refresh_record(...)` (transfer.rs:212). Settled routes are served straight from the store with zero RPC. `terminal_at` is stamped once at the terminal transition inside `refresh_record` (transfer.rs:262-266) and that transition IS persisted, so no terminal stamp is lost. Test `get_transfer_status_terminal_record_performs_no_poll` asserts `received_requests().is_empty()`. This closes the unauthenticated-poll amplification vector for settled transfers.

4. **Hardcoded program id (was MEDIUM).** `SOLANA_SOLRAY_PROGRAM_ID` env override via `LazyLock` + `solray_program_id()` (solana.rs), empty-string filtered to the mainnet default (secure default preserved). Consumed by the security-critical owner check (`checked_pda_bytes`, solana.rs:539) and PDA derivation (`packet_pda_address`, transfer.rs:353). The owner check is unweakened — string equality preserved, just against the configured id. Documented in `.env.example`. The embedded id is a public Solana program address, not a secret.

5. **`request()` doc — per-attempt permit.** Doc updated (solana.rs:199-206) to describe a fresh semaphore permit per attempt, released before the backoff sleep. Documentation-only; matches existing behavior.

## Findings

### CRITICAL
- none

### HIGH
- none

### MEDIUM
- none

### LOW / INFORMATIONAL
- **LOW — invalid `SOLANA_SOLRAY_PROGRAM_ID` is not validated at startup.** A non-empty but malformed value is accepted by the `LazyLock` and only fails later (per-request `Internal` in `packet_pda_address` via `Pubkey::from_str`, and every account fails the owner check). This is fail-closed (no accounts are trusted), so it is a robustness/operability nit, not a security hole. Fix (optional): validate the configured id once at startup and refuse to boot on a malformed value. `location: backend/src/external/solana.rs:508-520`
- **INFORMATIONAL — duplicate registration of the same on-chain route consumes multiple cap slots.** `track_transfer` mints a fresh `Uuid` per call (transfer.rs:158) with no dedup on (channel, legs). A single real, still-present commitment PDA can therefore be registered up to the 512 cap, each duplicate a non-terminal record that only prunes after it settles + 24h retention. This is bounded by the adjudicated 429-cap contract and gated behind real on-chain commitment evidence (transfer.rs:151-156, one RPC per attempt), and it is pre-existing (01c0622d / 4437e6fd), NOT introduced or worsened by the 3269d14a delta — the delta's prune wiring improves the surrounding exhaustion posture. Flagged only so the dedup gap is on record for a future hardening pass; do not block this PR on it. `location: backend/src/handlers/transfer.rs:128-179`

## Coverage gaps
- Categories present in diff but with no matching skill: none. Every triggered category maps to an applied skill; excluded skills are excluded for correct reasons (no manifest change, no secret-handling crypto, repo-wide scanners barred by the caller).
- Manual review recommended for: the timeout-terminal path is explicitly deferred to a later PR (timeout/receive events are event-sourced, not PDA-observable) — a route that never settles stays non-terminal and does not prune. This is a known, documented design boundary, not a delta regression, but is the residual lever behind the INFORMATIONAL item above; re-check when the event-sourced PR lands.

## Verdict
CLEAR — no findings above MEDIUM. All five round-2 fixes (3269d14a) are present, correctly implemented, and test-covered; the delta introduces no regression and resolves the round-2 HIGH plus all three MEDIUMs. Two LOW/INFORMATIONAL items are out-of-delta or fail-closed and do not block merge.
</details>
