### PR TITLE
ci: exclude data/ from deploy rclone sync

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -132,6 +132,8 @@ jobs:
             --filter "- .env" \
             --filter "- config/" \
             --filter "- config/**" \
+            --filter "- data/" \
+            --filter "- data/**" \
             --filter "- nolus-backend.bak" \
             --filter "- dist.bak/**" \
             --verbose


### PR DESCRIPTION
## Summary
Persist the backend's durable transfer-store image (`<deploy_dir>/data/`, default `TRANSFER_STORE_PATH=./data/transfers.json`) across deploys. `rclone sync` deletes destination paths absent from the deploy bundle, so without a filter every deploy would wipe the store that exists precisely to survive restarts with in-flight Nolus↔Solana transfers. `data/` joins `.env` and `config/` as server-persistent state.

Context: staging deploys of #361 and #362 failed their health probes and auto-rolled back — the backend exited at startup with `Permission denied (os error 13)` because the service user (`www-data`) cannot create `./data/` in the `deploy:deploy` 755 deploy dir. The missing dirs were created server-side with `www-data` ownership on both envs (`install -d -o www-data -g www-data <deploy_dir>/data`); this PR fixes the remaining pipeline half.

## Changes
- `deploy.yaml`: add `--filter "- data/"` and `--filter "- data/**"` to the rclone sync step, matching the existing `config/` filter pattern.

## Verification
- Reproduced the failure from the deploy-host journal: 5 systemd restart attempts of the new binary, each exiting `Permission denied (os error 13)` before binding :5050; rollback binary (pre-#361) starts clean.
- Confirmed `rclone sync` had no `data/` exclusion, so the destination store would be deleted on every deploy once permissions were fixed.
- Validated the workflow YAML parses after the edit.
- Ran the pre-commit gate (typecheck, eslint, style checks, vitest suite, build) — all green.
- Reviewed: 12-item bug checklist pass; security review clear; house-style conformance pass. One informational note: the new filters are unanchored (match `data/` at any depth of the bundle). We kept them unanchored for consistency with the existing `config/`/`.env` filters; anchoring all filters is a separate cleanup if ever needed.
- Created `data/` dirs (owned `www-data`) on both staging and prod deploy paths and verified ownership.

## Follow-ups
- None. Merge triggers the staging deploy, which is the end-to-end verification for this fix.